### PR TITLE
Add search pipeline test procedures

### DIFF
--- a/http_logs/operations/default.json
+++ b/http_logs/operations/default.json
@@ -82,6 +82,42 @@
       ]
     },
     {
+      "name": "multi-term-filter",
+      "operation-type": "search",
+      "index": "logs-*",
+      "request-timeout": 7200,
+      "body": {
+        "query": {
+          "bool": {
+            "must": [
+              {
+                "term": {
+                  "request.raw": {
+                    "value": "GET / HTTP/1.0"
+                  }
+                }
+              }
+            ],
+            "filter": [
+              {
+                "term": {
+                  "status": 200
+                }
+              }
+            ]
+          }
+        }
+      },
+      "detailed-results": true,
+      "assertions": [
+        {
+          "property": "hits",
+          "condition": "==",
+          "value": 10000
+        }
+      ]
+    },
+    {
       "name": "range",
       "operation-type": "search",
       "index": "logs-*",
@@ -376,6 +412,134 @@
               "patterns": [
                 "%{IPORHOST} %{HTTPDUSER} %{USER} \\[%{TIMESTAMP_ISO8601:@timestamp}\\] \"(?:%{WORD} %{NOTSPACE}(?: HTTP/%{NUMBER})?|%{DATA})\" %{NUMBER} (?:%{NUMBER}|-)"
               ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "create-http-log-baseline-search-pipeline",
+      "operation-type": "create-search-pipeline",
+      "id": "http-log-baseline-search-pipeline",
+      "body": {
+        "description": "Process search requests with a pipeline that does nothing. Baseline for overhead of pipeline."
+      }
+    },
+    {
+      "name": "create-http-log-status-filter-search-pipeline",
+      "operation-type": "create-search-pipeline",
+      "id": "http-log-status-filter-search-pipeline",
+      "body": {
+        "description": "Process search requests by adding filters based on the status field.",
+        "request_processors": [
+          {
+            "filter_query": {
+              "description": "This processor is going to restrict to documents with a specific status code.",
+              "query": {
+                "term": {
+                  "status": 200
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "create-http-log-rename-field-search-pipeline",
+      "operation-type": "create-search-pipeline",
+      "id": "http-log-rename-field-search-pipeline",
+      "body": {
+        "description": "Process search requests with a pipeline that renames the specified field.",
+        "response_processors": [
+          {
+            "rename_field": {
+              "field": "status",
+              "target_field": "status_code"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "create-http-log-rename-100-field-search-pipeline",
+      "operation-type": "create-search-pipeline",
+      "id": "http-log-rename-100-field-search-pipeline",
+      "body": {
+        "description": "Process search requests with a pipeline that renames the specified field 100 times.",
+        "response_processors": [
+          {% for i in range(1, 101) %}
+          {
+            "rename_field": {
+              "field": "status",
+              "target_field": "status_{{ i }}"
+            }
+          }{% if not loop.last %},{% endif %}
+          {% endfor %}
+        ]
+      }
+    },
+    {
+      "name": "create-http-log-dummy-scripting-search-pipeline",
+      "operation-type": "create-search-pipeline",
+      "id": "http-log-dummy-scripting-search-pipeline",
+      "body": {
+        "description": "Process search requests with a pipeline that does a dummy operation in script.",
+        "request_processors": [
+          {
+            "script": {
+              "lang": "painless",
+              "source": "int size = ctx._source['size']; ctx._source['size'] = size;"
+            }
+          }
+        ]
+      }
+    },    
+    {
+      "name": "create-http-log-100-dummy-scripting-search-pipeline",
+      "operation-type": "create-search-pipeline",
+      "id": "http-log-100-dummy-scripting-search-pipeline",
+      "body": {
+        "description": "Process search requests with a pipeline that does 100 dummy operations in script.",
+        "request_processors": [
+          {
+            "script": {
+              "lang": "painless",
+              "source": "for (int i = 0; i < 50; i++) { ctx._source['size'] = ctx._source['size'] + 1; } for (int i = 0; i < 50; i++) { ctx._source['size'] = ctx._source['size'] - 1; }"
+            }
+          }
+        ]
+      }
+    },      
+    {
+      "name": "create-http-log-all-processors-search-pipeline",
+      "operation-type": "create-search-pipeline",
+      "id": "http-log-all-processors-search-pipeline",
+      "body": {
+        "description": "Process search requests that filters on status, supports explain with request size is 10, and renames status field.",
+        "request_processors": [
+          {
+            "filter_query": {
+              "description": "This processor is going to restrict to documents with a specific status code.",
+              "query": {
+                "term": {
+                  "status": 200
+                }
+              }
+            }
+          },
+          {
+            "script": {
+              "lang": "painless",
+              "source": "int size = ctx._source['size']; ctx._source['size'] = size;"
+            }
+          }
+        ],
+        "response_processors": [
+          {
+            "rename_field": {
+              "field": "status",
+              "target_field": "status_code"
             }
           }
         ]

--- a/http_logs/test_procedures/default.json
+++ b/http_logs/test_procedures/default.json
@@ -976,4 +976,291 @@
           }
         }
       ]
+    },
+    {
+      "name": "search-pipeline",
+      "description": "Indexes the whole document corpus using OpenSearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Benchmark will only start the benchmark if the cluster turns green. Runs the search request through an search pipeline with predefined search processors.",
+      "schedule": [
+        {
+          "operation": "delete-index"
+        },
+        {
+          "operation": {
+            "operation-type": "create-index",
+            "settings": {{index_settings | default({}) | tojson}}
+          }
+        },
+        {
+          "name": "check-cluster-health",
+          "operation": {
+            "operation-type": "cluster-health",
+            "index": "logs-*",
+            "request-params": {
+              "wait_for_status": "{{cluster_health | default('green')}}",
+              "wait_for_no_relocating_shards": "true"
+            },
+            "retry-until-success": true
+          }
+        },
+        {
+          "operation": "create-http-log-baseline-search-pipeline"
+        },
+        {
+          "operation": "create-http-log-status-filter-search-pipeline"
+        },
+        {
+          "operation": "create-http-log-rename-field-search-pipeline"
+        },
+        {
+          "operation": "create-http-log-rename-100-field-search-pipeline"
+        },
+        {
+          "operation": "create-http-log-dummy-scripting-search-pipeline"
+        },
+        {
+          "operation": "create-http-log-100-dummy-scripting-search-pipeline"
+        },
+        {
+          "operation": "create-http-log-all-processors-search-pipeline"
+        },
+        {
+          "operation": "index-append",
+          "warmup-time-period": 240,
+          "clients": {{bulk_indexing_clients | default(8)}}
+        },
+        {
+          "name": "refresh-after-index",
+          "operation": "refresh"
+        },
+        {
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200
+          }
+        },
+        {
+          "name": "refresh-after-force-merge",
+          "operation": "refresh"
+        },
+        {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
+        },
+        {
+          "name": "match-all",
+          "operation": "default",
+          "warmup-iterations": 500,
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 8
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
+        },
+        {
+          "name": "match-all-baseline-search-pipeline",
+          "operation": "default",
+          "request-params": {
+            "search-pipeline": "http-log-baseline-search-pipeline"
+          },
+          "warmup-iterations": 500,
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 8
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
+        },
+        {
+          "name": "match-all-status-filter-search-pipeline",
+          "operation": "default",
+          "request-params": {
+            "search-pipeline": "http-log-status-filter-search-pipeline"
+          },
+          "warmup-iterations": 500,
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 8
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
+        },
+        {
+          "name": "match-all-rename-field-search-pipeline",
+          "operation": "default",
+          "request-params": {
+            "search-pipeline": "http-log-rename-field-search-pipeline"
+          },
+          "warmup-iterations": 500,
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 8
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
+        },
+        {
+          "name": "match-all-rename-100-field-search-pipeline",
+          "operation": "default",
+          "request-params": {
+            "search-pipeline": "http-log-rename-100-field-search-pipeline"
+          },
+          "warmup-iterations": 500,
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 8
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
+        },
+        {
+          "name": "match-all-dummy-scripting-search-pipeline",
+          "operation": "default",
+          "request-params": {
+            "search-pipeline": "http-log-dummy-scripting-search-pipeline"
+          },
+          "warmup-iterations": 500,
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 8
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
+        },
+        {
+          "name": "match-all-100-dummy-scripting-search-pipeline",
+          "operation": "default",
+          "request-params": {
+            "search-pipeline": "http-log-100-dummy-scripting-search-pipeline"
+          },
+          "warmup-iterations": 500,
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 8
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
+        },
+        {
+          "name": "match-all-all-processors-search-pipeline",
+          "operation": "default",
+          "request-params": {
+            "search-pipeline": "http-log-all-processors-search-pipeline"
+          },
+          "warmup-iterations": 500,
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 8
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
+        },
+        {
+          "name": "multi-term-filter",
+          "operation": "multi-term-filter",
+          "warmup-iterations": 500,
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 50
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
+        },
+        {
+          "name": "term-status-filter-search-pipeline",
+          "operation": "term",
+          "warmup-iterations": 500,
+          "request-params": {
+            "search-pipeline": "http-log-status-filter-search-pipeline"
+          },
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 50
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
+        },
+        {
+          "name": "range",
+          "operation": "range",
+          "warmup-iterations": 100,
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 1
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
+        },
+        {
+          "name": "range-all-processors-search-pipeline",
+          "operation": "range",
+          "request-params": {
+            "search-pipeline": "http-log-all-processors-search-pipeline"
+          },
+          "warmup-iterations": 100,
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 1
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
+        }
+      ]
     }


### PR DESCRIPTION
### Description

Add search pipeline test procedures in http_logs

Test results

```
|                                                 Min Throughput |                                     match-all |        8.01 |  ops/s |
|                                                Mean Throughput |                                     match-all |        8.01 |  ops/s |
|                                              Median Throughput |                                     match-all |        8.01 |  ops/s |
|                                                 Max Throughput |                                     match-all |        8.01 |  ops/s |
|                                        50th percentile latency |                                     match-all |     9.73825 |     ms |
|                                        90th percentile latency |                                     match-all |     10.4528 |     ms |
|                                        99th percentile latency |                                     match-all |     12.2243 |     ms |
|                                       100th percentile latency |                                     match-all |     26.1549 |     ms |
|                                   50th percentile service time |                                     match-all |     8.74931 |     ms |
|                                   90th percentile service time |                                     match-all |     9.55052 |     ms |
|                                   99th percentile service time |                                     match-all |     11.1923 |     ms |
|                                  100th percentile service time |                                     match-all |     25.0052 |     ms |
|                                                     error rate |                                     match-all |           0 |      % |
|                                                 Min Throughput |            match-all-baseline-search-pipeline |        8.01 |  ops/s |
|                                                Mean Throughput |            match-all-baseline-search-pipeline |        8.01 |  ops/s |
|                                              Median Throughput |            match-all-baseline-search-pipeline |        8.01 |  ops/s |
|                                                 Max Throughput |            match-all-baseline-search-pipeline |        8.01 |  ops/s |
|                                        50th percentile latency |            match-all-baseline-search-pipeline |      10.073 |     ms |
|                                        90th percentile latency |            match-all-baseline-search-pipeline |     11.7446 |     ms |
|                                        99th percentile latency |            match-all-baseline-search-pipeline |     14.7933 |     ms |
|                                       100th percentile latency |            match-all-baseline-search-pipeline |     21.9893 |     ms |
|                                   50th percentile service time |            match-all-baseline-search-pipeline |      9.1001 |     ms |
|                                   90th percentile service time |            match-all-baseline-search-pipeline |     10.8324 |     ms |
|                                   99th percentile service time |            match-all-baseline-search-pipeline |     14.3062 |     ms |
|                                  100th percentile service time |            match-all-baseline-search-pipeline |     21.1092 |     ms |
|                                                     error rate |            match-all-baseline-search-pipeline |           0 |      % |
|                                                 Min Throughput |       match-all-status-filter-search-pipeline |        8.01 |  ops/s |
|                                                Mean Throughput |       match-all-status-filter-search-pipeline |        8.01 |  ops/s |
|                                              Median Throughput |       match-all-status-filter-search-pipeline |        8.01 |  ops/s |
|                                                 Max Throughput |       match-all-status-filter-search-pipeline |        8.01 |  ops/s |
|                                        50th percentile latency |       match-all-status-filter-search-pipeline |     9.68312 |     ms |
|                                        90th percentile latency |       match-all-status-filter-search-pipeline |     12.0678 |     ms |
|                                        99th percentile latency |       match-all-status-filter-search-pipeline |     17.8542 |     ms |
|                                       100th percentile latency |       match-all-status-filter-search-pipeline |     18.5953 |     ms |
|                                   50th percentile service time |       match-all-status-filter-search-pipeline |     8.71568 |     ms |
|                                   90th percentile service time |       match-all-status-filter-search-pipeline |     10.9738 |     ms |
|                                   99th percentile service time |       match-all-status-filter-search-pipeline |     16.8035 |     ms |
|                                  100th percentile service time |       match-all-status-filter-search-pipeline |     17.7223 |     ms |
|                                                     error rate |       match-all-status-filter-search-pipeline |           0 |      % |
|                                                 Min Throughput |        match-all-rename-field-search-pipeline |        8.01 |  ops/s |
|                                                Mean Throughput |        match-all-rename-field-search-pipeline |        8.01 |  ops/s |
|                                              Median Throughput |        match-all-rename-field-search-pipeline |        8.01 |  ops/s |
|                                                 Max Throughput |        match-all-rename-field-search-pipeline |        8.01 |  ops/s |
|                                        50th percentile latency |        match-all-rename-field-search-pipeline |     9.62405 |     ms |
|                                        90th percentile latency |        match-all-rename-field-search-pipeline |     10.1699 |     ms |
|                                        99th percentile latency |        match-all-rename-field-search-pipeline |     10.5104 |     ms |
|                                       100th percentile latency |        match-all-rename-field-search-pipeline |     11.6243 |     ms |
|                                   50th percentile service time |        match-all-rename-field-search-pipeline |     8.62069 |     ms |
|                                   90th percentile service time |        match-all-rename-field-search-pipeline |     9.03405 |     ms |
|                                   99th percentile service time |        match-all-rename-field-search-pipeline |     9.58435 |     ms |
|                                  100th percentile service time |        match-all-rename-field-search-pipeline |     10.3457 |     ms |
|                                                     error rate |        match-all-rename-field-search-pipeline |           0 |      % |
|                                                 Min Throughput |    match-all-rename-100-field-search-pipeline |        8.01 |  ops/s |
|                                                Mean Throughput |    match-all-rename-100-field-search-pipeline |        8.01 |  ops/s |
|                                              Median Throughput |    match-all-rename-100-field-search-pipeline |        8.01 |  ops/s |
|                                                 Max Throughput |    match-all-rename-100-field-search-pipeline |        8.01 |  ops/s |
|                                        50th percentile latency |    match-all-rename-100-field-search-pipeline |     9.75318 |     ms |
|                                        90th percentile latency |    match-all-rename-100-field-search-pipeline |     10.6093 |     ms |
|                                        99th percentile latency |    match-all-rename-100-field-search-pipeline |     16.6149 |     ms |
|                                       100th percentile latency |    match-all-rename-100-field-search-pipeline |       19.29 |     ms |
|                                   50th percentile service time |    match-all-rename-100-field-search-pipeline |     8.78488 |     ms |
|                                   90th percentile service time |    match-all-rename-100-field-search-pipeline |     9.49673 |     ms |
|                                   99th percentile service time |    match-all-rename-100-field-search-pipeline |     16.0447 |     ms |
|                                  100th percentile service time |    match-all-rename-100-field-search-pipeline |     18.1853 |     ms |
|                                                     error rate |    match-all-rename-100-field-search-pipeline |           0 |      % |
|                                                 Min Throughput |     match-all-dummy-scripting-search-pipeline |        8.01 |  ops/s |
|                                                Mean Throughput |     match-all-dummy-scripting-search-pipeline |        8.01 |  ops/s |
|                                              Median Throughput |     match-all-dummy-scripting-search-pipeline |        8.01 |  ops/s |
|                                                 Max Throughput |     match-all-dummy-scripting-search-pipeline |        8.01 |  ops/s |
|                                        50th percentile latency |     match-all-dummy-scripting-search-pipeline |     10.0384 |     ms |
|                                        90th percentile latency |     match-all-dummy-scripting-search-pipeline |     11.4374 |     ms |
|                                        99th percentile latency |     match-all-dummy-scripting-search-pipeline |     14.1783 |     ms |
|                                       100th percentile latency |     match-all-dummy-scripting-search-pipeline |     15.0031 |     ms |
|                                   50th percentile service time |     match-all-dummy-scripting-search-pipeline |     9.00078 |     ms |
|                                   90th percentile service time |     match-all-dummy-scripting-search-pipeline |     10.6206 |     ms |
|                                   99th percentile service time |     match-all-dummy-scripting-search-pipeline |     13.0181 |     ms |
|                                  100th percentile service time |     match-all-dummy-scripting-search-pipeline |     14.0365 |     ms |
|                                                     error rate |     match-all-dummy-scripting-search-pipeline |           0 |      % |
|                                                 Min Throughput | match-all-100-dummy-scripting-search-pipeline |        8.01 |  ops/s |
|                                                Mean Throughput | match-all-100-dummy-scripting-search-pipeline |        8.01 |  ops/s |
|                                              Median Throughput | match-all-100-dummy-scripting-search-pipeline |        8.01 |  ops/s |
|                                                 Max Throughput | match-all-100-dummy-scripting-search-pipeline |        8.01 |  ops/s |
|                                        50th percentile latency | match-all-100-dummy-scripting-search-pipeline |       9.885 |     ms |
|                                        90th percentile latency | match-all-100-dummy-scripting-search-pipeline |     11.8179 |     ms |
|                                        99th percentile latency | match-all-100-dummy-scripting-search-pipeline |     16.7773 |     ms |
|                                       100th percentile latency | match-all-100-dummy-scripting-search-pipeline |     19.0872 |     ms |
|                                   50th percentile service time | match-all-100-dummy-scripting-search-pipeline |     8.84045 |     ms |
|                                   90th percentile service time | match-all-100-dummy-scripting-search-pipeline |      10.811 |     ms |
|                                   99th percentile service time | match-all-100-dummy-scripting-search-pipeline |     16.1169 |     ms |
|                                  100th percentile service time | match-all-100-dummy-scripting-search-pipeline |     18.3521 |     ms |
|                                                     error rate | match-all-100-dummy-scripting-search-pipeline |           0 |      % |
|                                                 Min Throughput |      match-all-all-processors-search-pipeline |        8.01 |  ops/s |
|                                                Mean Throughput |      match-all-all-processors-search-pipeline |        8.01 |  ops/s |
|                                              Median Throughput |      match-all-all-processors-search-pipeline |        8.01 |  ops/s |
|                                                 Max Throughput |      match-all-all-processors-search-pipeline |        8.01 |  ops/s |
|                                        50th percentile latency |      match-all-all-processors-search-pipeline |     9.66343 |     ms |
|                                        90th percentile latency |      match-all-all-processors-search-pipeline |      10.495 |     ms |
|                                        99th percentile latency |      match-all-all-processors-search-pipeline |     25.2279 |     ms |
|                                       100th percentile latency |      match-all-all-processors-search-pipeline |     32.8171 |     ms |
|                                   50th percentile service time |      match-all-all-processors-search-pipeline |     8.70776 |     ms |
|                                   90th percentile service time |      match-all-all-processors-search-pipeline |     9.27332 |     ms |
|                                   99th percentile service time |      match-all-all-processors-search-pipeline |     24.4597 |     ms |
|                                  100th percentile service time |      match-all-all-processors-search-pipeline |     31.6344 |     ms |
|                                                     error rate |      match-all-all-processors-search-pipeline |           0 |      % |
|                                                 Min Throughput |                             multi-term-filter |       29.56 |  ops/s |
|                                                Mean Throughput |                             multi-term-filter |       29.78 |  ops/s |
|                                              Median Throughput |                             multi-term-filter |       29.79 |  ops/s |
|                                                 Max Throughput |                             multi-term-filter |       29.98 |  ops/s |
|                                        50th percentile latency |                             multi-term-filter |     7398.11 |     ms |
|                                        90th percentile latency |                             multi-term-filter |     7789.16 |     ms |
|                                        99th percentile latency |                             multi-term-filter |     7849.36 |     ms |
|                                       100th percentile latency |                             multi-term-filter |     7855.63 |     ms |
|                                   50th percentile service time |                             multi-term-filter |     26.2379 |     ms |
|                                   90th percentile service time |                             multi-term-filter |     33.1612 |     ms |
|                                   99th percentile service time |                             multi-term-filter |     50.1975 |     ms |
|                                  100th percentile service time |                             multi-term-filter |     53.5071 |     ms |
|                                                     error rate |                             multi-term-filter |           0 |      % |
|                                                 Min Throughput |            term-status-filter-search-pipeline |       49.94 |  ops/s |
|                                                Mean Throughput |            term-status-filter-search-pipeline |       49.94 |  ops/s |
|                                              Median Throughput |            term-status-filter-search-pipeline |       49.94 |  ops/s |
|                                                 Max Throughput |            term-status-filter-search-pipeline |       49.94 |  ops/s |
|                                        50th percentile latency |            term-status-filter-search-pipeline |     30.9315 |     ms |
|                                        90th percentile latency |            term-status-filter-search-pipeline |     55.3377 |     ms |
|                                        99th percentile latency |            term-status-filter-search-pipeline |      65.439 |     ms |
|                                       100th percentile latency |            term-status-filter-search-pipeline |     67.1581 |     ms |
|                                   50th percentile service time |            term-status-filter-search-pipeline |     17.7503 |     ms |
|                                   90th percentile service time |            term-status-filter-search-pipeline |     23.2506 |     ms |
|                                   99th percentile service time |            term-status-filter-search-pipeline |     29.7062 |     ms |
|                                  100th percentile service time |            term-status-filter-search-pipeline |     34.8449 |     ms |
|                                                     error rate |            term-status-filter-search-pipeline |           0 |      % |
|                                                 Min Throughput |                                         range |           1 |  ops/s |
|                                                Mean Throughput |                                         range |        1.01 |  ops/s |
|                                              Median Throughput |                                         range |        1.01 |  ops/s |
|                                                 Max Throughput |                                         range |        1.01 |  ops/s |
|                                        50th percentile latency |                                         range |     14.3958 |     ms |
|                                        90th percentile latency |                                         range |     18.0099 |     ms |
|                                        99th percentile latency |                                         range |     39.0979 |     ms |
|                                       100th percentile latency |                                         range |     42.5644 |     ms |
|                                   50th percentile service time |                                         range |     12.4786 |     ms |
|                                   90th percentile service time |                                         range |     16.4111 |     ms |
|                                   99th percentile service time |                                         range |     37.2756 |     ms |
|                                  100th percentile service time |                                         range |     40.2138 |     ms |
|                                                     error rate |                                         range |           0 |      % |
|                                                 Min Throughput |          range-all-processors-search-pipeline |           1 |  ops/s |
|                                                Mean Throughput |          range-all-processors-search-pipeline |        1.01 |  ops/s |
|                                              Median Throughput |          range-all-processors-search-pipeline |        1.01 |  ops/s |
|                                                 Max Throughput |          range-all-processors-search-pipeline |        1.01 |  ops/s |
|                                        50th percentile latency |          range-all-processors-search-pipeline |     14.0563 |     ms |
|                                        90th percentile latency |          range-all-processors-search-pipeline |     17.4486 |     ms |
|                                        99th percentile latency |          range-all-processors-search-pipeline |     28.9902 |     ms |
|                                       100th percentile latency |          range-all-processors-search-pipeline |     47.4176 |     ms |
|                                   50th percentile service time |          range-all-processors-search-pipeline |     12.0969 |     ms |
|                                   90th percentile service time |          range-all-processors-search-pipeline |     15.2881 |     ms |
|                                   99th percentile service time |          range-all-processors-search-pipeline |     26.6797 |     ms |
|                                  100th percentile service time |          range-all-processors-search-pipeline |     45.3439 |     ms |
|                                                     error rate |          range-all-processors-search-pipeline |           0 |      % |
```


### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
