### PR TITLE
Add query optimization to prod-queries

### DIFF
--- a/vectorsearch/params/faiss-sift-128-l2.json
+++ b/vectorsearch/params/faiss-sift-128-l2.json
@@ -15,7 +15,12 @@
     "target_index_force_merge_timeout": 45.0,
     "hnsw_ef_search": 100,
     "hnsw_ef_construction": 100,
+
     "query_k": 100,
+    "query_body": {
+         "docvalue_fields" : ["_id"],
+         "stored_fields" : "_none_"
+    },
 
     "query_data_set_format": "hdf5",
     "query_data_set_path":"/tmp/sift-128-euclidean.hdf5",

--- a/vectorsearch/params/lucene-sift-128-l2.json
+++ b/vectorsearch/params/lucene-sift-128-l2.json
@@ -15,7 +15,12 @@
     "target_index_force_merge_timeout": 45.0,
     "hnsw_ef_search": 100,
     "hnsw_ef_construction": 100,
+
     "query_k": 100,
+    "query_body": {
+         "docvalue_fields" : ["_id"],
+         "stored_fields" : "_none_"
+    },
 
     "query_data_set_format": "hdf5",
     "query_data_set_path":"/tmp/sift-128-euclidean.hdf5",

--- a/vectorsearch/params/nmslib-sift-128-l2.json
+++ b/vectorsearch/params/nmslib-sift-128-l2.json
@@ -15,7 +15,12 @@
     "target_index_force_merge_timeout": 45.0,
     "hnsw_ef_search": 100,
     "hnsw_ef_construction": 100,
+
     "query_k": 100,
+    "query_body": {
+         "docvalue_fields" : ["_id"],
+         "stored_fields" : "_none_"
+    },
 
     "query_data_set_format": "hdf5",
     "query_data_set_path":"/tmp/sift-128-euclidean-test.hdf5",

--- a/vectorsearch/test_procedures/default.json
+++ b/vectorsearch/test_procedures/default.json
@@ -33,12 +33,16 @@
             "clients": {{ target_index_bulk_indexing_clients | default(1)}}
         },
         {
-            "name" : "refresh-target-index",
+            "name" : "refresh-target-index-before-force-merge",
             "operation" : "refresh-target-index"
         },
         {
             "name" : "force-merge-segments",
             "operation" : "force-merge"
+        },
+        {
+            "name" : "refresh-target-index-after-force-merge",
+            "operation" : "refresh-target-index"
         },
         {
             "name" : "warmup-indices",

--- a/vectorsearch/test_procedures/default.json
+++ b/vectorsearch/test_procedures/default.json
@@ -57,7 +57,8 @@
                 "neighbors_data_set_path" : "{{ neighbors_data_set_path | default('/tmp/vector-dataset.hdf5') }}",
                 "neighbors_data_set_format" : "{{ neighbors_data_set_format | default('hdf5') }}",
                 "num_vectors" : {{ query_count | default(-1) }},
-                "id-field-name": "{{ id_field_name }}"
+                "id-field-name": "{{ id_field_name }}",
+                "body": {{ query_body | default ({}) | tojson }}    
             },
             "clients": {{ search_clients | default(1)}}
         }


### PR DESCRIPTION
### Description
Use docvalue_fields to fetch id-field-name from docvalue store instead of source. This proves to perform better than current set up.

Added refresh after force merge

### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
