### PR TITLE
Remove Runtime Fields from Http_Logs workload (7.1)

### DIFF
--- a/http_logs/test_procedures/default.json
+++ b/http_logs/test_procedures/default.json
@@ -7,13 +7,6 @@
       ]
     },
     {
-      "name": "runtime-fields",
-      "description": "Indexes the whole document corpus using scripts to extract fields. Set the workload param `runtime_fields` to `true`.",
-      "schedule": [
-        {{ benchmark.collect(parts="common/default-schedule.json") }}
-      ]
-    },
-    {
       "name": "append-no-conflicts-index-only",
       "description": "Indexes the whole document corpus using OpenSearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Benchmark will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only.",
       "schedule": [


### PR DESCRIPTION
Remove runtime fields causing the OpenSearch-Benchmark Issue ([#106](https://github.com/opensearch-project/opensearch-benchmark/issues/105)) 
Signed-off-by: Ian Hoang <hoangia@amazon.com>

### Description
This removes runtime fields, a change that is present in some of branches of this workloads repository, causing issues to http_logs because OSB does not support runtime fields. The problem arises when users run http_logs workload. The log provides the following error:
```
[ERROR] Cannot execute_test. Error in load generator [0]
	Cannot run task [index-append]: expected str, bytes or os.PathLike object, not NoneType
```
Upon inspection, the http_logs data corpus used during the test was not downloaded, triggering this error when index-append operation occurs. This happens because OSB runs through the workload.py, reaches Runtime Fields class, fails there, and does not trigger the DefaultWorkloadPrepartor, that downloads the data corpus. 
 
### Issues Resolved
The issue it resolves resides in the main OpenSearch-Benchmark repository and not this workload repository: ([#106](https://github.com/opensearch-project/opensearch-benchmark/issues/105)) 
 
### Check List
- [ x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

