### PR TITLE
Update default param values

### DIFF
--- a/vectorsearch/params/corpus/10million/faiss-cohere-768-dp.json
+++ b/vectorsearch/params/corpus/10million/faiss-cohere-768-dp.json
@@ -12,7 +12,6 @@
     "target_index_bulk_indexing_clients": 10,
     
     "target_index_max_num_segments": 10,
-    "target_index_force_merge_timeout": 100,
     "hnsw_ef_search": 100,
     "hnsw_ef_construction": 100,
 

--- a/vectorsearch/params/corpus/10million/lucene-cohere-768-dp.json
+++ b/vectorsearch/params/corpus/10million/lucene-cohere-768-dp.json
@@ -12,7 +12,6 @@
     "target_index_bulk_indexing_clients": 10,
     
     "target_index_max_num_segments": 10,
-    "target_index_force_merge_timeout": 100,
     "hnsw_ef_search": 100,
     "hnsw_ef_construction": 100,
 

--- a/vectorsearch/params/corpus/10million/nmslib-cohere-768-dp.json
+++ b/vectorsearch/params/corpus/10million/nmslib-cohere-768-dp.json
@@ -12,7 +12,6 @@
     "target_index_bulk_indexing_clients": 10,
     
     "target_index_max_num_segments": 10,
-    "target_index_force_merge_timeout": 100,
     "hnsw_ef_search": 100,
     "hnsw_ef_construction": 100,
 
@@ -23,7 +22,7 @@
     },
 
     "query_data_set_format": "hdf5",
-    "query_data_set_corpus": "cohere-1m",
+    "query_data_set_corpus": "cohere-10m",
     "neighbors_data_set_corpus": "cohere-10m",
     "neighbors_data_set_format": "hdf5",
     "query_count": 10000

--- a/vectorsearch/params/corpus/1million/faiss-cohere-768-dp.json
+++ b/vectorsearch/params/corpus/1million/faiss-cohere-768-dp.json
@@ -12,7 +12,6 @@
     "target_index_bulk_indexing_clients": 10,
     
     "target_index_max_num_segments": 10,
-    "target_index_force_merge_timeout": 100,
     "hnsw_ef_search": 100,
     "hnsw_ef_construction": 100,
 

--- a/vectorsearch/params/corpus/1million/lucene-cohere-768-dp.json
+++ b/vectorsearch/params/corpus/1million/lucene-cohere-768-dp.json
@@ -12,7 +12,6 @@
     "target_index_bulk_indexing_clients": 10,
     
     "target_index_max_num_segments": 10,
-    "target_index_force_merge_timeout": 100,
     "hnsw_ef_search": 100,
     "hnsw_ef_construction": 100,
 

--- a/vectorsearch/params/corpus/1million/nmslib-cohere-768-dp.json
+++ b/vectorsearch/params/corpus/1million/nmslib-cohere-768-dp.json
@@ -12,7 +12,6 @@
     "target_index_bulk_indexing_clients": 10,
     
     "target_index_max_num_segments": 10,
-    "target_index_force_merge_timeout": 100,
     "hnsw_ef_search": 100,
     "hnsw_ef_construction": 100,
 

--- a/vectorsearch/params/faiss-sift-128-l2.json
+++ b/vectorsearch/params/faiss-sift-128-l2.json
@@ -11,8 +11,8 @@
     "target_index_bulk_index_data_set_path": "/tmp/sift-128-euclidean.hdf5",
     "target_index_bulk_indexing_clients": 10,
     
-    "target_index_max_num_segments": 10,
-    "target_index_force_merge_timeout": 45.0,
+    "target_index_max_num_segments": 1,
+    "target_index_force_merge_timeout": 300,
     "hnsw_ef_search": 100,
     "hnsw_ef_construction": 100,
 

--- a/vectorsearch/params/lucene-sift-128-l2.json
+++ b/vectorsearch/params/lucene-sift-128-l2.json
@@ -11,8 +11,8 @@
     "target_index_bulk_index_data_set_path": "/tmp/sift-128-euclidean.hdf5",
     "target_index_bulk_indexing_clients": 10,
     
-    "target_index_max_num_segments": 10,
-    "target_index_force_merge_timeout": 45.0,
+    "target_index_max_num_segments": 1,
+    "target_index_force_merge_timeout": 300,
     "hnsw_ef_search": 100,
     "hnsw_ef_construction": 100,
 

--- a/vectorsearch/params/nmslib-sift-128-l2.json
+++ b/vectorsearch/params/nmslib-sift-128-l2.json
@@ -11,8 +11,8 @@
     "target_index_bulk_index_data_set_path": "/tmp/sift-128-euclidean-train.hdf5",
     "target_index_bulk_indexing_clients": 10,
     
-    "target_index_max_num_segments": 10,
-    "target_index_force_merge_timeout": 45.0,
+    "target_index_max_num_segments": 1,
+    "target_index_force_merge_timeout": 300,
     "hnsw_ef_search": 100,
     "hnsw_ef_construction": 100,
 


### PR DESCRIPTION
### Description
Update default param values to increase merge time out for large dataset and reduce segment count for smaller datasets.
By removing merge timeout, default value will be used.

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
