### PR TITLE
Fix rally references in http_logs

### DIFF
--- a/http_logs/workload.json
+++ b/http_logs/workload.json
@@ -1,4 +1,4 @@
-{% import "rally.helpers" as rally with context %}
+{% import "benchmark.helpers" as benchmark with context %}
 
 {
   "version": 2,
@@ -44,13 +44,7 @@
   "corpora": [
       {%- if ingest_pipeline is defined and ingest_pipeline == "grok" %}
         {
-          "name": "http_logs_unparsed",
-<<<<<<< HEAD
-          "base-url": "https://rally-tracks.elastic.co/http_logs",
-          "target-type": "type",
-=======
           "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/http_logs",
->>>>>>> ccd7577... Use a different source for workload datasets (#13)
           "documents": [
           {
             "target-index": "logs-181998",
@@ -163,9 +157,10 @@
     {%- endif %}
   ],
   "operations": [
-    {{ rally.collect(parts="operations/*.json") }}
+    {{ benchmark.collect(parts="operations/*.json") }}
   ],
   "test_procedures": [
-    {{ rally.collect(parts="test_procedures/*.json") }}
+    {{ benchmark.collect(parts="test_procedures/*.json") }}
   ]
 }
+


### PR DESCRIPTION
Signed-off-by: Travis Benedict <benedtra@amazon.com>

### Description
Removes rally references in the http_logs workload.json that were causing failures for ES 6.x.

Successfully ran a test execution in test-mode.
 
### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-benchmark-workloads/issues/35
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
