### PR TITLE
Removing the RuntimeFieldResolver and its registration from http_logs

### DIFF
--- a/http_logs/workload.py
+++ b/http_logs/workload.py
@@ -15,50 +15,12 @@ async def reindex_async(es, params):
     return result["total"], "docs"
 
 
-class RuntimeFieldResolver(loader.WorkloadProcessor):
-    PATTERN = re.compile('.+-from-(.+)-using-(.+)')
-
-    def on_after_load_workload(self, t):
-        for test_procedure in t.test_procedures:
-            for task in test_procedure.schedule:
-                m = self.PATTERN.match(task.name)
-                if m is not None:
-                    source = m[1]
-                    impl = m[2].replace('-', '_')
-                    task.operation = copy(task.operation)
-                    task.operation.params = self._replace_field(f"{impl}.from_{source}.", task.operation.params)
-
-    def on_prepare_workload(self, workload, data_root_dir):
-        class EmptyTrueList(list):
-            def __bool__(self):
-                return True
-
-            def __eq__(self, other):
-                if isinstance(other, bool):
-                    return True
-
-        return EmptyTrueList()
-
-    def _replace_field(self, field, t):
-        if t == 'path' or t == 'status':
-            return field + t
-        if isinstance(t, list):
-            return [self._replace_field(field, v) for v in t]
-        if isinstance(t, dict):
-            return {
-                self._replace_field(field, k): self._replace_field(field, v)
-                for k, v in t.items()
-            }
-        return t
-
-
 def register(registry):
     async_runner = registry.meta_data.get("async_runner", False)
     if async_runner:
         registry.register_runner("reindex", reindex_async, async_runner=True)
     else:
         registry.register_runner("reindex", reindex)
-    registry.register_workload_processor(RuntimeFieldResolver())
     try:
         registry.register_workload_processor(loader.DefaultWorkloadPreparator())
     except TypeError as e:


### PR DESCRIPTION
### Description
Further pruning of the Runtime fields logic in http_logs that was started in #32 

Signed-off-by: Chase Engelbrecht <engechas@amazon.com>
 
### Issues Resolved

 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
