### PR TITLE
Fix noaa keyword-terms-numeric-terms field name

### DIFF
--- a/noaa/operations/default.json
+++ b/noaa/operations/default.json
@@ -839,7 +839,7 @@
                 },
                 "aggs": {
                   "max": {
-                    "max": { "field": "tmax" }
+                    "max": { "field": "TMAX" }
                   }
                 }
               }


### PR DESCRIPTION
### Description
Fix the field name for noaa keyword-terms-numeric-terms test

### Issues Resolved
resolves #147 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
