### PR TITLE
Use a different source for workload datasets

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -8,7 +8,7 @@ set -u
 set -o pipefail
 
 readonly ROOT=".benchmark/benchmarks"
-readonly URL="http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora"
+readonly URL="https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora"
 
 
 # see http://stackoverflow.com/a/246128

--- a/eventdata/workload.json
+++ b/eventdata/workload.json
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "eventdata",
-      "base-url": "https://rally-tracks.elastic.co/eventdata",
+      "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/eventdata",
       "documents": [
         {
           "source-file": "eventdata.json.bz2",

--- a/geonames/workload.json
+++ b/geonames/workload.json
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "geonames",
-      "base-url": "https://rally-tracks.elastic.co/geonames",
+      "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/geonames",
       "documents": [
         {
           "source-file": "documents-2.json.bz2",

--- a/geopoint/workload.json
+++ b/geopoint/workload.json
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "geopoint",
-      "base-url": "https://rally-tracks.elastic.co/geopoint",
+      "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/geopoint",
       "documents": [
         {
           "source-file": "documents.json.bz2",

--- a/geopointshape/workload.json
+++ b/geopointshape/workload.json
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "geopointshape",
-      "base-url": "https://rally-tracks.elastic.co/geopointshape",
+      "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/geopointshape",
       "documents": [
         {
           "source-file": "documents.json.bz2",

--- a/geoshape/workload.json
+++ b/geoshape/workload.json
@@ -20,7 +20,7 @@
   "corpora": [
     {
       "name": "linestrings",
-      "base-url": "https://rally-tracks.elastic.co/geoshape",
+      "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/geoshape",
       "target-index": "osmlinestrings",
       "documents": [
         {
@@ -33,7 +33,7 @@
     },
     {
       "name": "multilinestrings",
-      "base-url": "https://rally-tracks.elastic.co/geoshape",
+      "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/geoshape",
       "target-index": "osmmultilinestrings",
       "documents": [
         {
@@ -46,7 +46,7 @@
     },
     {
       "name": "polygons",
-      "base-url": "https://rally-tracks.elastic.co/geoshape",
+      "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/geoshape",
       "target-index": "osmpolygons",
       "documents": [
         {

--- a/http_logs/workload.json
+++ b/http_logs/workload.json
@@ -48,7 +48,7 @@
       {%- if ingest_pipeline is defined and ingest_pipeline == "grok" or runtime_fields is defined %}
         {
           "name": "http_logs_unparsed",
-          "base-url": "https://rally-tracks.elastic.co/http_logs",
+          "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/http_logs",
           "documents": [
           {
             "target-index": "logs-181998",
@@ -104,7 +104,7 @@
     {%- else %}
       {
         "name": "http_logs",
-        "base-url": "https://rally-tracks.elastic.co/http_logs",
+        "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/http_logs",
         "documents": [
           {
             "target-index": "logs-181998",

--- a/nested/workload.json
+++ b/nested/workload.json
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "nested",
-      "base-url": "https://rally-tracks.elastic.co/nested",
+      "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/nested",
       "documents": [
         {
           "source-file": "documents.json.bz2",

--- a/noaa/workload.json
+++ b/noaa/workload.json
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "noaa",
-      "base-url": "https://rally-tracks.elastic.co/noaa",
+      "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/noaa",
       "documents": [
         {
           "source-file": "documents.json.bz2",

--- a/nyc_taxis/workload.json
+++ b/nyc_taxis/workload.json
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "nyc_taxis",
-      "base-url": "https://rally-tracks.elastic.co/nyc_taxis",
+      "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/nyc_taxis",
       "documents": [
         {
           "source-file": "documents.json.bz2",

--- a/percolator/workload.json
+++ b/percolator/workload.json
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "percolator",
-      "base-url": "https://rally-tracks.elastic.co/percolator",
+      "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/percolator",
       "documents": [
         {
           "source-file": "queries-2.json.bz2",

--- a/pmc/workload.json
+++ b/pmc/workload.json
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "pmc",
-      "base-url": "https://rally-tracks.elastic.co/pmc",
+      "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/pmc",
       "documents": [
         {
           "source-file": "documents.json.bz2",

--- a/so/workload.json
+++ b/so/workload.json
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "so",
-      "base-url": "https://rally-tracks.elastic.co/so",
+      "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/so",
       "documents": [
         {
           "source-file": "posts.json.bz2",


### PR DESCRIPTION
Signed-off-by: Travis Benedict <benedtra@amazon.com>

### Description
Update the source for workload datasets to be an OpenSearch Benchmark specific S3 bucket.

I was able to successfully test this change all workloads except for `http_logs`. The modified integration test that I used for testing was failing to correctly load the workload. I believe this is because this workload is the only one that is reliant on the [osbenchmark package](https://github.com/opensearch-project/opensearch-benchmark-workloads/blob/main/http_logs/workload.py#L4). Testing against this workload will not succeed until the package is publish to PyPI. There were not issues with downloading the datasets for the workload.

 
### Issues Resolved
https://github.com/opensearch-project/opensearch-benchmark-workloads/issues/11 

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
