### PR TITLE
Correct Searchable Snapshots test procedure in nyc_taxis workload

### DIFF
--- a/nyc_taxis/TEST_PROCEDURES.md
+++ b/nyc_taxis/TEST_PROCEDURES.md
@@ -1,6 +1,6 @@
 # Test Procedures
 
-## searchable_snapshot 
+## searchable-snapshot
 
 A test procedure for measuring performance for the Searchable Snapshots feature. It runs the same search queries as the default test procedure `append-no-conflicts`.
 

--- a/nyc_taxis/TEST_PROCEDURES.md
+++ b/nyc_taxis/TEST_PROCEDURES.md
@@ -6,7 +6,8 @@ A test procedure for measuring performance for the Searchable Snapshots feature.
 
 In contrast with `append-no-conflicts` which runs queries on an index stored on the cluster itself, this test procedure runs queries on index backed by a remote snapshot.
 
-The test procedure will create a remote snapshot that is stored in Amazon S3, so an Amazon S3 bucket for storing the snapshot and credentials for an AWS account that has permission to access the bucket are required to run the test procedure. To learn more about configuring Amazon S3 as a snapshot repository, see the [OpenSearch docs](https://opensearch.org/docs/latest/opensearch/snapshots/snapshot-restore#amazon-s3).
+The test procedure will create a remote snapshot that is stored in Amazon S3, so an Amazon S3 bucket for storing the snapshot and credentials for an AWS account that has permission to access the bucket are required to run the test procedure.
+To learn more about configuring Amazon S3 as a snapshot repository, see the [OpenSearch docs](https://opensearch.org/docs/latest/opensearch/snapshots/snapshot-restore#amazon-s3).
 
 The Searchable Snapshots feature is supported by OpenSearch since version 2.4.0, see the [OpenSearch docs](https://opensearch.org/docs/2.4/opensearch/snapshots/searchable_snapshot) to learn more.
 
@@ -16,10 +17,18 @@ The Searchable Snapshots feature is supported by OpenSearch since version 2.4.0,
 
 In addition to those mentioned in [README](README.md) of NYC taxis workload:
 * `snapshot_repository_name` (default: "test-repository"): Name of the snapshot repository.
-* `snapshot_name` (default: "test-snapshot"): Name of the snapshot. 
-  It is recommended to assign a different value for different test executions, because there is no operation defined by opensearch-benchmark to delete a snapshot, and a new snapshot will not be created if a previous snapshot with the same name exists in the repository.
+* `snapshot_name` (default: "test-snapshot"): Name of the snapshot.
 * `s3_bucket_name`: Name of the Amazon S3 bucket that stores the snapshot. The S3 bucket needs to be prepared manually.
 * `s3_bucket_region`: The AWS Region where the Amazon S3 bucket exists. For example, "us-east-1".
+
+Example:
+```
+{
+  "s3_bucket_name": "name of your S3 bucket",
+  "s3_bucket_region": "region of your S3 bucket"
+}
+ ```
+Save it as `params.json` and provide it to Benchmark with `--workload-params="/path/to/params.json"`.
 
 #### The test procedure requires parameters to be provided for the `repository-s3` plugin using `--plugin-params`:
 See the [Benchmark docs](https://github.com/opensearch-project/opensearch-benchmark/blob/main/osbenchmark/resources/provision_configs/main/plugins/v1/repository_s3/README.md
@@ -37,19 +46,32 @@ Save it as `params.json` and provide it to Benchmark with `--opensearch-plugins=
 
 #### The test procedure requires parameters to be provided for the "provision_config_instance" using `--provision-config-instance-params`:
 
-A "provision_config_instance" is a specific configuration of OpenSearch. The parameter is used for setting a feature flag in JVM options to enable an experimental feature (for OpenSearch 2.4), and assigning `search` role to the node.
+A "provision_config_instance" is a specific configuration of OpenSearch. The parameter is used for configuring the following cluster settings:
+1. A feature flag to enable an experimental feature.
+2. Assigning `search` role to the node.
+3. Define the maximum cache size of a `search` node. (required when a node with both `data` and `search` roles)
 
-Note that use of built-in instances can be seen at [Benchmark repository](https://github.com/opensearch-project/opensearch-benchmark/tree/main/osbenchmark/resources/provision_configs/main/provision_config_instances/v1), and the parameter usage can be seen [here](https://github.com/opensearch-project/opensearch-benchmark/blob/main/osbenchmark/resources/provision_configs/main/provision_config_instances/v1/vanilla/README.md) in the same repository.
+Note that use of built-in instances can be seen at [Benchmark repository](https://github.com/opensearch-project/opensearch-benchmark/tree/main/osbenchmark/resources/provision_configs/main/provision_config_instances/v1),
+and the parameter usage can be seen [here](https://github.com/opensearch-project/opensearch-benchmark/blob/main/osbenchmark/resources/provision_configs/main/provision_config_instances/v1/vanilla/README.md) in the same repository.
 
 Example:
 ```
 {
   "additional_cluster_settings": {
-    "node.roles": "ingest, remote_cluster_client, data, cluster_manager, search"
-  },
-  "additional_java_settings": [
-    "-Dopensearch.experimental.feature.searchable_snapshot.enabled=true"
-  ]
+    "node.roles": "ingest, remote_cluster_client, data, cluster_manager, search",
+    "opensearch.experimental.feature.searchable_snapshot.enabled": "true",
+    "node.search.cache.size": "50GB"
+  }
 }
 ```
 Save it as `params.json` and provide it to Benchmark with `--provision-config-instance-params="/path/to/params.json"`.
+
+### Run the test procedure
+The test procedure can be run with parameter `--test-procedure searchable-snapshot`.
+An example of assigning all the required parameters to Benchmark is:
+```
+opensearch-benchmark execute_test --workload=nyc_taxis --test-procedure searchable-snapshot \
+--opensearch-plugin=repository-s3 --plugin-params=/path/to/plugin-params.json \
+--provision-config-instance-params=/path/to/provision-config-instance-params.json \
+--workload-params=/path/to/workload-params.json
+```

--- a/nyc_taxis/TEST_PROCEDURES.md
+++ b/nyc_taxis/TEST_PROCEDURES.md
@@ -7,7 +7,7 @@ A test procedure for measuring performance for the Searchable Snapshots feature.
 In contrast with `append-no-conflicts` which runs queries on an index stored on the cluster itself, this test procedure runs queries on index backed by a remote snapshot.
 
 The test procedure will create a remote snapshot that is stored in Amazon S3, so an Amazon S3 bucket for storing the snapshot and credentials for an AWS account that has permission to access the bucket are required to run the test procedure.
-To learn more about configuring Amazon S3 as a snapshot repository, see the [OpenSearch docs](https://opensearch.org/docs/latest/opensearch/snapshots/snapshot-restore#amazon-s3).
+To learn more about configuring Amazon S3 as a snapshot repository, see the [OpenSearch docs](https://opensearch.org/docs/2.6/tuning-your-cluster/availability-and-recovery/snapshots/snapshot-restore#amazon-s3).
 
 The Searchable Snapshots feature is supported by OpenSearch since version 2.4.0, see the [OpenSearch docs](https://opensearch.org/docs/2.4/opensearch/snapshots/searchable_snapshot) to learn more.
 
@@ -31,7 +31,7 @@ Example:
 Save it as `params.json` and provide it to Benchmark with `--workload-params="/path/to/params.json"`.
 
 #### The test procedure requires parameters to be provided for the `repository-s3` plugin using `--plugin-params`:
-See the [Benchmark docs](https://github.com/opensearch-project/opensearch-benchmark/blob/main/osbenchmark/resources/provision_configs/main/plugins/v1/repository_s3/README.md
+See the [Benchmark docs](https://github.com/opensearch-project/opensearch-benchmark/blob/0.2.0/osbenchmark/resources/provision_configs/main/plugins/v1/repository_s3/README.md
 ) for details.
 
 Example:
@@ -51,15 +51,15 @@ A "provision_config_instance" is a specific configuration of OpenSearch. The par
 2. Assigning `search` role to the node.
 3. Define the maximum cache size of a `search` node. (required when a node with both `data` and `search` roles)
 
-Note that use of built-in instances can be seen at [Benchmark repository](https://github.com/opensearch-project/opensearch-benchmark/tree/main/osbenchmark/resources/provision_configs/main/provision_config_instances/v1),
-and the parameter usage can be seen [here](https://github.com/opensearch-project/opensearch-benchmark/blob/main/osbenchmark/resources/provision_configs/main/provision_config_instances/v1/vanilla/README.md) in the same repository.
+Note that use of built-in instances can be seen at [Benchmark repository](https://github.com/opensearch-project/opensearch-benchmark/tree/0.2.0/osbenchmark/resources/provision_configs/main/provision_config_instances/v1),
+and the parameter usage can be seen [here](https://github.com/opensearch-project/opensearch-benchmark/blob/0.2.0/osbenchmark/resources/provision_configs/main/provision_config_instances/v1/vanilla/README.md) in the same repository.
 
 Example:
 ```
 {
   "additional_cluster_settings": {
-    "node.roles": "ingest, remote_cluster_client, data, cluster_manager, search",
     "opensearch.experimental.feature.searchable_snapshot.enabled": "true",
+    "node.roles": "ingest, remote_cluster_client, data, cluster_manager, search",
     "node.search.cache.size": "50GB"
   }
 }

--- a/nyc_taxis/TEST_PROCEDURES.md
+++ b/nyc_taxis/TEST_PROCEDURES.md
@@ -49,7 +49,8 @@ Save it as `params.json` and provide it to Benchmark with `--opensearch-plugins=
 A "provision_config_instance" is a specific configuration of OpenSearch. The parameter is used for configuring the following cluster settings:
 1. A feature flag to enable an experimental feature.
 2. Assigning `search` role to the node.
-3. Define the maximum cache size of a `search` node. (required when a node with both `data` and `search` roles)
+3. Define the maximum cache size of a `search` node, which is required when a node with both `data` and `search` roles.
+In the example, the value is set to `30GB` to get the best performance, because the `nyc_taxis` dataset takes up 20+GB disk storage after indexing.
 
 Note that use of built-in instances can be seen at [Benchmark repository](https://github.com/opensearch-project/opensearch-benchmark/tree/0.2.0/osbenchmark/resources/provision_configs/main/provision_config_instances/v1),
 and the parameter usage can be seen [here](https://github.com/opensearch-project/opensearch-benchmark/blob/0.2.0/osbenchmark/resources/provision_configs/main/provision_config_instances/v1/vanilla/README.md) in the same repository.
@@ -60,7 +61,7 @@ Example:
   "additional_cluster_settings": {
     "opensearch.experimental.feature.searchable_snapshot.enabled": "true",
     "node.roles": "ingest, remote_cluster_client, data, cluster_manager, search",
-    "node.search.cache.size": "50GB"
+    "node.search.cache.size": "30GB"
   }
 }
 ```

--- a/nyc_taxis/operations/default.json
+++ b/nyc_taxis/operations/default.json
@@ -42,6 +42,7 @@
       "operation-type": "delete-snapshot",
       "repository": "{{ snapshot_repository_name | default('test-repository') }}",
       "snapshot": "{{ snapshot_name | default('test-snapshot') }}",
+      "include-in-reporting": false
     },
     {
       "name": "create-snapshot",

--- a/nyc_taxis/test_procedures/default.json
+++ b/nyc_taxis/test_procedures/default.json
@@ -295,7 +295,7 @@
       ]
     },
     {
-      "name": "searchable_snapshot",
+      "name": "searchable-snapshot",
       "description": "Measuring performance for Searchable Snapshot feature. Based on the default test procedure 'append-no-conflicts'.",
       "schedule": [
         {

--- a/nyc_taxis/test_procedures/default.json
+++ b/nyc_taxis/test_procedures/default.json
@@ -297,7 +297,6 @@
     {
       "name": "searchable_snapshot",
       "description": "Measuring performance for Searchable Snapshot feature. Based on the default test procedure 'append-no-conflicts'.",
-      "default": true,
       "schedule": [
         {
           "operation": "delete-index"

--- a/nyc_taxis/workload.py
+++ b/nyc_taxis/workload.py
@@ -1,6 +1,5 @@
 async def delete_snapshot(opensearch, params):
-    await opensearch.snapshot.delete(repository=mandatory(params, "repository", repr(self)), 
-        snapshot=mandatory(params, "snapshot", repr(self))
+    await opensearch.snapshot.delete(repository=params["repository"], snapshot=params["snapshot"])
 
 def register(registry):
     registry.register_runner("delete-snapshot", delete_snapshot, async_runner=True)


### PR DESCRIPTION
### Description
**Problem**
There was 3 defects in my previous PR https://github.com/opensearch-project/opensearch-benchmark-workloads/pull/58 that caused `nyc_taxis` workload can not be run, as pointing out in issue https://github.com/opensearch-project/opensearch-benchmark-workloads/issues/66:
1. Extra trailing comma created a malformed JSON output.
https://github.com/opensearch-project/opensearch-benchmark-workloads/blob/af2c5b40247964e599cd4a00c2a5161d43466d19/nyc_taxis/operations/default.json#L44
2. The new `searchable_snapshot` is assigned as a default test procedure by mistake, while `append-no-conflict` is already the default test procedure. Error occurs when there are 2 default test procedures. 
https://github.com/opensearch-project/opensearch-benchmark-workloads/blob/af2c5b40247964e599cd4a00c2a5161d43466d19/nyc_taxis/test_procedures/default.json#L300
3. The custom operation `delete-snapshot` is not working. 
https://github.com/opensearch-project/opensearch-benchmark-workloads/blob/af2c5b40247964e599cd4a00c2a5161d43466d19/nyc_taxis/workload.py#L2

**Changes**
- Remove the extra trailing comma that caused JSON format error.
- Remove the line that setting `searchable_snapshot` as the default test procedure.
- Correct the definition of the custom operation `delete-snapshot`.
-  set the property "include-in-reporting" to `false` for operation `delete-snapshot`, which will not show the metrics for this operation in command line since it's an administrative operation.
- Rename the test procedure `searchable_snapshot` to use dash `-` instead of underscore `_`, to be corresponding with the existing test procedure `append-no-conflicts`.
- Update the documentation. Correct the description of workload parameter `snapshot_name`. Add more examples in workload parameters and the whole command to run the test procedure. Change the links to other documentation to use "Git tag" instead of using `main` branch.

**Testing**
Running the performance test with the default test_procedure `append-no-conflicts`:
```
opensearch-benchmark execute_test --workload-path=/home/ftianli/github/opensearch-benchmark-workloads/nyc_taxis --test-mode

   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/

[INFO] Preparing for test execution ...
[INFO] Executing test with workload [nyc_taxis], test_procedure [append-no-conflicts] and provision_config_instance ['defaults'] with version [3.0.0-SNAPSHOT].

Running delete-index                                                           [100% done]
Running create-index                                                           [100% done]
Running check-cluster-health                                                   [100% done]
Running index                                                                  [100% done]
Running refresh-after-index                                                    [100% done]
Running force-merge                                                            [100% done]
Running refresh-after-force-merge                                              [100% done]
Running wait-until-merges-finish                                               [100% done]
Running default                                                                [100% done]
Running range                                                                  [100% done]
Running distance_amount_agg                                                    [100% done]
Running autohisto_agg                                                          [100% done]
Running date_histogram_agg                                                     [100% done]
```

Running the performance test with the test_procedure `searchable-snapshot`
```
opensearch-benchmark execute_test --workload-path=/home/user/github/opensearch-benchmark-workloads/nyc_taxis \ 
--test-mode --test-procedure searchable-snapshot \
--opensearch-plugin=repository-s3 --plugin-params=/home/user/Downloads/benchmark/searchable_snapshot/plugin-params.json \
--provision-config-instance-params=/home/user/Downloads/benchmark/searchable_snapshot/provision-config-instance-params.json \
--workload-params=/home/user/Downloads/benchmark/searchable_snapshot/workload-params.json --kill-running-processes

   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/

[INFO] Preparing for test execution ...
[INFO] Executing test with workload [nyc_taxis], test_procedure [searchable_snapshot] and provision_config_instance ['defaults'] with version [3.0.0-SNAPSHOT].

Running delete-index                                                           [100% done]
Running create-index                                                           [100% done]
Running check-cluster-health                                                   [100% done]
Running index                                                                  [100% done]
Running refresh-after-index                                                    [100% done]
Running force-merge                                                            [100% done]
Running refresh-after-force-merge                                              [100% done]
Running wait-until-merges-finish                                               [100% done]
Running create-snapshot-repository                                             [100% done]
Running delete-snapshot                                                        [100% done]
Running create-snapshot                                                        [100% done]
Running wait-for-snapshot-creation                                             [100% done]
Running delete-local-index                                                     [100% done]
Running restore-snapshot                                                       [100% done]
Running default                                                                [100% done]
Running range                                                                  [100% done]
Running distance_amount_agg                                                    [100% done]
Running autohisto_agg                                                          [100% done]
Running date_histogram_agg                                                     [100% done]
```

### Issues Resolved
Resolve https://github.com/opensearch-project/opensearch-benchmark-workloads/issues/66

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
