### PR TITLE
Add concurrent indexing/querying scenario to PMC workload

### DIFF
--- a/pmc/README.md
+++ b/pmc/README.md
@@ -30,9 +30,10 @@ This workload allows the following parameters to be specified using `--workload-
 * `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
 * `conflicts` (default: "random"): Type of id conflicts to simulate. Valid values are: 'sequential' (A document id is replaced with a document id with a sequentially increasing id), 'random' (A document id is replaced with a document id with a random other id).
-* `conflict_probability` (default: 25): A number between 0 and 100 that defines the probability of id conflicts. This requires to run the respective test_procedure. Combining ``conflicts=sequential`` and ``conflict-probability=0`` makes Benchmark generate index ids by itself, instead of relying on OpenSearch's `automatic id generation`.
+* `conflict_probability` (default: 25): A number between 0 and 100 that defines the probability of id conflicts. This requires to run the respective test-procedure. Combining ``conflicts=sequential`` and ``conflict-probability=0`` makes OpenSearch Benchmark generate index ids by itself, instead of relying on OpenSearch's `automatic id generation.
 * `on_conflict` (default: "index"): Whether to use an "index" or an "update" action when simulating an id conflict.
-* `recency` (default: 0): A number between 0 and 1 that defines whether to bias towards more recent ids when simulating conflicts. See the [Benchmark docs](https://github.com/opensearch-project/OpenSearch-Benchmark/blob/main/DEVELOPER_GUIDE.md) for the full definition of this parameter. This requires to run the respective test_procedure.
+* `recency` (default: 0): A number between 0 and 1 that defines whether to bias towards more recent ids when simulating conflicts. See the [OpenSearch Benchmark docs](https://opensearch.org/docs/latest/benchmark/index/) for the full definition of this parameter. This requires to run the respective test-procedure.
+* `max_num_segments`: The number of segments to target when doing a force merge (default: -1)
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 5)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
@@ -40,8 +41,8 @@ This workload allows the following parameters to be specified using `--workload-
 * `default_search_timeout` (default: -1)
 * `cluster_health` (default: "green"): The minimum required cluster health.
 * `error_level` (default: "non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
-* `target_throughput` (default: default values for each operation): Number of requests per second, `none` for no limit.
-* `search_clients`: Number of clients that issues search requests.
+* `target_throughput` (default: default values for each operation): Number of requests per second.
+* `search_clients`: Number of clients that issue search requests.
 
 ### License
 

--- a/pmc/test_procedures/default.json
+++ b/pmc/test_procedures/default.json
@@ -1,6 +1,6 @@
     {
       "name": "append-no-conflicts",
-      "description": "Indexes the whole document corpus using OpenSearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Benchmark will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only. After that a couple of queries are run.",
+      "description": "Indexes the whole document corpus using OpenSearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and OpenSearch Benchmark will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only. After that a couple of queries are run.",
       "default": true,
       "schedule": [
         {
@@ -47,6 +47,7 @@
         {
           "operation": {
             "operation-type": "force-merge",
+            "max-num-segments": {{ max_num_segments | default(-1) }},
             "request-timeout": 7200
           }
         },
@@ -70,92 +71,50 @@
         {
           "operation": "default",
           "warmup-iterations": 500,
-          "iterations": 200
-          {%- if not target_throughput %}
-          ,"target-throughput": 20
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 200,
+          "target-throughput": {{ target_throughput | default(20) | tojson }},
+          "clients": {{ search_clients | default(1) }}
         },
         {
           "operation": "term",
           "warmup-iterations": 500,
-          "iterations": 200
-          {%- if not target_throughput %}
-          ,"target-throughput": 20
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 200,
+          "target-throughput": {{ target_throughput | default(20) | tojson }},
+          "clients": {{ search_clients | default(1) }}
         },
         {
           "operation": "phrase",
           "warmup-iterations": 500,
-          "iterations": 200
-          {%- if not target_throughput %}
-          ,"target-throughput": 20
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 200,
+          "target-throughput": {{ target_throughput | default(20) | tojson }},
+          "clients": {{ search_clients | default(1) }}
         },
         {
           "operation": "articles_monthly_agg_uncached",
           "warmup-iterations": 500,
-          "iterations": 200
-          {%- if not target_throughput %}
-          ,"target-throughput": 20
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 200,
+          "target-throughput": {{ target_throughput | default(20) | tojson }},
+          "clients": {{ search_clients | default(1) }}
         },
         {
           "operation": "articles_monthly_agg_cached",
           "warmup-iterations": 500,
-          "iterations": 200
-          {%- if not target_throughput %}
-          ,"target-throughput": 20
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-        {%- endif %}
+          "iterations": 200,
+          "target-throughput": {{ target_throughput | default(20) | tojson }},
+          "clients": {{ search_clients | default(1) }}
         },
         {
           "operation": "scroll",
           "warmup-iterations": 50,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ target_throughput | default(0.5) | tojson }},
+          "clients": {{ search_clients | default(1) }}
         }
       ]
     },
     {
       "name": "append-no-conflicts-index-only",
-      "description": "Indexes the whole document corpus using OpenSearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Benchmark will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only.",
+      "description": "Indexes the whole document corpus using OpenSearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and OpenSearch Benchmark will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only.",
       "schedule": [
         {
           "operation": "delete-index"
@@ -191,6 +150,9 @@
         {
           "operation": {
             "operation-type": "force-merge",
+{%- if force_merge_max_num_segments is defined %}
+            "max-num-segments": {{ force_merge_max_num_segments | tojson }},
+{%- endif %}
             "request-timeout": 7200
           }
         },
@@ -278,7 +240,7 @@
     },
     {
       "name": "append-fast-with-conflicts",
-      "description": "Indexes the whole document corpus using a setup that will lead to a larger indexing throughput than the default settings. Benchmark will produce duplicate ids in 25% of all documents (not configurable) so we can simulate a scenario with appends most of the time and some updates in between.",
+      "description": "Indexes the whole document corpus using a setup that will lead to a larger indexing throughput than the default settings. OpenSearch Benchmark will produce duplicate ids in 25% of all documents (not configurable) so we can simulate a scenario with appends most of the time and some updates in between.",
       "schedule": [
         {
           "operation": "delete-index"

--- a/pmc/test_procedures/indexing-querying.json
+++ b/pmc/test_procedures/indexing-querying.json
@@ -1,0 +1,137 @@
+{
+  "name": "indexing-querying",
+  "description": "Indexes half the data for NYC Taxis, then concurrently queries OpenSearch while indexing again.",
+  "default": false,
+  "schedule": [
+    {
+      "operation": {
+        "operation-type": "put-settings",
+        "body": {
+          "transient": {
+            "search.default_search_timeout": "{{default_search_timeout | default(-1)}}"
+          }
+        }
+      }
+    },
+    {
+      "operation": "delete-index"
+    },
+    {
+      "operation": {
+        "operation-type": "create-index",
+        "settings": {{index_settings | default({}) | tojson}}
+      }
+    },
+    {
+      "name": "check-cluster-health",
+      "operation": {
+        "operation-type": "cluster-health",
+        "index": "pmc",
+        "request-params": {
+          "wait_for_status": "{{cluster_health | default('green')}}",
+          "wait_for_no_relocating_shards": "true"
+        },
+        "retry-until-success": true
+      }
+    },
+    {
+      "name": "initial-index-append",
+      "operation": {
+        "operation-type": "bulk",
+        "bulk-size": {{bulk_size | default(500)}},
+        "ingest-percentage": 50
+      },
+      "warmup-time-period": 30,
+      "clients": {{bulk_indexing_clients | default(8)}},
+      "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
+    },
+    {
+      "name": "refresh-after-index",
+      "operation": "refresh"
+    },
+    {
+      "operation": {
+        "operation-type": "force-merge",
+{%- if force_merge_max_num_segments is defined %}
+        "max-num-segments": {{ force_merge_max_num_segments | tojson }},
+{%- endif %}
+        "request-timeout": 7200
+      }
+    },
+    {
+      "name": "refresh-after-force-merge",
+      "operation": "refresh"
+    },
+    {
+      "name": "wait-until-merges-finish",
+      "operation": {
+        "operation-type": "index-stats",
+        "index": "_all",
+        "condition": {
+          "path": "_all.total.merges.current",
+          "expected-value": 0
+        },
+        "retry-until-success": true,
+        "include-in-reporting": false
+      }
+    },
+    {
+      "parallel": {
+        "tasks": [
+          {
+            "name": "concurrent-index-append",
+            "operation": {
+              "operation-type": "bulk",
+              "bulk-size": {{bulk_size | default(500)}},
+              "ingest-percentage": 50
+            },
+            "clients": {{bulk_indexing_clients | default(8)}},
+            "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
+          },
+          {
+            "operation": "default",
+            "warmup-iterations": 500,
+            "iterations": 200,
+            "target-throughput": {{ target_throughput | default(20) | tojson }},
+            "clients": {{ search_clients | default(1) }}
+          },
+          {
+            "operation": "term",
+            "warmup-iterations": 500,
+            "iterations": 200,
+            "target-throughput": {{ target_throughput | default(20) | tojson }},
+            "clients": {{ search_clients | default(1) }}
+          },
+          {
+            "operation": "phrase",
+            "warmup-iterations": 500,
+            "iterations": 200,
+            "target-throughput": {{ target_throughput | default(20) | tojson }},
+            "clients": {{ search_clients | default(1) }}
+          },
+          {
+            "operation": "articles_monthly_agg_uncached",
+            "warmup-iterations": 500,
+            "iterations": 200,
+            "target-throughput": {{ target_throughput | default(20) | tojson }},
+            "clients": {{ search_clients | default(1) }}
+          },
+          {
+            "operation": "articles_monthly_agg_cached",
+            "warmup-iterations": 500,
+            "iterations": 200,
+            "target-throughput": {{ target_throughput | default(20) | tojson }},
+            "clients": {{ search_clients | default(1) }}
+          },
+          {
+            "operation": "scroll",
+            "warmup-iterations": 50,
+            "iterations": 100,
+            "target-throughput": {{ target_throughput | default(0.5) | tojson }},
+            "clients": {{ search_clients | default(1) }}
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Description
Add concurrent indexing/querying scenario to PMC workload.

### Testing
Tested both the standard scenario and the concurrent one against an OpenSearch cluster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Creative Commons license.  Attribution: https://github.com/elastic/rally-tracks/pmc.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
