### PR TITLE
Provide sort query with int field type in http_logs

### DIFF
--- a/http_logs/operations/default.json
+++ b/http_logs/operations/default.json
@@ -228,6 +228,32 @@
       }
     },
     {
+      "name": "desc_sort_size",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "query": {
+          "match_all": {}
+        },
+        "sort" : [
+          {"size" : "desc"}
+        ]
+      }
+    },
+    {
+      "name": "asc_sort_size",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "query": {
+          "match_all": {}
+        },
+        "sort" : [
+          {"size" : "asc"}
+        ]
+      }
+    },
+    {
       "name": "desc_sort_timestamp",
       "operation-type": "search",
       "index": "logs-*",

--- a/http_logs/test_procedures/default.json
+++ b/http_logs/test_procedures/default.json
@@ -163,6 +163,34 @@
           "target-throughput": 1
         },
         {
+          "operation": "desc_sort_size",
+          "warmup-iterations": 200,
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 0.5
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
+        },
+        {
+          "operation": "asc_sort_size",
+          "warmup-iterations": 200,
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 0.5
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
+        },
+        {
           "operation": "desc_sort_timestamp",
           "warmup-iterations": 200,
           "iterations": 100
@@ -453,6 +481,34 @@
           "iterations": 200,
           "#COMMENT": "Throughput is considered per request. So we issue one scroll request per second which will retrieve 25 pages",
           "target-throughput": 1
+        },
+        {
+          "operation": "desc_sort_size",
+          "warmup-iterations": 200,
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 0.5
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
+        },
+        {
+          "operation": "asc_sort_size",
+          "warmup-iterations": 200,
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 0.5
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         },
         {
           "operation": "desc_sort_timestamp",


### PR DESCRIPTION
### Description
After https://github.com/opensearch-project/OpenSearch/pull/6424, we added support for sort point based optimization for INT types and we would like to cover that in sort queries.

### Issues Resolved
#94 

```
   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/

[INFO] You did not provide an explicit timeout in the client options. Assuming default of 10 seconds.
[INFO] Executing test with workload [http_logs], test_procedure [append-no-conflicts] and provision_config_instance ['external'] with version [2.7.0].

[WARNING] refresh_total_time is 3 ms indicating that the cluster is not in a defined clean state. Recorded index time metrics may be misleading.
Running asc_sort_size                                                          [100% done]

------------------------------------------------------
    _______             __   _____
   / ____(_)___  ____ _/ /  / ___/_________  ________
  / /_  / / __ \/ __ `/ /   \__ \/ ___/ __ \/ ___/ _ \
 / __/ / / / / / /_/ / /   ___/ / /__/ /_/ / /  /  __/
/_/   /_/_/ /_/\__,_/_/   /____/\___/\____/_/   \___/
------------------------------------------------------
            
|                                                         Metric |          Task |       Value |   Unit |
|---------------------------------------------------------------:|--------------:|------------:|-------:|
|                     Cumulative indexing time of primary shards |               |           0 |    min |
|             Min cumulative indexing time across primary shards |               |           0 |    min |
|          Median cumulative indexing time across primary shards |               |           0 |    min |
|             Max cumulative indexing time across primary shards |               |           0 |    min |
|            Cumulative indexing throttle time of primary shards |               |           0 |    min |
|    Min cumulative indexing throttle time across primary shards |               |           0 |    min |
| Median cumulative indexing throttle time across primary shards |               |           0 |    min |
|    Max cumulative indexing throttle time across primary shards |               |           0 |    min |
|                        Cumulative merge time of primary shards |               |           0 |    min |
|                       Cumulative merge count of primary shards |               |           0 |        |
|                Min cumulative merge time across primary shards |               |           0 |    min |
|             Median cumulative merge time across primary shards |               |           0 |    min |
|                Max cumulative merge time across primary shards |               |           0 |    min |
|               Cumulative merge throttle time of primary shards |               |           0 |    min |
|       Min cumulative merge throttle time across primary shards |               |           0 |    min |
|    Median cumulative merge throttle time across primary shards |               |           0 |    min |
|       Max cumulative merge throttle time across primary shards |               |           0 |    min |
|                      Cumulative refresh time of primary shards |               |       5e-05 |    min |
|                     Cumulative refresh count of primary shards |               |          96 |        |
|              Min cumulative refresh time across primary shards |               |           0 |    min |
|           Median cumulative refresh time across primary shards |               |           0 |    min |
|              Max cumulative refresh time across primary shards |               | 1.66667e-05 |    min |
|                        Cumulative flush time of primary shards |               |           0 |    min |
|                       Cumulative flush count of primary shards |               |          48 |        |
|                Min cumulative flush time across primary shards |               |           0 |    min |
|             Median cumulative flush time across primary shards |               |           0 |    min |
|                Max cumulative flush time across primary shards |               |           0 |    min |
|                                        Total Young Gen GC time |               |           0 |      s |
|                                       Total Young Gen GC count |               |           0 |        |
|                                          Total Old Gen GC time |               |           0 |      s |
|                                         Total Old Gen GC count |               |           0 |        |
|                                                     Store size |               |     18.8707 |     GB |
|                                                  Translog size |               | 2.45869e-06 |     GB |
|                                         Heap used for segments |               |           0 |     MB |
|                                       Heap used for doc values |               |           0 |     MB |
|                                            Heap used for terms |               |           0 |     MB |
|                                            Heap used for norms |               |           0 |     MB |
|                                           Heap used for points |               |           0 |     MB |
|                                    Heap used for stored fields |               |           0 |     MB |
|                                                  Segment count |               |          46 |        |
|                                                 Min Throughput | asc_sort_size |         0.5 |  ops/s |
|                                                Mean Throughput | asc_sort_size |         0.5 |  ops/s |
|                                              Median Throughput | asc_sort_size |         0.5 |  ops/s |
|                                                 Max Throughput | asc_sort_size |         0.5 |  ops/s |
|                                        50th percentile latency | asc_sort_size |     554.457 |     ms |
|                                        90th percentile latency | asc_sort_size |     565.052 |     ms |
|                                        99th percentile latency | asc_sort_size |      571.32 |     ms |
|                                       100th percentile latency | asc_sort_size |     596.967 |     ms |
|                                   50th percentile service time | asc_sort_size |     551.881 |     ms |
|                                   90th percentile service time | asc_sort_size |      562.54 |     ms |
|                                   99th percentile service time | asc_sort_size |     568.647 |     ms |
|                                  100th percentile service time | asc_sort_size |     595.064 |     ms |
|                                                     error rate | asc_sort_size |           0 |      % |
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
