### PR TITLE
Include client processing time start and end

### DIFF
--- a/vectorsearch/runners.py
+++ b/vectorsearch/runners.py
@@ -8,6 +8,7 @@ import logging
 
 from opensearchpy.exceptions import ConnectionTimeout
 from osbenchmark.worker_coordinator.runner import Retry, Runner
+from osbenchmark.client import RequestContextHolder
 
 from osbenchmark.utils.parse import parse_int_parameter, parse_string_parameter
 
@@ -19,6 +20,7 @@ def register(registry):
         WarmupIndicesRunner.RUNNER_NAME, Retry(WarmupIndicesRunner(), retry_until_success=True), async_runner=True
     )
 
+request_context_holder = RequestContextHolder()
 
 class WarmupIndicesRunner(Runner):
     """
@@ -32,7 +34,9 @@ class WarmupIndicesRunner(Runner):
         method = "GET"
         warmup_url = "/_plugins/_knn/warmup/{}".format(index)
         result = {'success': False}
+        request_context_holder.on_client_request_start()
         response = await opensearch.transport.perform_request(method, warmup_url)
+        request_context_holder.on_client_request_end()
         if response is None or response['_shards'] is None:
             return result
         status = response['_shards']['failed'] == 0


### PR DESCRIPTION
### Description
Opensearch Benchmark added new metric called "client_processing_time to measure time taken between send and receive request to opensearch. This requires changes to set start/end before and after  call to opensearch api.

### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
