### PR TITLE
Add new maintainers to .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @IanHoang @gkamat
+* @IanHoang @gkamat @beaioun @cgchinmay


### PR DESCRIPTION
### Description
New maintainers need to be added to .github/CODEOWNERS too

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
