### PR TITLE
Add procedures to split indexing, search and merge

### DIFF
--- a/vectorsearch/README.md
+++ b/vectorsearch/README.md
@@ -13,7 +13,7 @@ OpenSearch.
 Before running a benchmark, ensure that the load generation host is able to access your cluster endpoint and that the 
 appropriate dataset is available on the host.
 
-Currently, we support only one test procedure for the vector search workload. This is named no-train-test and does not include the steps required to train the model being used.
+Currently, we support 4 test procedures for the vector search workload. The default procedure is named no-train-test and does not include the steps required to train the model being used.
 This test procedures will index a data set of vectors into an OpenSearch cluster and then run a set of queries against the generated index. 
 
 Due to the number of parameters this workload offers, it's recommended to create a parameter file that specifies the desired workload 
@@ -45,6 +45,22 @@ The No Train Test procedure is used to test vector search indices which requires
 You can define the underlying configuration of the vector search algorithm like specific engine, space type, etc... as
 method definition . Check [vector search method definitions]([https://opensearch.org/docs/latest/search-plugins/knn/knn-index/#method-definitions)
 for more details.
+
+### No Train Test Index Only
+This procedure is used to index only vector search index which requires no training. This will be useful if
+you are interested in benchmarking only indexing operation.
+
+## Force Merge Index
+This procedure is used to optimize vector search indices by performing force merge on an index, up to given maximum segments.
+For a large dataset, force merge is a costly operation. Hence, it is better to have separate procedure to trigger
+force merge occasionally based on user's requirement.
+
+## Search
+This procedure is used to benchmark previously indexed vector search index. This will be useful if you want
+to benchmark large vector search index without indexing everytime since load time is substantial for a large dataset.
+This also contains warmup operation to avoid cold start problem during vector search.
+
+
 
 #### Parameters
 

--- a/vectorsearch/test_procedures/common/force-merge-schedule.json
+++ b/vectorsearch/test_procedures/common/force-merge-schedule.json
@@ -1,0 +1,12 @@
+{
+    "name" : "refresh-target-index-before-force-merge",
+    "operation" : "refresh-target-index"
+},
+{
+    "name" : "force-merge-segments",
+    "operation" : "force-merge"
+},
+{
+    "name" : "refresh-target-index-after-force-merge",
+    "operation" : "refresh-target-index"
+}

--- a/vectorsearch/test_procedures/common/index-only-schedule.json
+++ b/vectorsearch/test_procedures/common/index-only-schedule.json
@@ -1,0 +1,34 @@
+{
+    "operation": {
+        "name": "delete-target-index",
+        "operation-type": "delete-index",
+        "only-if-exists": true,
+        "index": "{{ target_index_name | default('target_index') }}"
+    }
+},
+{
+    "operation": {
+        "name": "create-target-index",
+        "operation-type": "create-index",
+        "index": "{{ target_index_name | default('target_index') }}"
+    }
+},
+{
+    "operation": {
+        "name": "custom-vector-bulk",
+        "operation-type": "bulk-vector-data-set",
+        "index": "{{ target_index_name | default('target_index') }}",
+        "field": "{{ target_field_name | default('target_field') }}",
+        "bulk_size": {{ target_index_bulk_size | default(500)}},
+        "data_set_format": "{{ target_index_bulk_index_data_set_format | default('hdf5') }}",
+        "data_set_path": "{{ target_index_bulk_index_data_set_path  }}",
+        "data_set_corpus": "{{ target_index_bulk_index_data_set_corpus  }}",
+        "num_vectors": {{ target_index_num_vectors | default(-1) }},
+        "id-field-name": "{{ id_field_name }}"
+    },
+    "clients": {{ target_index_bulk_indexing_clients | default(1)}}
+},
+{
+    "name" : "refresh-target-index",
+    "operation" : "refresh-target-index"
+}

--- a/vectorsearch/test_procedures/common/search-only-schedule.json
+++ b/vectorsearch/test_procedures/common/search-only-schedule.json
@@ -1,0 +1,25 @@
+{
+    "name" : "warmup-indices",
+    "operation" : "warmup-indices",
+    "index": "{{ target_index_name | default('target_index') }}"
+},
+{
+    "operation": {
+        "name": "prod-queries",
+        "operation-type": "vector-search",
+        "index": "{{ target_index_name | default('target_index') }}",
+        "detailed-results": true,
+        "k": {{ query_k  | default(100) }},
+        "field" : "{{ target_field_name | default('target_field') }}",
+        "data_set_format" : "{{ query_data_set_format | default('hdf5') }}",
+        "data_set_path" : "{{ query_data_set_path }}",
+        "data_set_corpus" : "{{ query_data_set_corpus }}",
+        "neighbors_data_set_path" : "{{ neighbors_data_set_path }}",
+        "neighbors_data_set_corpus" : "{{ neighbors_data_set_corpus }}",
+        "neighbors_data_set_format" : "{{ neighbors_data_set_format | default('hdf5') }}",
+        "num_vectors" : {{ query_count | default(-1) }},
+        "id-field-name": "{{ id_field_name }}",
+        "body": {{ query_body | default ({}) | tojson }}    
+    },
+    "clients": {{ search_clients | default(1)}}
+}

--- a/vectorsearch/test_procedures/default.json
+++ b/vectorsearch/test_procedures/default.json
@@ -3,161 +3,32 @@
     "description": "Index vector search which does not use an algorithm that requires training.",
     "default": true,
     "schedule": [
-        {
-            "operation": {
-                "name": "delete-target-index",
-                "operation-type": "delete-index",
-                "only-if-exists": true,
-                "index": "{{ target_index_name | default('target_index') }}"
-            }
-        },
-        {
-            "operation": {
-                "name": "create-target-index",
-                "operation-type": "create-index",
-                "index": "{{ target_index_name | default('target_index') }}"
-            }
-        },
-        {
-            "operation": {
-                "name": "custom-vector-bulk",
-                "operation-type": "bulk-vector-data-set",
-                "index": "{{ target_index_name | default('target_index') }}",
-                "field": "{{ target_field_name | default('target_field') }}",
-                "bulk_size": {{ target_index_bulk_size | default(500)}},
-                "data_set_format": "{{ target_index_bulk_index_data_set_format | default('hdf5') }}",
-                "data_set_path": "{{ target_index_bulk_index_data_set_path  }}",
-                "data_set_corpus": "{{ target_index_bulk_index_data_set_corpus  }}",
-                "num_vectors": {{ target_index_num_vectors | default(-1) }},
-                "id-field-name": "{{ id_field_name }}"
-            },
-            "clients": {{ target_index_bulk_indexing_clients | default(1)}}
-        },
-        {
-            "name" : "refresh-target-index-before-force-merge",
-            "operation" : "refresh-target-index"
-        },
-        {
-            "name" : "force-merge-segments",
-            "operation" : "force-merge"
-        },
-        {
-            "name" : "refresh-target-index-after-force-merge",
-            "operation" : "refresh-target-index"
-        },
-        {
-            "name" : "warmup-indices",
-            "operation" : "warmup-indices",
-            "index": "{{ target_index_name | default('target_index') }}"
-        },
-        {
-            "operation": {
-                "name": "prod-queries",
-                "operation-type": "vector-search",
-                "index": "{{ target_index_name | default('target_index') }}",
-                "detailed-results": true,
-                "k": {{ query_k  | default(100) }},
-                "field" : "{{ target_field_name | default('target_field') }}",
-                "data_set_format" : "{{ query_data_set_format | default('hdf5') }}",
-                "data_set_path" : "{{ query_data_set_path }}",
-                "data_set_corpus" : "{{ query_data_set_corpus }}",
-                "neighbors_data_set_path" : "{{ neighbors_data_set_path }}",
-                "neighbors_data_set_corpus" : "{{ neighbors_data_set_corpus }}",
-                "neighbors_data_set_format" : "{{ neighbors_data_set_format | default('hdf5') }}",
-                "num_vectors" : {{ query_count | default(-1) }},
-                "id-field-name": "{{ id_field_name }}",
-                "body": {{ query_body | default ({}) | tojson }}    
-            },
-            "clients": {{ search_clients | default(1)}}
-        }
+       {{ benchmark.collect(parts="common/index-only-schedule.json") }},
+       {{ benchmark.collect(parts="common/force-merge-schedule.json") }},
+       {{ benchmark.collect(parts="common/search-only-schedule.json") }}
     ]
 },
 {
-    "name": "no-train-test-only-index",
+    "name": "no-train-test-index-only",
     "description": "Perform only indexing operation for vector search",
+    "default": false,
     "schedule": [
-       {
-            "operation": {
-                "name": "delete-target-index",
-                "operation-type": "delete-index",
-                "only-if-exists": true,
-                "index": "{{ target_index_name | default('target_index') }}"
-            }
-        },
-        {
-            "operation": {
-                "name": "create-target-index",
-                "operation-type": "create-index",
-                "index": "{{ target_index_name | default('target_index') }}"
-            }
-        },
-        {
-            "operation": {
-                "name": "custom-vector-bulk",
-                "operation-type": "bulk-vector-data-set",
-                "index": "{{ target_index_name | default('target_index') }}",
-                "field": "{{ target_field_name | default('target_field') }}",
-                "bulk_size": {{ target_index_bulk_size | default(500)}},
-                "data_set_format": "{{ target_index_bulk_index_data_set_format | default('hdf5') }}",
-                "data_set_path": "{{ target_index_bulk_index_data_set_path  }}",
-                "data_set_corpus": "{{ target_index_bulk_index_data_set_corpus  }}",
-                "num_vectors": {{ target_index_num_vectors | default(-1) }},
-                "id-field-name": "{{ id_field_name }}"
-            },
-            "clients": {{ target_index_bulk_indexing_clients | default(1)}}
-        },
-        {
-            "name" : "refresh-target-index-before-force-merge",
-            "operation" : "refresh-target-index"
-        }
+       {{ benchmark.collect(parts="common/index-only-schedule.json") }}
+    ]
+},
+{
+    "name": "search-only",
+    "default": false,
+    "description": "Perform only vector search on previously indexed cluster.",
+    "schedule": [
+       {{ benchmark.collect(parts="common/search-only-schedule.json") }}
     ]
 },
 {
     "name": "force-merge-index",
-    "description": "Force merge vector search index",
+    "default": false,
+    "description": "Force merge vector search index to improve search performance",
     "schedule": [
-        {
-            "name" : "refresh-target-index-before-force-merge",
-            "operation" : "refresh-target-index"
-        },
-        {
-            "name" : "force-merge-segments",
-            "operation" : "force-merge"
-        },
-        {
-            "name" : "refresh-target-index-after-force-merge",
-            "operation" : "refresh-target-index"
-        }
-    ]
-},
-{
-    "name": "no-train-test-only-search",
-    "description": "Perform only vector search on previosuly indexed cluster.",
-    "schedule": [
-        {
-            "name" : "warmup-indices",
-            "operation" : "warmup-indices",
-            "index": "{{ target_index_name | default('target_index') }}"
-        },
-        {
-            "operation": {
-                "name": "prod-queries",
-                "operation-type": "vector-search",
-                "detailed-results": true,
-                "index": "{{ target_index_name | default('target_index') }}",
-                "k": {{ query_k  | default(100) }},
-                "field" : "{{ target_field_name | default('target_field') }}",
-                "data_set_format" : "{{ query_data_set_format | default('hdf5') }}",
-                "data_set_path" : "{{ query_data_set_path }}",
-                "data_set_corpus" : "{{ query_data_set_corpus }}",
-                "neighbors_data_set_path" : "{{ neighbors_data_set_path }}",
-                "neighbors_data_set_corpus" : "{{ neighbors_data_set_corpus }}",
-                "neighbors_data_set_format" : "{{ neighbors_data_set_format | default('hdf5') }}",
-                "num_vectors" : {{ query_count | default(-1) }},
-                "id-field-name": "{{ id_field_name }}",
-                "body": {{ query_body | default ({}) | tojson }}    
-            },
-            "clients": {{ search_clients | default(1)}}
-        }
+       {{ benchmark.collect(parts="common/force-merge-schedule.json") }}
     ]
 }

--- a/vectorsearch/test_procedures/default.json
+++ b/vectorsearch/test_procedures/default.json
@@ -55,6 +55,96 @@
                 "name": "prod-queries",
                 "operation-type": "vector-search",
                 "index": "{{ target_index_name | default('target_index') }}",
+                "detailed-results": true,
+                "k": {{ query_k  | default(100) }},
+                "field" : "{{ target_field_name | default('target_field') }}",
+                "data_set_format" : "{{ query_data_set_format | default('hdf5') }}",
+                "data_set_path" : "{{ query_data_set_path }}",
+                "data_set_corpus" : "{{ query_data_set_corpus }}",
+                "neighbors_data_set_path" : "{{ neighbors_data_set_path }}",
+                "neighbors_data_set_corpus" : "{{ neighbors_data_set_corpus }}",
+                "neighbors_data_set_format" : "{{ neighbors_data_set_format | default('hdf5') }}",
+                "num_vectors" : {{ query_count | default(-1) }},
+                "id-field-name": "{{ id_field_name }}",
+                "body": {{ query_body | default ({}) | tojson }}    
+            },
+            "clients": {{ search_clients | default(1)}}
+        }
+    ]
+},
+{
+    "name": "no-train-test-only-index",
+    "description": "Perform only indexing operation for vector search",
+    "schedule": [
+       {
+            "operation": {
+                "name": "delete-target-index",
+                "operation-type": "delete-index",
+                "only-if-exists": true,
+                "index": "{{ target_index_name | default('target_index') }}"
+            }
+        },
+        {
+            "operation": {
+                "name": "create-target-index",
+                "operation-type": "create-index",
+                "index": "{{ target_index_name | default('target_index') }}"
+            }
+        },
+        {
+            "operation": {
+                "name": "custom-vector-bulk",
+                "operation-type": "bulk-vector-data-set",
+                "index": "{{ target_index_name | default('target_index') }}",
+                "field": "{{ target_field_name | default('target_field') }}",
+                "bulk_size": {{ target_index_bulk_size | default(500)}},
+                "data_set_format": "{{ target_index_bulk_index_data_set_format | default('hdf5') }}",
+                "data_set_path": "{{ target_index_bulk_index_data_set_path  }}",
+                "data_set_corpus": "{{ target_index_bulk_index_data_set_corpus  }}",
+                "num_vectors": {{ target_index_num_vectors | default(-1) }},
+                "id-field-name": "{{ id_field_name }}"
+            },
+            "clients": {{ target_index_bulk_indexing_clients | default(1)}}
+        },
+        {
+            "name" : "refresh-target-index-before-force-merge",
+            "operation" : "refresh-target-index"
+        }
+    ]
+},
+{
+    "name": "force-merge-index",
+    "description": "Force merge vector search index",
+    "schedule": [
+        {
+            "name" : "refresh-target-index-before-force-merge",
+            "operation" : "refresh-target-index"
+        },
+        {
+            "name" : "force-merge-segments",
+            "operation" : "force-merge"
+        },
+        {
+            "name" : "refresh-target-index-after-force-merge",
+            "operation" : "refresh-target-index"
+        }
+    ]
+},
+{
+    "name": "no-train-test-only-search",
+    "description": "Perform only vector search on previosuly indexed cluster.",
+    "schedule": [
+        {
+            "name" : "warmup-indices",
+            "operation" : "warmup-indices",
+            "index": "{{ target_index_name | default('target_index') }}"
+        },
+        {
+            "operation": {
+                "name": "prod-queries",
+                "operation-type": "vector-search",
+                "detailed-results": true,
+                "index": "{{ target_index_name | default('target_index') }}",
                 "k": {{ query_k  | default(100) }},
                 "field" : "{{ target_field_name | default('target_field') }}",
                 "data_set_format" : "{{ query_data_set_format | default('hdf5') }}",


### PR DESCRIPTION
### Description
For large dataset, users might prefer to do indexing, search, force merge as different test execution. To support this use case, added three additional procedure,
1)index only, 2)force-merge 3)search-only. This can be used in nightly to run search workload every day without indexing everytime.

Integration test is executed here: https://github.com/VijayanB/opensearch-benchmark/actions/runs/8256914251

### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
