### PR TITLE
Simpify assignment of workload parameters target_throughout and search_clients

### DIFF
--- a/geonames/test_procedures/default.json
+++ b/geonames/test_procedures/default.json
@@ -60,352 +60,227 @@
         {
           "operation": "index-stats",
           "warmup-iterations": 500,
-          "iterations": 1000
-          {%- if not target_throughput %}
-          ,"target-throughput": 90
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 1000,
+          "target-throughput": {{ target_throughput | default(90) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "node-stats",
           "warmup-iterations": 100,
-          "iterations": 1000
-          {%- if not target_throughput %}
-          ,"target-throughput": 90
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 1000,
+          "target-throughput": {{ target_throughput | default(90) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "default",
           "warmup-iterations": 500,
-          "iterations": 1000
-          {%- if not target_throughput %}
-          ,"target-throughput": 50
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 1000,
+          "target-throughput": {{ target_throughput | default(50) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "term",
           "warmup-iterations": 500,
-          "iterations": 1000
-          {%- if not target_throughput %}
-          ,"target-throughput": 100
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 1000,
+          "target-throughput": {{ target_throughput | default(100) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "phrase",
           "warmup-iterations": 500,
-          "iterations": 1000
-          {%- if not target_throughput %}
-          ,"target-throughput": 110
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 1000,
+          "target-throughput": {{ target_throughput | default(110) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "country_agg_uncached",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 3
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(3) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "country_agg_cached",
           "warmup-iterations": 1000,
-          "iterations": 1000
-          {%- if not target_throughput %}
-          ,"target-throughput": 100
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 1000,
+          "target-throughput": {{ target_throughput | default(100) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "scroll",
           "warmup-iterations": 200,
           "iterations": 100,
-          "#COMMENT": "Throughput is considered per request. So we issue one scroll request per second which will retrieve 25 pages"
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.8
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "#COMMENT": "Throughput is considered per request. So we issue one scroll request per second which will retrieve 25 pages",
+          "target-throughput": {{ target_throughput | default(0.8) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "expression",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(1.5) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "painless_static",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(1.5) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "painless_dynamic",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(1.5) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "decay_geo_gauss_function_score",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(1) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "decay_geo_gauss_script_score",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(1) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "field_value_function_score",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(1.5) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "field_value_script_score",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(1.5) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "large_terms",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1.1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(1.1) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "large_filtered_terms",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1.1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(1.1) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "large_prohibited_terms",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1.1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(1.1) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "desc_sort_population",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(1.5) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "asc_sort_population",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(1.5) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "asc_sort_with_after_population",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(1.5) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "desc_sort_geonameid",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 6
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(6) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "desc_sort_with_after_geonameid",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 6
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(6) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "asc_sort_geonameid",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 6
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(6) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "asc_sort_with_after_geonameid",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 6
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(6) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         }
       ]

--- a/geopoint/test_procedures/default.json
+++ b/geopoint/test_procedures/default.json
@@ -62,57 +62,37 @@
         {
           "operation": "polygon",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(2) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "bbox",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(2) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "distance",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(5) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "distanceRange",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(0.5) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         }
       ]

--- a/geopointshape/test_procedures/default.json
+++ b/geopointshape/test_procedures/default.json
@@ -60,29 +60,19 @@
         {
           "operation": "polygon",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(2) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "bbox",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(2) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         }
       ]

--- a/geoshape/test_procedures/default.json
+++ b/geoshape/test_procedures/default.json
@@ -127,29 +127,19 @@
         {
           "operation": "polygon",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.3
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(0.3) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "bbox",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.25
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(0.25) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         }
       ]

--- a/http_logs/test_procedures/default.json
+++ b/http_logs/test_procedures/default.json
@@ -59,86 +59,56 @@
         {
           "operation": "default",
           "warmup-iterations": 500,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 8
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(8) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "name": "term",
           "operation": "term",
           "warmup-iterations": 500,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 50
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(50) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "range",
           "warmup-iterations": 100,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(1) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "200s-in-range",
           "warmup-iterations": 500,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 33
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(33) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "400s-in-range",
           "warmup-iterations": 500,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 50
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(50) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "hourly_agg",
           "warmup-iterations": 100,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(0.2) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
@@ -151,57 +121,37 @@
         {
           "operation": "desc_sort_timestamp",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(0.5) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "asc_sort_timestamp",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(0.5) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "desc_sort_with_after_timestamp",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(0.5) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "asc_sort_with_after_timestamp",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(0.5) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
@@ -233,60 +183,40 @@
           "name": "desc-sort-timestamp-after-force-merge-1-seg",
           "operation": "desc_sort_timestamp",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(2) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "name": "asc-sort-timestamp-after-force-merge-1-seg",
           "operation": "asc_sort_timestamp",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(2) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "name": "desc-sort-with-after-timestamp-after-force-merge-1-seg",
           "operation": "desc_sort_with_after_timestamp",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(0.5)) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "name": "asc-sort-with-after-timestamp-after-force-merge-1-seg",
           "operation": "asc_sort_with_after_timestamp",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(0.5) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         }
       ]

--- a/nested/test_procedures/default.json
+++ b/nested/test_procedures/default.json
@@ -61,114 +61,51 @@
         {
           "operation": "randomized-nested-queries",
           "warmup-iterations": 500,
-          "iterations": 1000
-          {%- if not target_throughput %}
-          ,"target-throughput": 20
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 2
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 1000,
+          "target-throughput": {{ target_throughput | default(20) }},
+          "clients": {{ search_clients | default(2) }}
         },
         {
           "operation": "randomized-term-queries",
           "warmup-iterations": 500,
-          "iterations": 200
-          {%- if not target_throughput %}
-          ,"target-throughput": 25
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 2
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 200,
+          "target-throughput": {{ target_throughput | default(25) }},
+          "clients": {{ search_clients | default(2) }}
         },
         {
           "operation": "randomized-sorted-term-queries",
           "warmup-iterations": 500,
-          "iterations": 200
-          {%- if not target_throughput %}
-          ,"target-throughput": 16
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 2
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 200,
+          "target-throughput": {{ target_throughput | default(16) }},
+          "clients": {{ search_clients | default(2) }}
         },
         {
           "operation": "match-all",
           "warmup-iterations": 500,
-          "iterations": 200
-          {%- if not target_throughput %}
-          ,"target-throughput": 5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 2
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 200,
+          "target-throughput": {{ target_throughput | default(5) }},
+          "clients": {{ search_clients | default(2) }}
         },
         {
           "operation": "nested-date-histo",
           "warmup-iterations": 100,
-          "iterations": 200
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 2
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 200,
+          "target-throughput": {{ target_throughput | default(1) }},
+          "clients": {{ search_clients | default(2) }}
         },
         {
           "operation": "randomized-nested-queries-with-inner-hits_default",
           "warmup-iterations": 500,
-          "iterations": 1000
-          {%- if not target_throughput %}
-          ,"target-throughput": 18
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 2
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 1000,
+          "target-throughput": {{ target_throughput | default(18) }},
+          "clients": {{ search_clients | default(2) }}
         },
         {
           "operation": "randomized-nested-queries-with-inner-hits_default_big_size",
           "warmup-iterations": 500,
-          "iterations": 1000
-          {%- if not target_throughput %}
-          ,"target-throughput": 16
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 2
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 1000,
+          "target-throughput": {{ target_throughput | default(16) }},
+          "clients": {{ search_clients | default(2) }}
         }
       ]
     },

--- a/noaa/test_procedures/default.json
+++ b/noaa/test_procedures/default.json
@@ -61,113 +61,73 @@
         {
           "operation": "range_field_big_range",
           "warmup-iterations": 100,
-          "iterations": 500
-          {%- if not target_throughput %}
-          ,"target-throughput": 6
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 500,
+          "target-throughput": {{ target_throughput | default(6) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "range_field_small_range",
           "warmup-iterations": 100,
-          "iterations": 500
-          {%- if not target_throughput %}
-          ,"target-throughput": 10
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 500,
+          "target-throughput": {{ target_throughput | default(10) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "range_field_conjunction_big_range_small_term_query",
           "warmup-iterations": 100,
-          "iterations": 500
-          {%- if not target_throughput %}
-          ,"target-throughput": 10
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 500,
+          "target-throughput": {{ target_throughput | default(10) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "range_field_conjunction_small_range_small_term_query",
           "warmup-iterations": 100,
-          "iterations": 500
-          {%- if not target_throughput %}
-          ,"target-throughput": 10
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 500,
+          "target-throughput": {{ target_throughput | default(10) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "range_field_conjunction_small_range_big_term_query",
           "warmup-iterations": 100,
-          "iterations": 500
-          {%- if not target_throughput %}
-          ,"target-throughput": 4
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 500,
+          "target-throughput": {{ target_throughput | default(4) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "range_field_conjunction_big_range_big_term_query",
           "warmup-iterations": 100,
-          "iterations": 500
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 500,
+          "target-throughput": {{ target_throughput | default(1) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "range_field_disjunction_small_range_small_term_query",
           "warmup-iterations": 100,
-          "iterations": 500
-          {%- if not target_throughput %}
-          ,"target-throughput": 10
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 500,
+          "target-throughput": {{ target_throughput | default(10) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "range_field_disjunction_big_range_small_term_query",
           "warmup-iterations": 100,
-          "iterations": 500
-          {%- if not target_throughput %}
-          ,"target-throughput": 6
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 500,
+          "target-throughput": {{ target_throughput | default(6) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         }
       ]
@@ -283,306 +243,135 @@
         {
           "operation": "max_temp",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 4
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(4) }},
+          "clients": {{ search_clients | default(1) }}
         },
         {
           "operation": "last_max_temp_top_hits",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 4
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(4) }},
+          "clients": {{ search_clients | default(1) }}
         },
         {
           "operation": "last_max_temp_top_metrics",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 4
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(4) }},
+          "clients": {{ search_clients | default(1) }}
         },
         {
           "operation": "max_temp_per_station_10",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(2) }},
+          "clients": {{ search_clients | default(1) }}
         },
         {
           "operation": "last_max_temp_per_station_top_hits_10",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(2) }},
+          "clients": {{ search_clients | default(1) }}
         },
         {
           "operation": "last_max_temp_per_station_top_metrics_10",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(2) }},
+          "clients": {{ search_clients | default(1) }}
         },
         {
           "operation": "last_min_and_max_temp_per_station_top_metrics_10",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(2) }},
+          "clients": {{ search_clients | default(1) }}
         },
         {
           "operation": "last_five_max_temp_per_station_top_metrics_10",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(2) }},
+          "clients": {{ search_clients | default(1) }}
         },
         {
           "operation": "max_temp_per_station_10_depth_first",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(2) }},
+          "clients": {{ search_clients | default(1) }}
         },
         {
           "operation": "last_max_temp_per_station_top_hits_10_depth_first",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(1) }},
+          "clients": {{ search_clients | default(1) }}
         },
         {
           "operation": "last_max_temp_per_station_top_metrics_10_depth_first",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(1) }},
+          "clients": {{ search_clients | default(1) }}
         },
         {
           "operation": "last_max_temp_per_station_top_metrics_10_sort_by",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(1) }},
