### PR TITLE
Removed references to non-existent OSB version in README files.

### DIFF
--- a/eventdata/README.md
+++ b/eventdata/README.md
@@ -35,7 +35,7 @@ The purpose of this workload is to provide an efficient way to benchmark indexin
 
 ### Parameters
 
-This workload allows to overwrite the following parameters with Benchmark 0.8.0+ using `--workload-params`:
+This workload allows the following parameters to be specified using `--workload-params`:
 
 * `bulk_size` (default: 5000)
 * `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.

--- a/geonames/README.md
+++ b/geonames/README.md
@@ -33,7 +33,7 @@ Modifications:
 
 ### Parameters
 
-This workload allows to overwrite the following parameters with Benchmark 0.8.0+ using `--workload-params`:
+This workload allows the following parameters to be specified using `--workload-params`:
 
 * `bulk_size` (default: 5000)
 * `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.

--- a/geopoint/README.md
+++ b/geopoint/README.md
@@ -15,7 +15,7 @@ This workload is based on [PlanetOSM](http://wiki.openstreetmap.org/wiki/Planet.
 
 ### Parameters
 
-This workload allows to overwrite the following parameters with Benchmark 0.8.0+ using `--workload-params`:
+This workload allows the following parameters to be specified using `--workload-params`:
 
 * `bulk_size` (default: 5000)
 * `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.

--- a/geopointshape/README.md
+++ b/geopointshape/README.md
@@ -12,7 +12,7 @@ This workload is based on [PlanetOSM](http://wiki.openstreetmap.org/wiki/Planet.
 
 ### Parameters
 
-This workload allows to overwrite the following parameters with Benchmark 0.8.0+ using `--workload-params`:
+This workload allows the following parameters to be specified using `--workload-params`:
 
 * `bulk_size` (default: 5000)
 * `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.

--- a/geoshape/README.md
+++ b/geoshape/README.md
@@ -12,7 +12,7 @@ This workload is based on [PlanetOSM](http://wiki.openstreetmap.org/wiki/Planet.
 
 ### Parameters
 
-This workload allows to overwrite the following parameters with Benchmark 0.8.0+ using `--workload-params`:
+This workload allows the following parameters to be specified using `--workload-params`:
 
 * `linestring_bulk_size` (default: 100): The bulk request size for indexing linestrings.
 * `multilinestring_bulk_size` (default: 100): The bulk request size for indexing multilinestrings.

--- a/http_logs/README.md
+++ b/http_logs/README.md
@@ -31,7 +31,7 @@ data set, except the timestamp is ISO8601 and all the fields are unparsed via th
 
 ### Parameters
 
-This workload allows to overwrite the following parameters with Benchmark 0.8.0+ using `--workload-params`:
+This workload allows the following parameters to be specified using `--workload-params`:
 
 * `bulk_size` (default: 5000)
 * `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.

--- a/nested/README.md
+++ b/nested/README.md
@@ -48,7 +48,7 @@ These scripts are available in the raw_data_prep_scripts.zip file.
 
 ### Parameters
 
-This workload allows to overwrite the following parameters with Benchmark 0.8.0+ using `--workload-params`:
+This workload allows the following parameters to be specified using `--workload-params`:
 
 * `bulk_size` (default: 5000)
 * `bulk_indexing_clients` (default: 4): Number of clients that issue bulk indexing requests.

--- a/noaa/README.md
+++ b/noaa/README.md
@@ -42,7 +42,7 @@ To recreate the document corpus:
 
 ### Parameters
 
-This workload allows to overwrite the following parameters with Benchmark 0.8.0+ using `--workload-params`:
+This workload allows the following parameters to be specified using `--workload-params`:
 
 * `bulk_size` (default: 5000)
 * `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.

--- a/percolator/README.md
+++ b/percolator/README.md
@@ -18,7 +18,7 @@ The queries.json.bz2 file contains list of ES queries that has been randomly gen
 
 ### Parameters
 
-This workload allows to overwrite the following parameters with Benchmark 0.8.0+ using `--workload-params`:
+This workload allows the following parameters to be specified using `--workload-params`:
 
 * `bulk_size` (default: 5000)
 * `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.

--- a/pmc/README.md
+++ b/pmc/README.md
@@ -24,7 +24,7 @@ Note that the ``body`` content is actually much longer has been shortened here t
 
 ### Parameters
 
-This workload allows to overwrite the following parameters with Benchmark 0.8.0+ using `--workload-params`:
+This workload allows the following parameters to be specified using `--workload-params`:
 
 * `bulk_size` (default: 500)
 * `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.

--- a/so/README.md
+++ b/so/README.md
@@ -41,7 +41,7 @@ These scripts are available in the raw_data_prep_script.zip file.
 
 ### Parameters
 
-This workload allows to overwrite the following parameters with Benchmark 0.8.0+ using `--workload-params`:
+This workload allows the following parameters to be specified using `--workload-params`:
 
 * `bulk_size` (default: 5000)
 * `bulk_indexing_clients` (default: 4): Number of clients that issue bulk indexing requests.


### PR DESCRIPTION
### Description
Removes unnecessary and incorrect references to _Benchmark 0.8.0_ in the workload README files.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
