### PR TITLE
Update pmc import to use osbenchmark

### DIFF
--- a/pmc/workload.py
+++ b/pmc/workload.py
@@ -3,8 +3,7 @@ def put_settings(es, params):
 
 
 def register(registry):
-    # register a fallback for older Rally versions
     try:
-        from esrally.driver.runner import PutSettings
+        from osbenchmark.worker_coordinator.runner import PutSettings
     except ImportError:
         registry.register_runner("put-settings", put_settings)


### PR DESCRIPTION
Signed-off-by: Travis Benedict <benedtra@amazon.com>

### Description
Removes an import which references the esrally Python package by replacing it with the osbenchmark equivalent. This change could not be tested because the osbenchmark package has not been published to PyPI yet.

I don't think this code is strictly necessary anymore since there won't be previous version of Benchmark, but without being able to test the change I didn't want to make any significant changes. 
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-benchmark-workloads/issues/11
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
