### PR TITLE
Provide variation of the workload(s) with unsigned_long data type

### DIFF
--- a/nyc_taxis/README.md
+++ b/nyc_taxis/README.md
@@ -73,6 +73,7 @@ This workload allows to overwrite the following parameters using `--workload-par
 * `error_level` (default: "non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
 * `target_throughput` (default: default values for each operation): Number of requests per second, `none` for no limit.
 * `search_clients`: Number of clients that issues search requests.
+* `trip_distance_type` (default: { "scaling_factor": 100, "type": "scaled_float" }): The `trip_distance` field type mapping
 
 ### Test Procedures
 The workload contains multiple test procedures, see [TEST_PROCEDURES](TEST_PROCEDURES.md) for details.

--- a/nyc_taxis/index.json
+++ b/nyc_taxis/index.json
@@ -80,10 +80,10 @@
         "scaling_factor": 100,
         "type": "scaled_float"
       },
-      "trip_distance": {
+      "trip_distance": {%- if trip_distance_type is defined %} {{ trip_distance_type | tojson }} {%- else %} {
         "scaling_factor": 100,
         "type": "scaled_float"
-      },
+      }{%- endif %},
       "pickup_location": {
         "type": "geo_point"
       }


### PR DESCRIPTION
### Description
Provide variation of the workload(s) with `unsigned_long` data type

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-benchmark-workloads/issues/85

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