+          "clients": {{ search_clients | default(1) }}
         },
         {
           "operation": "max_temp_per_station_5000",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(1) }},
+          "clients": {{ search_clients | default(1) }}
         },
         {
           "operation": "last_max_temp_per_station_top_hits_5000",
           "warmup-iterations": 10,
-          "iterations": 50
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 50,
+          "target-throughput": {{ target_throughput | default(1) }},
+          "clients": {{ search_clients | default(1) }}
         },
         {
           "operation": "last_max_temp_per_station_top_hits_5000_via_source",
           "warmup-iterations": 10,
-          "iterations": 50
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 50,
+          "target-throughput": {{ target_throughput | default(1) }},
+          "clients": {{ search_clients | default(1) }}
         },
         {
           "operation": "last_max_temp_per_station_top_metrics_5000",
           "warmup-iterations": 10,
-          "iterations": 50
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 50,
+          "target-throughput": {{ target_throughput | default(1) }},
+          "clients": {{ search_clients | default(1) }}
         },
         {
           "operation": "last_min_and_max_temp_per_station_top_metrics_5000",
           "warmup-iterations": 10,
-          "iterations": 50
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 50,
+          "target-throughput": {{ target_throughput | default(1) }},
+          "clients": {{ search_clients | default(1) }}
         },
         {
           "operation": "last_five_max_temp_per_station_top_metrics_5000",
           "warmup-iterations": 10,
-          "iterations": 50
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 50,
+          "target-throughput": {{ target_throughput | default(1) }},
+          "clients": {{ search_clients | default(1) }}
         },
         {
           "operation": "last_country_code_per_station_top_metrics_5000",
           "warmup-iterations": 10,
-          "iterations": 50
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 50,
+          "target-throughput": {{ target_throughput | default(1) }},
+          "clients": {{ search_clients | default(1) }}
         }
       ]
     },

