### PR TITLE
Revert "Added benchmarks for multi-term aggregation (#89)"

### DIFF
--- a/http_logs/operations/default.json
+++ b/http_logs/operations/default.json
@@ -189,33 +189,6 @@
       }
     },
     {
-      "name": "multi_term_agg",
-      "operation-type": "search",
-      "index": "logs-*",
-      "body": {
-        "size": 0,
-        "query": {
-          "range": {
-            "@timestamp": {
-              "gte": "1998-05-03T00:00:00Z",
-              "lt": "1998-05-07T00:00:00Z"
-            }
-          }
-        },
-        "aggs": {
-          "mterms": {
-            "multi_terms": {
-              "terms": [
-                {"field": "clientip"},
-                {"field": "status"},
-                {"field": "size"}
-              ]
-            }
-          }
-        }
-      }
-    },
-    {
       "name": "scroll",
       "operation-type": "search",
       "index": "logs-*",

--- a/http_logs/test_procedures/default.json
+++ b/http_logs/test_procedures/default.json
@@ -129,21 +129,7 @@
         },
         {
           "operation": "hourly_agg",
-          "warmup-iterations": 50,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
-        },
-        {
-          "operation": "multi_term_agg",
-          "warmup-iterations": 50,
+          "warmup-iterations": 100,
           "iterations": 100
           {%- if not target_throughput %}
           ,"target-throughput": 0.2
@@ -463,7 +449,7 @@
         },
         {
           "operation": "hourly_agg",
-          "warmup-iterations": 50,
+          "warmup-iterations": 100,
           "iterations": 100
           {%- if not target_throughput %}
           ,"target-throughput": 0.2
@@ -481,34 +467,6 @@
           "iterations": 200,
           "#COMMENT": "Throughput is considered per request. So we issue one scroll request per second which will retrieve 25 pages",
           "target-throughput": 1
-        },
-        {
-          "operation": "desc_sort_size",
-          "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
-        },
-        {
-          "operation": "asc_sort_size",
-          "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
         },
         {
           "operation": "desc_sort_timestamp",


### PR DESCRIPTION
This reverts commit 2b5ff9, since multi-term aggregations are not supported in OpenSearch 1.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
