### PR TITLE
Update workload download endpoints

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -8,7 +8,7 @@ set -u
 set -o pipefail
 
 readonly ROOT=".benchmark/benchmarks"
-readonly URL="https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora"
+readonly URL="https://dbyiw3u3rf9yr.cloudfront.net/corpora"
 
 
 # see http://stackoverflow.com/a/246128

--- a/eventdata/workload.json
+++ b/eventdata/workload.json
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "eventdata",
-      "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/eventdata",
+      "base-url": "https://dbyiw3u3rf9yr.cloudfront.net/corpora/eventdata",
       "documents": [
         {
           "source-file": "eventdata.json.bz2",

--- a/geonames/workload.json
+++ b/geonames/workload.json
@@ -2,7 +2,7 @@
 {
   "version": 2,
   "description": "POIs from Geonames",
-  "data-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/geonames",
+  "data-url": "https://dbyiw3u3rf9yr.cloudfront.net/corpora/geonames",
   "indices": [
     {
       "name": "geonames",
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "geonames",
-      "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/geonames",
+      "base-url": "https://dbyiw3u3rf9yr.cloudfront.net/corpora/geonames",
       "documents": [
         {
           "source-file": "documents-2.json.bz2",

--- a/geopoint/workload.json
+++ b/geopoint/workload.json
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "geopoint",
-      "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/geopoint",
+      "base-url": "https://dbyiw3u3rf9yr.cloudfront.net/corpora/geopoint",
       "documents": [
         {
           "source-file": "documents.json.bz2",

--- a/geopointshape/workload.json
+++ b/geopointshape/workload.json
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "geopointshape",
-      "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/geopointshape",
+      "base-url": "https://dbyiw3u3rf9yr.cloudfront.net/corpora/geopointshape",
       "documents": [
         {
           "source-file": "documents.json.bz2",

--- a/geoshape/workload.json
+++ b/geoshape/workload.json
@@ -20,7 +20,7 @@
   "corpora": [
     {
       "name": "linestrings",
-      "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/geoshape",
+      "base-url": "https://dbyiw3u3rf9yr.cloudfront.net/corpora/geoshape",
       "target-index": "osmlinestrings",
       "documents": [
         {
@@ -33,7 +33,7 @@
     },
     {
       "name": "multilinestrings",
-      "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/geoshape",
+      "base-url": "https://dbyiw3u3rf9yr.cloudfront.net/corpora/geoshape",
       "target-index": "osmmultilinestrings",
       "documents": [
         {
@@ -46,7 +46,7 @@
     },
     {
       "name": "polygons",
-      "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/geoshape",
+      "base-url": "https://dbyiw3u3rf9yr.cloudfront.net/corpora/geoshape",
       "target-index": "osmpolygons",
       "documents": [
         {

--- a/http_logs/workload.json
+++ b/http_logs/workload.json
@@ -56,7 +56,7 @@
       {%- elif ingest_pipeline is defined and ingest_pipeline == "grok" %}
         {
           "name": "http_logs_unparsed",
-          "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/http_logs",
+          "base-url": "https://dbyiw3u3rf9yr.cloudfront.net/corpora/http_logs",
           "documents": [
           {
             "target-index": "logs-181998",
@@ -112,7 +112,7 @@
     {%- else %}
       {
         "name": "http_logs",
-        "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/http_logs",
+        "base-url": "https://dbyiw3u3rf9yr.cloudfront.net/corpora/http_logs",
         "documents": [
           {
             "target-index": "logs-181998",

--- a/nested/workload.json
+++ b/nested/workload.json
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "nested",
-      "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/nested",
+      "base-url": "https://dbyiw3u3rf9yr.cloudfront.net/corpora/nested",
       "documents": [
         {
           "source-file": "documents.json.bz2",

--- a/noaa/workload.json
+++ b/noaa/workload.json
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "noaa",
-      "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/noaa",
+      "base-url": "https://dbyiw3u3rf9yr.cloudfront.net/corpora/noaa",
       "documents": [
         {
           "source-file": "documents.json.bz2",

--- a/nyc_taxis/workload.json
+++ b/nyc_taxis/workload.json
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "nyc_taxis",
-      "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/nyc_taxis",
+      "base-url": "https://dbyiw3u3rf9yr.cloudfront.net/corpora/nyc_taxis",
       "documents": [
         {
           "source-file": "documents.json.bz2",

--- a/percolator/workload.json
+++ b/percolator/workload.json
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "percolator",
-      "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/percolator",
+      "base-url": "https://dbyiw3u3rf9yr.cloudfront.net/corpora/percolator",
       "documents": [
         {
           "source-file": "queries-2.json.bz2",

--- a/pmc/workload.json
+++ b/pmc/workload.json
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "pmc",
-      "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/pmc",
+      "base-url": "https://dbyiw3u3rf9yr.cloudfront.net/corpora/pmc",
       "documents": [
         {
           "source-file": "documents.json.bz2",

--- a/so/workload.json
+++ b/so/workload.json
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "so",
-      "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/so",
+      "base-url": "https://dbyiw3u3rf9yr.cloudfront.net/corpora/so",
       "documents": [
         {
           "source-file": "posts.json.bz2",


### PR DESCRIPTION
### Description
Update workload download endpoints to use Cloudfront distribution endpoint instead of S3 endpoint. S3 endpoint is will start blocking TLSv1 and v1.1 calls. The guidance is to use CDN over the S3 bucket to not break the download functionality for older versions of OSB that use TLSv1 or v1.1. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