--- a/nyc_taxis/test_procedures/default.json
+++ b/nyc_taxis/test_procedures/default.json
@@ -56,71 +56,46 @@
         {
           "operation": "default",
           "warmup-iterations": 50,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 3
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(3) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "range",
           "warmup-iterations": 50,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.7
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(0.7) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "distance_amount_agg",
           "warmup-iterations": 50,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(2) }}
+         {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "autohisto_agg",
           "warmup-iterations": 50,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(1.5) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "date_histogram_agg",
           "warmup-iterations": 50,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(1.5) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         }
       ]

--- a/nyc_taxis/test_procedures/seachable-snapshot.json
+++ b/nyc_taxis/test_procedures/seachable-snapshot.json
@@ -77,71 +77,46 @@
         {
           "operation": "default",
           "warmup-iterations": 50,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 3
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(3) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "range",
           "warmup-iterations": 50,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.7
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(0.7) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "distance_amount_agg",
           "warmup-iterations": 50,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(2) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "autohisto_agg",
           "warmup-iterations": 50,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(1.5) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "date_histogram_agg",
           "warmup-iterations": 50,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(1.5) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         }
       ]

--- a/percolator/test_procedures/default.json
+++ b/percolator/test_procedures/default.json
@@ -61,85 +61,55 @@
         {
           "operation": "percolator_with_content_president_bush",
           "warmup-iterations": 100,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 50
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(50) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "percolator_with_content_saddam_hussein",
           "warmup-iterations": 100,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 50
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(50) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "percolator_with_content_hurricane_katrina",
           "warmup-iterations": 100,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 50
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(50) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "percolator_with_content_google",
           "warmup-iterations": 100,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 27
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(27) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "percolator_no_score_with_content_google",
           "warmup-iterations": 100,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 100
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(100) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "percolator_with_highlighting",
           "warmup-iterations": 100,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 50
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(50) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
@@ -152,15 +122,10 @@
         {
           "operation": "percolator_no_score_with_content_ignore_me",
           "warmup-iterations": 100,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 15
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(15) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         }
       ]

