### PR TITLE
Fixed invalid field name in distance_amount_agg operation in nyc_taxis workload

### DIFF
--- a/nyc_taxis/operations/default.json
+++ b/nyc_taxis/operations/default.json
@@ -53,10 +53,22 @@
       "operation-type": "search",
       "body": {
         "size": 0,
+        "query": {
+          "bool": {
+            "filter": {
+              "range": {
+                "trip_distance": {
+                  "lt": 50,
+                  "gte": 0
+                }
+              }
+            }
+          }
+        },
         "aggs": {
           "distance_histo": {
             "histogram": {
-              "field": "distance",
+              "field": "trip_distance",
               "interval": 1
             },
             "aggs": {

--- a/nyc_taxis/test_procedures/default.json
+++ b/nyc_taxis/test_procedures/default.json
@@ -84,7 +84,7 @@
         {
           "operation": "distance_amount_agg",
           "warmup-iterations": 50,
-          "iterations": 100
+          "iterations": 50
           {%- if not target_throughput %}
           ,"target-throughput": 2
           {%- elif target_throughput is string and target_throughput.lower() == 'none' %}

--- a/nyc_taxis/test_procedures/seachable-snapshot.json
+++ b/nyc_taxis/test_procedures/seachable-snapshot.json
@@ -105,7 +105,7 @@
         {
           "operation": "distance_amount_agg",
           "warmup-iterations": 50,
-          "iterations": 100
+          "iterations": 50
           {%- if not target_throughput %}
           ,"target-throughput": 2
           {%- elif target_throughput is string and target_throughput.lower() == 'none' %}


### PR DESCRIPTION
### Description
Previously, the `distance_amount_agg` test operation aggregated on a field `distance` which doesn't exist, thus producing meaningless benchmark results. This PR fixes that typo bug and adds a range query to produce a known number of buckets and execute the request with an acceptable latency.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
