### PR TITLE
Adding sort queries on half_float field type

### DIFF
--- a/nyc_taxis/index.json
+++ b/nyc_taxis/index.json
@@ -40,8 +40,7 @@
         "type": "scaled_float"
       },
       "tip_amount": {
-        "scaling_factor": 100,
-        "type": "scaled_float"
+        "type": "half_float"
       },
       "payment_type": {
         "type": "keyword"

--- a/nyc_taxis/operations/default.json
+++ b/nyc_taxis/operations/default.json
@@ -326,4 +326,30 @@
           }
         }
       }
+    },
+    {
+      "name": "desc_sort_tip_amount",
+      "operation-type": "search",
+      "index": "nyc_taxis",
+      "body": {
+        "query": {
+          "match_all": {}
+        },
+        "sort" : [
+          {"tip_amount" : "desc"}
+        ]
+      }
+    },
+    {
+      "name": "asc_sort_tip_amount",
+      "operation-type": "search",
+      "index": "nyc_taxis",
+      "body": {
+        "query": {
+          "match_all": {}
+        },
+        "sort" : [
+          {"tip_amount" : "asc"}
+        ]
+      }
     }

--- a/nyc_taxis/test_procedures/default.json
+++ b/nyc_taxis/test_procedures/default.json
@@ -125,7 +125,7 @@
         },
         {
           "operation": "desc_sort_tip_amount",
-          "warmup-iterations": 10,
+          "warmup-iterations": 50,
           "iterations": 100
           {%- if not target_throughput %}
           ,"target-throughput": 0.5
@@ -139,7 +139,7 @@
         },
         {
           "operation": "asc_sort_tip_amount",
-          "warmup-iterations": 10,
+          "warmup-iterations": 50,
           "iterations": 100
           {%- if not target_throughput %}
           ,"target-throughput": 0.5

--- a/nyc_taxis/test_procedures/default.json
+++ b/nyc_taxis/test_procedures/default.json
@@ -125,7 +125,7 @@
         },
         {
           "operation": "desc_sort_tip_amount",
-          "warmup-iterations": 200,
+          "warmup-iterations": 10,
           "iterations": 100
           {%- if not target_throughput %}
           ,"target-throughput": 0.5
@@ -139,7 +139,7 @@
         },
         {
           "operation": "asc_sort_tip_amount",
-          "warmup-iterations": 200,
+          "warmup-iterations": 10,
           "iterations": 100
           {%- if not target_throughput %}
           ,"target-throughput": 0.5

--- a/nyc_taxis/test_procedures/default.json
+++ b/nyc_taxis/test_procedures/default.json
@@ -122,6 +122,34 @@
           {%-if search_clients is defined and search_clients %}
           ,"clients": {{ search_clients | tojson}}
           {%- endif %}
+        },
+        {
+          "operation": "desc_sort_tip_amount",
+          "warmup-iterations": 200,
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 0.5
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
+        },
+        {
+          "operation": "asc_sort_tip_amount",
+          "warmup-iterations": 200,
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 0.5
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
         }
       ]
     },


### PR DESCRIPTION
### Description
`half_float` field type is unique and we have custom comparators for this field. `half_float` is a mapping where BKD is indexed with 2 bytes while its doc values are stored as 4 bytes, so the sort logic comparison is divided in 2 ways, but still we were able to enable BKD point based optimization for this type.
`nyc_taxis` workload has many float type, `tip_amount` generally are between 0 to 100 $ and it should qualify as `half_float`. So making this field as `half_float` and adding asc & desc sort queries for this field will likely to improve our benchmarking coverage.

### Issues Resolved
#138 

### Test
```
[ec2-user@ip-172-31-6-46 ~]$ opensearch-benchmark execute-test --workload=nyc_taxis --target-hosts=172.31.3.244:9200 --pipeline=benchmark-only --include-tasks="desc_sort_tip_amount,asc_sort_tip_amount"

   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/

[WARNING] Local changes in [/home/ec2-user/.benchmark/benchmarks/workloads/default] prevent workloads update from remote. Please commit your changes.
[WARNING] Local changes in [/home/ec2-user/.benchmark/benchmarks/workloads/default] prevent workloads update from remote. Please commit your changes.
[WARNING] Local changes in [/home/ec2-user/.benchmark/benchmarks/workloads/default] prevent workloads update from remote. Please commit your changes.
[INFO] Executing test with workload [nyc_taxis], test_procedure [append-no-conflicts] and provision_config_instance ['external'] with version [3.0.0-SNAPSHOT].

Running desc_sort_tip_amount                                                   [ 94% done]
Running desc_sort_tip_amount                                                   [ 95% done]
Running desc_sort_tip_amount                                                   [100% done]
Running asc_sort_tip_amount                                                    [ 26% done]
Running asc_sort_tip_amount                                                    [ 91% done]


Running asc_sort_tip_amount                                                    [100% done]

------------------------------------------------------
    _______             __   _____
   / ____(_)___  ____ _/ /  / ___/_________  ________
  / /_  / / __ \/ __ `/ /   \__ \/ ___/ __ \/ ___/ _ \
 / __/ / / / / / /_/ / /   ___/ / /__/ /_/ / /  /  __/
/_/   /_/_/ /_/\__,_/_/   /____/\___/\____/_/   \___/
------------------------------------------------------
            
