### PR TITLE
Update the big5 workload with specifications for the associated data corpus

### DIFF
--- a/big5/README.md
+++ b/big5/README.md
@@ -2,7 +2,32 @@
 
 This repository contains the "Big5" workload for benchmarking OpenSearch using OpenSearch Benchmark. The "Big5" workload focuses on five essential areas in OpenSearch performance and querying: Text Querying, Sorting, Date Histogram, Range Queries, and Terms Aggregation.
 
-This workload is derived from the [Elasticsearch vs. OpenSearch comparison benchmark](https://github.com/elastic/elasticsearch-opensearch-benchmark) published by Elastic.  It has been slightly modified to be compliant with OpenSearch features.
+This workload is derived from the [Elasticsearch vs. OpenSearch comparison benchmark](https://github.com/elastic/elasticsearch-opensearch-benchmark) published by Elastic.  It has been modified to conform to OpenSearch Benchmark terminology and comply with OpenSearch features; changes are in the JSON files within the workload.
+
+
+### The "Big 5" Areas
+
+1. Text Querying:
+
+   Free text search is vital for databases due to its flexibility, ease of use, and ability to quickly filter data. It allows users to input natural language queries, eliminating the need for complex query languages and making data retrieval more intuitive. With free text search, users can find information using familiar terms, such as names, email addresses, or user IDs, without requiring knowledge about the underlying schema. It is particularly useful for handling unstructured data, supporting partial matches, and facilitating data exploration.
+
+2. Sorting:
+
+   Sorting is a process of arranging data in a particular order, such as alphabetical, numerical, or chronological. The sort query in OpenSearch is useful for organizing search results based on specific criteria, ensuring that the most relevant results are presented to users. It is a vital feature that enhances the user experience and improves the overall effectiveness of the search process.
+
+   In the context of observability and security, in which signals from multiple systems are correlated, sorting is a crucial operation. By sorting results based on timestamp, metrics, or any other relevant field, analysts can more efficiently identify issues, security threats, or correlations within the data. With this information, it becomes easier to identify patterns, trends, and insights that can inform business decisions to protect your data and ensure uptime.
+
+3. Date Histogram:
+
+   The date histogram aggregation in OpenSearch is useful for aggregating and analyzing time-based data by dividing it into intervals, or buckets. This capability allows users to visualize and better understand trends, patterns, and anomalies over time.
+
+4. Range Queries:
+
+   The range query in OpenSearch is useful for filtering search results based on a specific range of values in a given field. This capability allows users to narrow down their search results and find more relevant information quickly.
+
+5. Terms Aggregation:
+
+   Terms allow users to dynamically build into buckets to source based on aggregation values. These can be 100s or 1000s of unique terms that get returned individually or in composite aggregations. Larger size values use more memory and compute to push the aggregations through.
 
 
 ### Prerequisites
@@ -14,9 +39,34 @@ Before using this repository, ensure you have the following installed:
 - An existing datastream with data generated using the open-source tool [Elastic Integration Corpus Generator Tool](https://github.com/elastic/elastic-integration-corpus-generator-tool). The data should follow the expected document structure mentioned below.
 
 
+### Parameters
+
+This workload allows the following parameters to be specified using `--workload-params`:
+
+* `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.
+* `bulk_size` (default: 5000): The number of documents in each bulk during indexing.
+* `cluster_health` (default: "green"): The minimum required cluster health.
+* `document_compressed_size_in_bytes`: If specifying an alternate data corpus, the compressed size of the corpus.
+* `document_count`: If specifying an alternate data corpus, the number of documents in that corpus.
+* `document_file`: If specifying an alternate data corpus, the file name of the corpus.
+* `document_uncompressed_size_in_bytes`: If specifying an alternate data corpus, the uncompressed size of the corpus.
+* `document_url`:  If specifying an alternate data corpus, the full path to the corpus file (optional).
+* `error_level` (default: "non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
+* `index_name` (default: "big5"): The name of the index the workload should create and use for its operations.
+* `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
+* `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
+* `max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use.
+* `number_of_replicas` (default: 1): The number of replicas to use for the index.
+* `number_of_shards` (default: 1): The number of shards to use for the index.
+* `query_cache_enabled` (default: false): Whether the query cache should be enabled.
+* `requests_cache_enabled` (default: false): Whether the requests cache should be enabled.
+* `search_clients`: (default: 1): Number of clients that issue search requests.
+* `target_throughput` (default: 2): default throughput for each operation in requests per second, `none` for no limit.
+
+
 ### Data Document Structure
 
-The datastream must already exist and the data be generated using the open-source tool [Elastic Integration Corpus Generator Tool](https://github.com/elastic/elastic-integration-corpus-generator-tool). The expected structure of the documents is specified in the "Data Document Structure" section of this README.
+The document schema can be found in the `index.json` file.  An example document from the data corpus is provided below.
 
 ```json
 {
@@ -63,29 +113,69 @@ The datastream must already exist and the data be generated using the open-sourc
 
 ```
 
+### Sample Run Output
 
+```
+   ____                  _____                      __       ____                  __                         __
+  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
+ / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
+/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
+\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
+    /_/
 
-### The "Big 5" Areas
+[INFO] You did not provide an explicit timeout in the client options. Assuming default of 10 seconds.
+[INFO] Executing test with workload [big5], test_procedure [big5] and provision_config_instance ['external'] with version [2.5.0].
 
-1. Text Querying:
+Running delete-index                                                           [100% done]
+Running create-index                                                           [100% done]
+Running check-cluster-health                                                   [100% done]
+Running index-append                                                           [100% done]
+Running refresh-after-index                                                    [100% done]
+Running force-merge                                                            [100% done]
+Running refresh-after-force-merge                                              [100% done]
+Running wait-until-merges-finish                                               [100% done]
+Running default                                                                [100% done]
+Running desc_sort_timestamp                                                    [100% done]
+Running asc_sort_timestamp                                                     [100% done]
+Running desc_sort_with_after_timestamp                                         [100% done]
+Running asc_sort_with_after_timestamp                                          [100% done]
+Running desc_sort_timestamp_can_match_shortcut                                 [100% done]
+Running desc_sort_timestamp_no_can_match_shortcut                              [100% done]
+Running asc_sort_timestamp_can_match_shortcut                                  [100% done]
+Running asc_sort_timestamp_no_can_match_shortcut                               [100% done]
+Running term                                                                   [100% done]
+Running multi_terms-keyword                                                    [100% done]
+Running keyword-terms                                                          [100% done]
+Running keyword-terms-low-cardinality                                          [100% done]
+Running composite-terms                                                        [100% done]
+Running composite_terms-keyword                                                [100% done]
+Running composite-date_histogram-daily                                         [100% done]
+Running range                                                                  [100% done]
+Running range-numeric                                                          [100% done]
+Running keyword-in-range                                                       [100% done]
+Running date_histogram_hourly_agg                                              [100% done]
+Running date_histogram_minute_agg                                              [100% done]
+Running scroll                                                                 [100% done]
+Running query-string-on-message                                                [100% done]
+Running query-string-on-message-filtered                                       [100% done]
+Running query-string-on-message-filtered-sorted-num                            [100% done]
+Running sort_keyword_can_match_shortcut                                        [100% done]
+Running sort_keyword_no_can_match_shortcut                                     [100% done]
+Running sort_numeric_desc                                                      [100% done]
+Running sort_numeric_asc                                                       [100% done]
+Running sort_numeric_desc_with_match                                           [100% done]
+Running sort_numeric_asc_with_match                                            [100% done]
+Running range_field_conjunction_big_range_big_term_query                       [100% done]
+Running range_field_disjunction_big_range_small_term_query                     [100% done]
+Running range_field_conjunction_small_range_small_term_query                   [100% done]
+Running range_field_conjunction_small_range_big_term_query                     [100% done]
+Running range-auto-date-histo                                                  [100% done]
+Running range-auto-date-histo-with-metrics                                     [100% done]
 
-   Free text search is vital for databases due to its flexibility, ease of use, and ability to quickly filter data. It allows users to input natural language queries, eliminating the need for complex query languages and making data retrieval more intuitive. With free text search, users can find information using familiar terms, such as names, email addresses, or user IDs, without requiring knowledge about the underlying schema. It is particularly useful for handling unstructured data, supporting partial matches, and facilitating data exploration.
+------------------------------------------------------
+```
 
-2. Sorting:
+### License
 
-   Sorting is a process of arranging data in a particular order, such as alphabetical, numerical, or chronological. The sort query in OpenSearch is useful for organizing search results based on specific criteria, ensuring that the most relevant results are presented to users. It is a vital feature that enhances the user experience and improves the overall effectiveness of the search process.
-
-   In the context of observability and security, in which signals from multiple systems are correlated, sorting is a crucial operation. By sorting results based on timestamp, metrics, or any other relevant field, analysts can more efficiently identify issues, security threats, or correlations within the data. With this information, it becomes easier to identify patterns, trends, and insights that can inform business decisions to protect your data and ensure uptime.
-
-3. Date Histogram:
-
-   The date histogram aggregation in OpenSearch is useful for aggregating and analyzing time-based data by dividing it into intervals, or buckets. This capability allows users to visualize and better understand trends, patterns, and anomalies over time.
-
-4. Range Queries:
-
-   The range query in OpenSearch is useful for filtering search results based on a specific range of values in a given field. This capability allows users to narrow down their search results and find more relevant information quickly.
-
-5. Terms Aggregation:
-
-   Terms allow users to dynamically build into buckets to source based on aggregation values. These can be 100s or 1000s of unique terms that get returned individually or in composite aggregations. Larger size values use more memory and compute to push the aggregations through.
+Please see the included LICENSE.txt file for details about the license applicable to this workload and its associated artifacts.
 

--- a/big5/index.json
+++ b/big5/index.json
@@ -1,10 +1,12 @@
 {
     "settings": {
+	  "index.number_of_shards": {{number_of_shards | default(1)}},
+	  "index.number_of_replicas": {{number_of_replicas | default(1)}},
+	  "index.queries.cache.enabled": {{query_cache_enabled | default(false) | tojson}},
+  	  "index.requests.cache.enable": {{requests_cache_enabled | default(false) | tojson}},
 	  "index.codec": "best_compression",
-	  "index.number_of_shards": "1",
 	  "index.translog.sync_interval": "30s",
-	  "index.translog.durability": "async",
-	  "index.number_of_replicas": "1"
+	  "index.translog.durability": "async"
       },
       "mappings": {
 	  "properties": {

--- a/big5/operations/default.json
+++ b/big5/operations/default.json
@@ -7,7 +7,7 @@
     {
       "name": "default",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": {
         "query": {
           "match_all": {}
@@ -17,7 +17,7 @@
     {
       "name": "term",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "request-timeout": 7200,
       "body": {
         "query": {
@@ -32,7 +32,7 @@
     {
       "name": "range",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": {
         "query": {
           "range": {
@@ -47,7 +47,7 @@
     {
       "name": "range-numeric",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": {
         "query": {
           "range": {
@@ -62,7 +62,7 @@
     {
       "name": "keyword-in-range",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": {
         "query": {
           "bool": {
@@ -88,7 +88,7 @@
     {
       "name": "date_histogram_hourly_agg",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": {
         "size": 0,
         "aggs": {
@@ -104,7 +104,7 @@
     {
       "name": "date_histogram_minute_agg",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": {
         "size": 0,
         "query": {
@@ -128,7 +128,7 @@
     {
       "name": "scroll",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "pages": 25,
       "results-per-page": 1000,
       "body": {
@@ -140,7 +140,7 @@
     {
       "name": "desc_sort_timestamp",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": {
         "query": {
           "match_all": {}
@@ -153,7 +153,7 @@
     {
       "name": "desc_sort_with_after_timestamp",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": {
         "track_total_hits": false,
         "query": {
@@ -168,7 +168,7 @@
     {
       "name": "asc_sort_timestamp",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": {
         "query": {
           "match_all": {}
@@ -181,7 +181,7 @@
     {
       "name": "asc_sort_with_after_timestamp",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": {
         "track_total_hits": false,
         "query": {
@@ -196,7 +196,7 @@
     {
       "name": "desc_sort_timestamp_can_match_shortcut",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": {
         "track_total_hits": false,
         "query": {
@@ -212,7 +212,7 @@
     {
       "name": "desc_sort_timestamp_no_can_match_shortcut",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "request-params" : {
           "pre_filter_shard_size" : 100000
       },
@@ -231,7 +231,7 @@
     {
       "name": "asc_sort_timestamp_can_match_shortcut",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": {
         "track_total_hits": false,
         "query": {
@@ -247,7 +247,7 @@
     {
       "name": "asc_sort_timestamp_no_can_match_shortcut",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "request-params" : {
           "pre_filter_shard_size" : 100000
       },
@@ -266,7 +266,7 @@
     {
       "name": "sort_keyword_can_match_shortcut",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": {
         "track_total_hits": false,
         "query": {
@@ -282,7 +282,7 @@
     {
       "name": "sort_keyword_no_can_match_shortcut",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "request-params" : {
           "pre_filter_shard_size" : 100000
       },
@@ -301,7 +301,7 @@
     {
       "name": "sort_numeric_desc",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": {
         "track_total_hits": false,
         "query": {
@@ -317,7 +317,7 @@
     {
       "name": "sort_numeric_asc",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": {
         "track_total_hits": false,
         "query": {
@@ -333,7 +333,7 @@
     {
       "name": "sort_numeric_desc_with_match",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": {
         "track_total_hits": false,
         "query": {
@@ -351,7 +351,7 @@
     {
       "name": "sort_numeric_asc_with_match",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": {
         "track_total_hits": false,
         "query": {
@@ -370,7 +370,7 @@
       "name": "terms-significant-1",
       "operation-type": "search",
       "request-timeout": 7200,
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": 
         {
           "track_total_hits": false,
@@ -404,7 +404,7 @@
       "name": "terms-significant-2",
       "operation-type": "search",
       "request-timeout": 7200,
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": {
         "track_total_hits": false,
         "size": 0,
@@ -436,7 +436,7 @@
     {
       "name": "range_field_conjunction_big_range_big_term_query",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": {
         "query": {
           "bool": {
@@ -462,7 +462,7 @@
     {
       "name": "range_field_disjunction_big_range_small_term_query",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": {
         "query": {
           "bool": {
@@ -488,7 +488,7 @@
     {
       "name": "range_field_conjunction_small_range_small_term_query",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": {
         "query": {
           "bool": {
@@ -514,7 +514,7 @@
     {
       "name": "range_field_conjunction_small_range_big_term_query",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": {
         "query": {
           "bool": {
@@ -535,7 +535,7 @@
     {
       "name": "range-auto-date-histo",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": {
         "size": 0,
         "aggs": {
@@ -582,7 +582,7 @@
     {
       "name": "range-auto-date-histo-with-metrics",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "request-timeout": 7200,
       "body": {
         "size": 0,
@@ -639,7 +639,7 @@
     {
       "name": "multi_terms-keyword",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "request-timeout": 7200,
       "body":{
         "size": 0,
@@ -670,7 +670,7 @@
     {
       "name": "composite-terms",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": {
         "size": 0,
         "query": {
@@ -696,7 +696,7 @@
     {
       "name": "composite_terms-keyword",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": {
         "size": 0,
         "query": {
@@ -723,7 +723,7 @@
     {
       "name": "composite-date_histogram-daily",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": {
         "size": 0,
         "query": {
@@ -748,7 +748,7 @@
     {
       "name": "keyword-terms",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": {
         "size": 0,
         "aggs": {
@@ -764,7 +764,7 @@
     {
       "name": "keyword-terms-low-cardinality",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": {
         "size": 0,
         "aggs": {
@@ -780,7 +780,7 @@
     {
       "name": "query-string-on-message",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": {
         "query": {
           "query_string": {
@@ -792,7 +792,7 @@
     {
       "name": "query-string-on-message-filtered",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": {
         "query": {
           "bool": {
@@ -818,7 +818,7 @@
     {
       "name": "query-string-on-message-filtered-sorted-num",
       "operation-type": "search",
-      "index": "logs-benchmark-*",
+      "index": "{{index_name | default('big5')}}",
       "body": {
         "query": {
           "bool": {

--- a/big5/test_procedures/common/big5-schedule.json
+++ b/big5/test_procedures/common/big5-schedule.json
@@ -11,7 +11,7 @@
   "name": "check-cluster-health",
   "operation": {
     "operation-type": "cluster-health",
-    "index": "big5",
+    "index": "{{index_name | default('big5')}}",
     "request-params": {
       "wait_for_status": "{{cluster_health | default('green')}}",
       "wait_for_no_relocating_shards": "true"
@@ -32,8 +32,9 @@
 {
   "operation": {
     "operation-type": "force-merge",
-    "max-num-segments": {{ max_num_segments | default(-1) }},
-    "request-timeout": 7200
+    "request-timeout": 7200{%- if force_merge_max_num_segments is defined %},
+    "max-num-segments": {{ max_num_segments | tojson }}
+    {%- endif %}
   }
 },
 {
@@ -57,222 +58,259 @@
   "operation": "default",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "desc_sort_timestamp",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "asc_sort_timestamp",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "desc_sort_with_after_timestamp",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "asc_sort_with_after_timestamp",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "desc_sort_timestamp_can_match_shortcut",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "desc_sort_timestamp_no_can_match_shortcut",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "asc_sort_timestamp_can_match_shortcut",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "asc_sort_timestamp_no_can_match_shortcut",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "name": "term",
   "operation": "term",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "multi_terms-keyword",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "keyword-terms",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "keyword-terms-low-cardinality",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "composite-terms",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "composite_terms-keyword",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "composite-date_histogram-daily",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "range",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "range-numeric",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "keyword-in-range",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "date_histogram_hourly_agg",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "date_histogram_minute_agg",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "scroll",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "query-string-on-message",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "query-string-on-message-filtered",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "query-string-on-message-filtered-sorted-num",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "sort_keyword_can_match_shortcut",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "sort_keyword_no_can_match_shortcut",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "sort_numeric_desc",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "sort_numeric_asc",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "sort_numeric_desc_with_match",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "sort_numeric_asc_with_match",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "range_field_conjunction_big_range_big_term_query",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "range_field_disjunction_big_range_small_term_query",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "range_field_conjunction_small_range_small_term_query",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "range_field_conjunction_small_range_big_term_query",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "range-auto-date-histo",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "range-auto-date-histo-with-metrics",
   "warmup-iterations": 200,
   "iterations": 100,
-  "target-throughput": 2
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 }

--- a/big5/workload.json
+++ b/big5/workload.json
@@ -12,14 +12,14 @@
   "corpora": [
     {
       "name": "big5",
-      "base-url": "https://opensearch-benchmark-workloads.s3.amazonaws.com/corpora/big5",
+      "base-url": "https://dbyiw3u3rf9yr.cloudfront.net/corpora/big5",
       "documents": [
         {
           "source-url": "{{ document_url | safe }}",
-          "source-file": "{{ document_file | default('documents.json') }}",
-          "document-count": {{ document_count | default(2000) }},
-          "uncompressed-bytes": {{ document_uncompressed_size_in_bytes | default(2000) }},
-          "compressed-bytes": {{ document_compressed_size_in_bytes | default(1) }}
+          "source-file": "{{ document_file | default('documents.json.bz2') }}",
+          "document-count": {{ document_count | default(69223950) }},
+          "compressed-bytes": {{ document_compressed_size_in_bytes | default(3494648233) }},
+          "uncompressed-bytes": {{ document_uncompressed_size_in_bytes | default(64048001338) }}
         }
       ]
     }


### PR DESCRIPTION
### Description
Added specifications for the data corpus associated with the _big5_ workload.  Updated the README and added several workload parameters.

###.Testing
Carried out sample runs against an OpenSearch cluster.

Ran integration tests:
```
  py38: commands succeeded
  py39: commands succeeded
  py310: commands succeeded
  py311: commands succeeded
```

### Issues Resolved
#136

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
