### PR TITLE
Revert test procedure to remove additions from backporting

### DIFF
--- a/http_logs/test_procedures/default.json
+++ b/http_logs/test_procedures/default.json
@@ -3,20 +3,6 @@
       "description": "Indexes the whole document corpus using OpenSearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Benchmark will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only. After that a couple of queries are run.",
       "default": true,
       "schedule": [
-        {{ benchmark.collect(parts="common/default-schedule.json") }}
-      ]
-    },
-    {
-      "name": "runtime-fields",
-      "description": "Indexes the whole document corpus using scripts to extract fields. Set the workload param `runtime_fields` to `true`.",
-      "schedule": [
-        {{ benchmark.collect(parts="common/default-schedule.json") }}
-      ]
-    },
-    {
-      "name": "append-no-conflicts-index-only",
-      "description": "Indexes the whole document corpus using OpenSearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Benchmark will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only.",
-      "schedule": [
         {
           "operation": "delete-index"
         },


### PR DESCRIPTION
Signed-off-by: Travis Benedict <benedtra@amazon.com>

### Description
Backporting this change https://github.com/opensearch-project/opensearch-benchmark-workloads/pull/12  added additional fields that were not part of the original http_logs test procedure. This was causing issues running the workload for Elasticsearch 7.1

### Issues Resolved
https://github.com/opensearch-project/opensearch-benchmark-workloads/issues/38
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