--- a/pmc/test_procedures/default.json
+++ b/pmc/test_procedures/default.json
@@ -70,85 +70,55 @@
         {
           "operation": "default",
           "warmup-iterations": 500,
-          "iterations": 200
-          {%- if not target_throughput %}
-          ,"target-throughput": 20
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 200,
+          "target-throughput": {{ target_throughput | default(20) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "term",
           "warmup-iterations": 500,
-          "iterations": 200
-          {%- if not target_throughput %}
-          ,"target-throughput": 20
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 200,
+          "target-throughput": {{ target_throughput | default(20) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "phrase",
           "warmup-iterations": 500,
-          "iterations": 200
-          {%- if not target_throughput %}
-          ,"target-throughput": 20
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 200,
+          "target-throughput": {{ target_throughput | default(20) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "articles_monthly_agg_uncached",
           "warmup-iterations": 500,
-          "iterations": 200
-          {%- if not target_throughput %}
-          ,"target-throughput": 20
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 200,
+          "target-throughput": {{ target_throughput | default(20) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         },
         {
           "operation": "articles_monthly_agg_cached",
           "warmup-iterations": 500,
-          "iterations": 200
-          {%- if not target_throughput %}
-          ,"target-throughput": 20
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
+          "iterations": 200,
+          "target-throughput": {{ target_throughput | default(20) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-        {%- endif %}
         },
         {
           "operation": "scroll",
           "warmup-iterations": 50,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(0.5) }}
+          {%- if search_clients is defined %}
+          ,"clients": {{ search_clients }}
           {%- endif %}
         }
       ]


### PR DESCRIPTION
### Description

Simplify the assignment of parameters `target-throughput` and `search_clients` to reduce the code duplication, which was introduced in the commit https://github.com/opensearch-project/opensearch-benchmark-workloads/commit/dd2ff3b22fe184f14ad1207cfb052a6e2fb0e761.
Initially I planned to use Jinja `macro` syntax to reuse the redundant codes, but after looking at the target codes, I think simplifying the code itself might be a better option.

For `target_throughput`, I propose to change from
```
{%- if not target_throughput %}
,"target-throughput": 2
{%- elif target_throughput is string and target_throughput.lower() == 'none' %}
{%- else %}
,"target-throughput": {{ target_throughput | tojson }}
{%- endif %}
```
to
```
"target-throughput": {{ target_throughput | default(2) }}
```

For `search_clients`, I propose to change from
```
{%- if search_clients is defined and search_clients %}
,"clients": {{ search_clients | tojson}}
{%- endif %}
```
to
```
{%- if search_clients is defined %}
"clients": {{ search_clients }}
{%- endif %}
```

or from
```
{%- if not search_clients %}
,"clients": 2
{%- elif search_clients is defined and search_clients %}
,"clients": {{ search_clients | tojson}}
{%- endif %}
```
to
```
"clients": {{ search_clients | default(2) }}
```

Some reasons:
1. For the field `target-throughput`, there was a specified value assigned to everywhere has got the field, so it's typical to use `"target-throughput": {{ target_throughput | default(2) }}` to assign a default value if adding the ability to assign custom value. This way is commonly used in the repository, such as https://github.com/opensearch-project/opensearch-benchmark-workloads/blob/1/nyc_taxis/test_procedures/default.json#L34 and https://github.com/opensearch-project/opensearch-benchmark-workloads/blob/1/so/test_procedures/default.json#L12, and there is no need to use the current tedious statements for "target-throughput".
2. Validating the data type of the input value is not useful, and there is no such validation for other parameters in this repository.
Although there is a difference in the error message after the code change, but I think it's acceptable, because there is no such tedious value validation for other fields. 
For example, assigning non-number value to `target-throughput` after my code change will throw the following error.
```
opensearch-benchmark execute-test \
--workload-path=/home/ftianli/github/opensearch-benchmark-workloads/nyc_taxis --test-procedure append-no-conflicts --test-mode \
--workload-params="target_throughput:text,search_clients:4"

[ERROR] Cannot execute-test. Error in test execution orchestrator (Could not load '/home/ftianli/github/opensearch-benchmark-workloads/nyc_taxis/workload.json': Expecting value: line 454 column 32 (char 11316). Lines containing the error:

          "operation": "default",
          "warmup-iterations": 50,
          "iterations": 100,
          "target-throughput": text
-------------------------------^ Error is here
          ,"clients": 4
        },
``` 
The below is the error before my code change:
I guess the error message comes from opensearch-benchmark validates the user input of "target-throughput", although the field is not assigned in json file.
```
[ERROR] Cannot execute-test. Error in test execution orchestrator (Task [default] specifies invalid target throughput [text].)
```
4. Looks like the expression `and search_clients` in existing statement `if search_clients is defined and search_clients` make no sense in this case. Empty value such as `None` or `none` or "" still be assigned in json file.
5. I don't think the expression `| tojson` is necessary here in `,"clients": {{ search_clients | tojson}}`, looking at the document https://jinja.palletsprojects.com/en/2.11.x/templates/#tojson, `tojson()` used to escape certain special characters in HTML contexts. The 2 parameters `target_throughout` and `search_clients` has number value, and I don't think escaping character is necessary here. 
Besides, using expression `| tojson` seems comes from Elasticsearch code https://github.com/elastic/rally-tracks/commit/dcd691f0c376141184c9824fc23d38de337ccae6, but don't understand the meaning of that.

Testing:
```
opensearch-benchmark execute-test \
--workload-path=/home/ftianli/github/opensearch-benchmark-workloads/nyc_taxis --test-procedure append-no-conflicts --test-mode \
--workload-params="target_throughput:10,search_clients:4"
```
```
opensearch-benchmark execute-test \
--workload-path=/home/ftianli/github/opensearch-benchmark-workloads/noaa --test-procedure append-no-conflicts --test-mode \
--workload-params="target_throughput:10,search_clients:4"
```

### Issues Resolved
https://github.com/opensearch-project/opensearch-benchmark-workloads/issues/64

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