|                                                         Metric |                 Task |       Value |   Unit |
|---------------------------------------------------------------:|---------------------:|------------:|-------:|
|                     Cumulative indexing time of primary shards |                      |           0 |    min |
|             Min cumulative indexing time across primary shards |                      |           0 |    min |
|          Median cumulative indexing time across primary shards |                      |           0 |    min |
|             Max cumulative indexing time across primary shards |                      |           0 |    min |
|            Cumulative indexing throttle time of primary shards |                      |           0 |    min |
|    Min cumulative indexing throttle time across primary shards |                      |           0 |    min |
| Median cumulative indexing throttle time across primary shards |                      |           0 |    min |
|    Max cumulative indexing throttle time across primary shards |                      |           0 |    min |
|                        Cumulative merge time of primary shards |                      |           0 |    min |
|                       Cumulative merge count of primary shards |                      |           0 |        |
|                Min cumulative merge time across primary shards |                      |           0 |    min |
|             Median cumulative merge time across primary shards |                      |           0 |    min |
|                Max cumulative merge time across primary shards |                      |           0 |    min |
|               Cumulative merge throttle time of primary shards |                      |           0 |    min |
|       Min cumulative merge throttle time across primary shards |                      |           0 |    min |
|    Median cumulative merge throttle time across primary shards |                      |           0 |    min |
|       Max cumulative merge throttle time across primary shards |                      |           0 |    min |
|                      Cumulative refresh time of primary shards |                      |           0 |    min |
|                     Cumulative refresh count of primary shards |                      |         100 |        |
|              Min cumulative refresh time across primary shards |                      |           0 |    min |
|           Median cumulative refresh time across primary shards |                      |           0 |    min |
|              Max cumulative refresh time across primary shards |                      |           0 |    min |
|                        Cumulative flush time of primary shards |                      |           0 |    min |
|                       Cumulative flush count of primary shards |                      |          50 |        |
|                Min cumulative flush time across primary shards |                      |           0 |    min |
|             Median cumulative flush time across primary shards |                      |           0 |    min |
|                Max cumulative flush time across primary shards |                      |           0 |    min |
|                                        Total Young Gen GC time |                      |           0 |      s |
|                                       Total Young Gen GC count |                      |           0 |        |
|                                          Total Old Gen GC time |                      |           0 |      s |
|                                         Total Old Gen GC count |                      |           0 |        |
|                                                     Store size |                      |     72.0877 |     GB |
|                                                  Translog size |                      | 2.56114e-06 |     GB |
|                                         Heap used for segments |                      |           0 |     MB |
|                                       Heap used for doc values |                      |           0 |     MB |
|                                            Heap used for terms |                      |           0 |     MB |
|                                            Heap used for norms |                      |           0 |     MB |
|                                           Heap used for points |                      |           0 |     MB |
|                                    Heap used for stored fields |                      |           0 |     MB |
|                                                  Segment count |                      |         333 |        |
|                                                 Min Throughput | desc_sort_tip_amount |         0.5 |  ops/s |
|                                                Mean Throughput | desc_sort_tip_amount |         0.5 |  ops/s |
|                                              Median Throughput | desc_sort_tip_amount |         0.5 |  ops/s |
|                                                 Max Throughput | desc_sort_tip_amount |         0.5 |  ops/s |
|                                        50th percentile latency | desc_sort_tip_amount |     11.9902 |     ms |
|                                        90th percentile latency | desc_sort_tip_amount |     12.6701 |     ms |
|                                        99th percentile latency | desc_sort_tip_amount |     13.3074 |     ms |
|                                       100th percentile latency | desc_sort_tip_amount |     13.4193 |     ms |
|                                   50th percentile service time | desc_sort_tip_amount |     9.26986 |     ms |
|                                   90th percentile service time | desc_sort_tip_amount |     9.82747 |     ms |
|                                   99th percentile service time | desc_sort_tip_amount |     10.3689 |     ms |
|                                  100th percentile service time | desc_sort_tip_amount |     10.4408 |     ms |
|                                                     error rate | desc_sort_tip_amount |           0 |      % |
|                                                 Min Throughput |  asc_sort_tip_amount |         0.5 |  ops/s |
|                                                Mean Throughput |  asc_sort_tip_amount |         0.5 |  ops/s |
|                                              Median Throughput |  asc_sort_tip_amount |         0.5 |  ops/s |
|                                                 Max Throughput |  asc_sort_tip_amount |         0.5 |  ops/s |
|                                        50th percentile latency |  asc_sort_tip_amount |      98.617 |     ms |
|                                        90th percentile latency |  asc_sort_tip_amount |     99.5494 |     ms |
|                                        99th percentile latency |  asc_sort_tip_amount |     102.915 |     ms |
|                                       100th percentile latency |  asc_sort_tip_amount |     112.141 |     ms |
|                                   50th percentile service time |  asc_sort_tip_amount |     95.3346 |     ms |
|                                   90th percentile service time |  asc_sort_tip_amount |      95.776 |     ms |
|                                   99th percentile service time |  asc_sort_tip_amount |     100.285 |     ms |
|                                  100th percentile service time |  asc_sort_tip_amount |       109.3 |     ms |
|                                                     error rate |  asc_sort_tip_amount |           0 |      % |

```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
