### PR TITLE
Enable/Disable Query and Requests Caching with parameters

### DIFF
--- a/eventdata/README.md
+++ b/eventdata/README.md
@@ -42,6 +42,7 @@ This workload allows the following parameters to be specified using `--workload-
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 5)
+* `requests_cache_enabled` (default: false)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.

--- a/eventdata/README.md
+++ b/eventdata/README.md
@@ -42,6 +42,7 @@ This workload allows the following parameters to be specified using `--workload-
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 5)
+* `query_cache_enabled` (default: false)
 * `requests_cache_enabled` (default: false)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.

--- a/eventdata/index.json
+++ b/eventdata/index.json
@@ -2,7 +2,7 @@
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(5)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
-    "index.requests.cache.enable": {{requests_cache_enabled | default(false)}}
+    "index.requests.cache.enable": {{requests_cache_enabled | default(false) | tojson}}
   },
   "mappings": {
     "dynamic": "strict",

--- a/eventdata/index.json
+++ b/eventdata/index.json
@@ -2,7 +2,7 @@
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(5)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
-    "index.requests.cache.enable": false
+    "index.requests.cache.enable": {{requests_cache_enabled | default(false)}}
   },
   "mappings": {
     "dynamic": "strict",

--- a/eventdata/index.json
+++ b/eventdata/index.json
@@ -2,6 +2,7 @@
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(5)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
+    "index.queries.cache.enabled": {{query_cache_enabled | default(false) | tojson}},
     "index.requests.cache.enable": {{requests_cache_enabled | default(false) | tojson}}
   },
   "mappings": {

--- a/geonames/README.md
+++ b/geonames/README.md
@@ -44,6 +44,7 @@ This workload allows the following parameters to be specified using `--workload-
 * `recency` (default: 0): A number between 0 and 1 that defines whether to bias towards more recent ids when simulating conflicts. See the [Benchmark docs](https://github.com/opensearch-project/OpenSearch-Benchmark/blob/main/DEVELOPER_GUIDE.md) for the full definition of this parameter. This requires to run the respective test_procedure.
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 5)
+* `query_cache_enabled` (default: false)
 * `requests_cache_enabled` (default: false)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.

--- a/geonames/README.md
+++ b/geonames/README.md
@@ -44,6 +44,7 @@ This workload allows the following parameters to be specified using `--workload-
 * `recency` (default: 0): A number between 0 and 1 that defines whether to bias towards more recent ids when simulating conflicts. See the [Benchmark docs](https://github.com/opensearch-project/OpenSearch-Benchmark/blob/main/DEVELOPER_GUIDE.md) for the full definition of this parameter. This requires to run the respective test_procedure.
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 5)
+* `requests_cache_enabled` (default: false)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.

--- a/geonames/index.json
+++ b/geonames/index.json
@@ -3,6 +3,7 @@
     "index.number_of_shards": {{number_of_shards | default(5)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
     "index.store.type": "{{store_type | default('fs')}}",
+    "index.queries.cache.enabled": {{query_cache_enabled | default(false) | tojson}},
     "index.requests.cache.enable": {{requests_cache_enabled | default(false) | tojson}}
   },
   "mappings": {

--- a/geonames/index.json
+++ b/geonames/index.json
@@ -3,7 +3,7 @@
     "index.number_of_shards": {{number_of_shards | default(5)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
     "index.store.type": "{{store_type | default('fs')}}",
-    "index.requests.cache.enable": {{requests_cache_enabled | default(false)}}
+    "index.requests.cache.enable": {{requests_cache_enabled | default(false) | tojson}}
   },
   "mappings": {
     "dynamic": "strict",

--- a/geonames/index.json
+++ b/geonames/index.json
@@ -3,7 +3,7 @@
     "index.number_of_shards": {{number_of_shards | default(5)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
     "index.store.type": "{{store_type | default('fs')}}",
-    "index.requests.cache.enable": false
+    "index.requests.cache.enable": {{requests_cache_enabled | default(false)}}
   },
   "mappings": {
     "dynamic": "strict",

--- a/geopoint/README.md
+++ b/geopoint/README.md
@@ -26,6 +26,7 @@ This workload allows the following parameters to be specified using `--workload-
 * `recency` (default: 0): A number between 0 and 1 that defines whether to bias towards more recent ids when simulating conflicts. See the [Benchmark docs](https://github.com/opensearch-project/OpenSearch-Benchmark/blob/main/DEVELOPER_GUIDE.md) for the full definition of this parameter. This requires to run the respective test_procedure.
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 5)
+* `requests_cache_enabled` (default: false)
 * `max_num_segments`: The maximum number of segments to force-merge to.
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.

--- a/geopoint/README.md
+++ b/geopoint/README.md
@@ -26,6 +26,7 @@ This workload allows the following parameters to be specified using `--workload-
 * `recency` (default: 0): A number between 0 and 1 that defines whether to bias towards more recent ids when simulating conflicts. See the [Benchmark docs](https://github.com/opensearch-project/OpenSearch-Benchmark/blob/main/DEVELOPER_GUIDE.md) for the full definition of this parameter. This requires to run the respective test_procedure.
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 5)
+* `query_cache_enabled` (default: false)
 * `requests_cache_enabled` (default: false)
 * `max_num_segments`: The maximum number of segments to force-merge to.
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.

--- a/geopoint/index.json
+++ b/geopoint/index.json
@@ -2,7 +2,7 @@
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(5)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
-    "index.requests.cache.enable": {{requests_cache_enabled | default(false)}}
+    "index.requests.cache.enable": {{requests_cache_enabled | default(false) | tojson}}
   },
   "mappings": {
     "dynamic": "strict",

--- a/geopoint/index.json
+++ b/geopoint/index.json
@@ -2,7 +2,7 @@
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(5)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
-    "index.requests.cache.enable": false
+    "index.requests.cache.enable": {{requests_cache_enabled | default(false)}}
   },
   "mappings": {
     "dynamic": "strict",

--- a/geopoint/index.json
+++ b/geopoint/index.json
@@ -2,6 +2,7 @@
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(5)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
+    "index.queries.cache.enabled": {{query_cache_enabled | default(false) | tojson}},
     "index.requests.cache.enable": {{requests_cache_enabled | default(false) | tojson}}
   },
   "mappings": {

--- a/geopointshape/README.md
+++ b/geopointshape/README.md
@@ -22,6 +22,7 @@ This workload allows the following parameters to be specified using `--workload-
 * `recency` (default: 0): A number between 0 and 1 that defines whether to bias towards more recent ids when simulating conflicts. See the [Benchmark docs](https://github.com/opensearch-project/OpenSearch-Benchmark/blob/main/DEVELOPER_GUIDE.md) for the full definition of this parameter. This requires to run the respective test_procedure.
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 1)
+* `requests_cache_enabled` (default: false)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.

--- a/geopointshape/README.md
+++ b/geopointshape/README.md
@@ -22,6 +22,7 @@ This workload allows the following parameters to be specified using `--workload-
 * `recency` (default: 0): A number between 0 and 1 that defines whether to bias towards more recent ids when simulating conflicts. See the [Benchmark docs](https://github.com/opensearch-project/OpenSearch-Benchmark/blob/main/DEVELOPER_GUIDE.md) for the full definition of this parameter. This requires to run the respective test_procedure.
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 1)
+* `query_cache_enabled` (default: false)
 * `requests_cache_enabled` (default: false)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.

--- a/geopointshape/index.json
+++ b/geopointshape/index.json
@@ -2,6 +2,7 @@
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(1)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
+    "index.queries.cache.enabled": {{query_cache_enabled | default(false) | tojson}},
     "index.requests.cache.enable": {{requests_cache_enabled | default(false) | tojson}}
   },
   "mappings": {

--- a/geopointshape/index.json
+++ b/geopointshape/index.json
@@ -2,7 +2,7 @@
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(1)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
-    "index.requests.cache.enable": false
+    "index.requests.cache.enable": {{requests_cache_enabled | default(false)}}
   },
   "mappings": {
     "dynamic": "strict",

--- a/geopointshape/index.json
+++ b/geopointshape/index.json
@@ -2,7 +2,7 @@
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(1)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
-    "index.requests.cache.enable": {{requests_cache_enabled | default(false)}}
+    "index.requests.cache.enable": {{requests_cache_enabled | default(false) | tojson}}
   },
   "mappings": {
     "dynamic": "strict",

--- a/geoshape/README.md
+++ b/geoshape/README.md
@@ -21,6 +21,7 @@ This workload allows the following parameters to be specified using `--workload-
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 1)
+* `requests_cache_enabled` (default: false)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.

--- a/geoshape/README.md
+++ b/geoshape/README.md
@@ -21,6 +21,7 @@ This workload allows the following parameters to be specified using `--workload-
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 1)
+* `query_cache_enabled` (default: false)
 * `requests_cache_enabled` (default: false)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.

--- a/geoshape/index.json
+++ b/geoshape/index.json
@@ -2,6 +2,7 @@
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(1)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
+    "index.queries.cache.enabled": {{query_cache_enabled | default(false) | tojson}},
     "index.requests.cache.enable": {{requests_cache_enabled | default(false) | tojson}}
   },
   "mappings": {

--- a/geoshape/index.json
+++ b/geoshape/index.json
@@ -2,7 +2,7 @@
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(1)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
-    "index.requests.cache.enable": false
+    "index.requests.cache.enable": {{requests_cache_enabled | default(false)}}
   },
   "mappings": {
     "dynamic": "strict",

--- a/geoshape/index.json
+++ b/geoshape/index.json
@@ -2,7 +2,7 @@
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(1)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
-    "index.requests.cache.enable": {{requests_cache_enabled | default(false)}}
+    "index.requests.cache.enable": {{requests_cache_enabled | default(false) | tojson}}
   },
   "mappings": {
     "dynamic": "strict",

--- a/http_logs/README.md
+++ b/http_logs/README.md
@@ -40,6 +40,7 @@ This workload allows the following parameters to be specified using `--workload-
 * `conflict_probability` (default: 25): A number between 0 and 100 that defines the probability of id conflicts. This requires to run the respective test_procedure. Combining ``conflicts=sequential`` and ``conflict-probability=0`` makes Benchmark generate index ids by itself, instead of relying on OpenSearch's `automatic id generation`.
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 5)
+* `query_cache_enabled` (default: false)
 * `requests_cache_enabled` (default: false)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.

--- a/http_logs/README.md
+++ b/http_logs/README.md
@@ -40,6 +40,7 @@ This workload allows the following parameters to be specified using `--workload-
 * `conflict_probability` (default: 25): A number between 0 and 100 that defines the probability of id conflicts. This requires to run the respective test_procedure. Combining ``conflicts=sequential`` and ``conflict-probability=0`` makes Benchmark generate index ids by itself, instead of relying on OpenSearch's `automatic id generation`.
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 5)
+* `requests_cache_enabled` (default: false)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.

--- a/http_logs/index.json
+++ b/http_logs/index.json
@@ -2,7 +2,7 @@
   "settings": {
     "index.number_of_shards": {{ number_of_shards | default(5) }},
     "index.number_of_replicas": {{ number_of_replicas | default(0) }},
-    "index.requests.cache.enable": false
+    "index.requests.cache.enable": {{requests_cache_enabled | default(false)}}
   },
   "mappings": {
     "dynamic": "strict",

--- a/http_logs/index.json
+++ b/http_logs/index.json
@@ -2,7 +2,7 @@
   "settings": {
     "index.number_of_shards": {{ number_of_shards | default(5) }},
     "index.number_of_replicas": {{ number_of_replicas | default(0) }},
-    "index.requests.cache.enable": {{requests_cache_enabled | default(false)}}
+    "index.requests.cache.enable": {{requests_cache_enabled | default(false) | tojson}}
   },
   "mappings": {
     "dynamic": "strict",

--- a/http_logs/index.json
+++ b/http_logs/index.json
@@ -2,6 +2,7 @@
   "settings": {
     "index.number_of_shards": {{ number_of_shards | default(5) }},
     "index.number_of_replicas": {{ number_of_replicas | default(0) }},
+    "index.queries.cache.enabled": {{query_cache_enabled | default(false) | tojson}},
     "index.requests.cache.enable": {{requests_cache_enabled | default(false) | tojson}}
   },
   "mappings": {

--- a/nested/README.md
+++ b/nested/README.md
@@ -55,6 +55,7 @@ This workload allows the following parameters to be specified using `--workload-
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 1)
+* `requests_cache_enabled` (default: false)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.

--- a/nested/README.md
+++ b/nested/README.md
@@ -55,6 +55,7 @@ This workload allows the following parameters to be specified using `--workload-
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 1)
+* `query_cache_enabled` (default: false)
 * `requests_cache_enabled` (default: false)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.

--- a/nested/index.json
+++ b/nested/index.json
@@ -3,7 +3,7 @@
     "index.number_of_shards": {{number_of_shards | default(1)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
     "index.store.type": "{{store_type | default('fs')}}",
-    "index.requests.cache.enable": {{requests_cache_enabled | default(false)}}
+    "index.requests.cache.enable": {{requests_cache_enabled | default(false | tojson)}}
   },
   "mappings": {
     "dynamic": "strict",

--- a/nested/index.json
+++ b/nested/index.json
@@ -3,6 +3,7 @@
     "index.number_of_shards": {{number_of_shards | default(1)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
     "index.store.type": "{{store_type | default('fs')}}",
+    "index.queries.cache.enabled": {{query_cache_enabled | default(false) | tojson}},
     "index.requests.cache.enable": {{requests_cache_enabled | default(false | tojson)}}
   },
   "mappings": {

--- a/nested/index.json
+++ b/nested/index.json
@@ -3,7 +3,7 @@
     "index.number_of_shards": {{number_of_shards | default(1)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
     "index.store.type": "{{store_type | default('fs')}}",
-    "index.requests.cache.enable": false
+    "index.requests.cache.enable": {{requests_cache_enabled | default(false)}}
   },
   "mappings": {
     "dynamic": "strict",

--- a/noaa/README.md
+++ b/noaa/README.md
@@ -49,6 +49,8 @@ This workload allows the following parameters to be specified using `--workload-
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 1)
+* `query_cache_enabled` (default: false)
+* `requests_cache_enabled` (default: false)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.

--- a/noaa/index.json
+++ b/noaa/index.json
@@ -2,8 +2,8 @@
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(1)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
-    "index.queries.cache.enabled": {{query_cache_enabled | default(false)}},
-    "index.requests.cache.enable": {{requests_cache_enabled | default(false)}},
+    "index.queries.cache.enabled": {{query_cache_enabled | default(false) | tojson}},
+    "index.requests.cache.enable": {{requests_cache_enabled | default(false) | tojson}},
     "index.merge.policy.max_merged_segment": "100GB"
   },
   "mappings": {

--- a/noaa/index.json
+++ b/noaa/index.json
@@ -2,8 +2,8 @@
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(1)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
-    "index.queries.cache.enabled": false,
-    "index.requests.cache.enable": false,
+    "index.queries.cache.enabled": {{query_cache_enabled | default(false)}},
+    "index.requests.cache.enable": {{requests_cache_enabled | default(false)}},
     "index.merge.policy.max_merged_segment": "100GB"
   },
   "mappings": {

--- a/nyc_taxis/README.md
+++ b/nyc_taxis/README.md
@@ -66,6 +66,7 @@ This workload allows to overwrite the following parameters using `--workload-par
 * `recency` (default: 0): A number between 0 and 1 that defines whether to bias towards more recent ids when simulating conflicts. See the [Benchmark docs](https://github.com/opensearch-project/OpenSearch-Benchmark/blob/main/DEVELOPER_GUIDE.md) for the full definition of this parameter. Only used by the `update` test_procedure.
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 1)
+* `requests_cache_enabled` (default: false)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `force_merge_max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.

--- a/nyc_taxis/README.md
+++ b/nyc_taxis/README.md
@@ -66,6 +66,7 @@ This workload allows to overwrite the following parameters using `--workload-par
 * `recency` (default: 0): A number between 0 and 1 that defines whether to bias towards more recent ids when simulating conflicts. See the [Benchmark docs](https://github.com/opensearch-project/OpenSearch-Benchmark/blob/main/DEVELOPER_GUIDE.md) for the full definition of this parameter. Only used by the `update` test_procedure.
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 1)
+* `query_cache_enabled` (default: false)
 * `requests_cache_enabled` (default: false)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `force_merge_max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use.

--- a/nyc_taxis/index.json
+++ b/nyc_taxis/index.json
@@ -2,6 +2,7 @@
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(1)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
+    "index.queries.cache.enabled": {{query_cache_enabled | default(false) | tojson}},
     "index.requests.cache.enable": {{requests_cache_enabled | default(false) | tojson}}
   },
   "mappings": {

--- a/nyc_taxis/index.json
+++ b/nyc_taxis/index.json
@@ -2,7 +2,7 @@
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(1)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
-    "index.requests.cache.enable": {{requests_cache_enabled | default(false)}}
+    "index.requests.cache.enable": {{requests_cache_enabled | default(false) | tojson}}
   },
   "mappings": {
     "_source": {

--- a/nyc_taxis/index.json
+++ b/nyc_taxis/index.json
@@ -2,7 +2,7 @@
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(1)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
-    "index.requests.cache.enable": false
+    "index.requests.cache.enable": {{requests_cache_enabled | default(false)}}
   },
   "mappings": {
     "_source": {

--- a/percolator/README.md
+++ b/percolator/README.md
@@ -27,7 +27,6 @@ This workload allows the following parameters to be specified using `--workload-
 * `number_of_shards` (default: 5)
 * `query_cache_enabled` (default: false)
 * `requests_cache_enabled` (default: false)
-* 
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.

--- a/percolator/README.md
+++ b/percolator/README.md
@@ -25,6 +25,9 @@ This workload allows the following parameters to be specified using `--workload-
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 5)
+* `query_cache_enabled` (default: false)
+* `requests_cache_enabled` (default: false)
+* 
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.

--- a/percolator/index.json
+++ b/percolator/index.json
@@ -2,8 +2,8 @@
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(5)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
-    "index.queries.cache.enabled": false,
-    "index.requests.cache.enable": false
+    "index.queries.cache.enabled": {{query_cache_enabled | default(false)}},
+    "index.requests.cache.enable": {{requests_cache_enabled | default(false)}}
   },
   "mappings": {
     "_source": {

--- a/percolator/index.json
+++ b/percolator/index.json
@@ -2,8 +2,8 @@
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(5)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
-    "index.queries.cache.enabled": {{query_cache_enabled | default(false)}},
-    "index.requests.cache.enable": {{requests_cache_enabled | default(false)}}
+    "index.queries.cache.enabled": {{query_cache_enabled | default(false) | tojson}},
+    "index.requests.cache.enable": {{requests_cache_enabled | default(false) | tojson}}
   },
   "mappings": {
     "_source": {

--- a/pmc/README.md
+++ b/pmc/README.md
@@ -35,6 +35,7 @@ This workload allows the following parameters to be specified using `--workload-
 * `recency` (default: 0): A number between 0 and 1 that defines whether to bias towards more recent ids when simulating conflicts. See the [Benchmark docs](https://github.com/opensearch-project/OpenSearch-Benchmark/blob/main/DEVELOPER_GUIDE.md) for the full definition of this parameter. This requires to run the respective test_procedure.
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 5)
+* `requests_cache_enabled` (default: false)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `default_search_timeout` (default: -1)

--- a/pmc/README.md
+++ b/pmc/README.md
@@ -35,6 +35,7 @@ This workload allows the following parameters to be specified using `--workload-
 * `recency` (default: 0): A number between 0 and 1 that defines whether to bias towards more recent ids when simulating conflicts. See the [Benchmark docs](https://github.com/opensearch-project/OpenSearch-Benchmark/blob/main/DEVELOPER_GUIDE.md) for the full definition of this parameter. This requires to run the respective test_procedure.
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 5)
+* `query_cache_enabled` (default: false)
 * `requests_cache_enabled` (default: false)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.

--- a/pmc/index.json
+++ b/pmc/index.json
@@ -2,7 +2,7 @@
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(5)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
-    "index.requests.cache.enable": {{requests_cache_enabled | default(false)}}
+    "index.requests.cache.enable": {{requests_cache_enabled | default(false) | tojson}}
   },
   "mappings": {
     "_source": {

--- a/pmc/index.json
+++ b/pmc/index.json
@@ -2,6 +2,7 @@
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(5)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
+    "index.queries.cache.enabled": {{query_cache_enabled | default(false) | tojson}},
     "index.requests.cache.enable": {{requests_cache_enabled | default(false) | tojson}}
   },
   "mappings": {

--- a/pmc/index.json
+++ b/pmc/index.json
@@ -2,7 +2,7 @@
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(5)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
-    "index.requests.cache.enable": false
+    "index.requests.cache.enable": {{requests_cache_enabled | default(false)}}
   },
   "mappings": {
     "_source": {

--- a/so/README.md
+++ b/so/README.md
@@ -48,6 +48,7 @@ This workload allows the following parameters to be specified using `--workload-
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 5)
+* `requests_cache_enabled` (default: false)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.

--- a/so/README.md
+++ b/so/README.md
@@ -48,6 +48,7 @@ This workload allows the following parameters to be specified using `--workload-
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 5)
+* `query_cache_enabled` (default: false)
 * `requests_cache_enabled` (default: false)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.

--- a/so/index.json
+++ b/so/index.json
@@ -2,7 +2,7 @@
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(5)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
-    "index.requests.cache.enable": {{requests_cache_enabled | default(false)}}
+    "index.requests.cache.enable": {{requests_cache_enabled | default(false) | tojson}}
   },
   "mappings": {
     "dynamic": "strict",

--- a/so/index.json
+++ b/so/index.json
@@ -2,7 +2,7 @@
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(5)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
-    "index.requests.cache.enable": false
+    "index.requests.cache.enable": {{requests_cache_enabled | default(false)}}
   },
   "mappings": {
     "dynamic": "strict",

--- a/so/index.json
+++ b/so/index.json
@@ -2,6 +2,7 @@
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(5)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
+    "index.queries.cache.enabled": {{query_cache_enabled | default(false) | tojson}},
     "index.requests.cache.enable": {{requests_cache_enabled | default(false) | tojson}}
   },
   "mappings": {


### PR DESCRIPTION
### Description

**Providing ability to enable query and/or requests cache on a workload.**

pass the parameters below with true or false according to your need. 

```
query_cache_enabled
requests_cache_enabled
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
