### PR TITLE
Add quick fix to Big5 Workload for integration tests

### DIFF
--- a/big5/workload.json
+++ b/big5/workload.json
@@ -17,8 +17,8 @@
         {
           "source-url": "{{ document_url | safe }}",
           "source-file": "{{ document_file | default('documents.json') }}",
-          "document-count": {{ document_count }},
-          "uncompressed-bytes": {{ document_uncompressed_size_in_bytes }},
+          "document-count": {{ document_count | default(2000) }},
+          "uncompressed-bytes": {{ document_uncompressed_size_in_bytes | default(2000) }},
           "compressed-bytes": {{ document_compressed_size_in_bytes | default(1) }}
         }
       ]


### PR DESCRIPTION
### Description
Integration Tests in OpenSearch Benchmark repository are failing due to the following error:
```
Error: _test.py::test_list_workloads[in-memory-it] [ERROR] Cannot list. Could not load '/home/runner/work/opensearch-benchmark/opensearch-benchmark/.benchmark/benchmarks/workloads/default/big5/workload.json': Expecting value: line 20 column 29 (char 412). Lines containing the error:

        {
          "source-url": "",
          "source-file": "documents.json",
          "document-count": ,
----------------------------^ Error is here
          "uncompressed-bytes": ,
          "compressed-bytes": 1
```
This PR adds some changes to get around this issue

_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
