### PR TITLE
Add default-size operation to http-logs

### DIFF
--- a/http_logs/operations/default.json
+++ b/http_logs/operations/default.json
@@ -59,6 +59,17 @@
       }
     },
     {
+      "name": "default-size",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "size": {{default_size | default(1000)}},
+        "query": {
+          "match_all": {}
+        }
+      }
+    },
+    {
       "name": "term",
       "operation-type": "search",
       "index": "logs-*",

--- a/http_logs/test_procedures/default.json
+++ b/http_logs/test_procedures/default.json
@@ -71,6 +71,21 @@
           {%- endif %}
         },
         {
+          "name": "match-all-size",
+          "operation": "default-size",
+          "warmup-iterations": 500,
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 8
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
+        },
+        {
           "name": "term",
           "operation": "term",
           "warmup-iterations": 500,
@@ -392,6 +407,21 @@
         },
         {
           "operation": "default",
+          "warmup-iterations": 500,
+          "iterations": 100
+          {%- if not target_throughput %}
+          ,"target-throughput": 8
+          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+          {%- else %}
+          ,"target-throughput": {{ target_throughput | tojson }}
+          {%- endif %}
+          {%-if search_clients is defined and search_clients %}
+          ,"clients": {{ search_clients | tojson}}
+          {%- endif %}
+        },
+        {
+          "name": "match-all-size",
+          "operation": "default-size",
           "warmup-iterations": 500,
           "iterations": 100
           {%- if not target_throughput %}


### PR DESCRIPTION
### Description
Add a `default-size` operation to the http-logs procedures. The `scroll` operation uses a `match_all` query with size 1000, so the `default-size` operation will give us a baseline for that from which we can infer the scroll context overhead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
