### PR TITLE
Fix merge policy to restrict to OS 2.11+ in Big5 workload

### DIFF
--- a/big5/index.json
+++ b/big5/index.json
@@ -10,7 +10,7 @@
     "index.number_of_replicas": {{number_of_replicas | default(1)}},
     "index.queries.cache.enabled": {{query_cache_enabled | default(false) | tojson}},
     "index.requests.cache.enable": {{requests_cache_enabled | default(false) | tojson}},
-    {% if distribution_version is not defined or distribution_version < 6.0 %}
+    {% if ( (distribution_version is not defined) or (distribution_version > 2.11 and distribution_version < 6.0) ) %}
       "index.merge.policy": "{{index_merge_policy | default('log_byte_size') }}",
     {% endif %}
     "index.codec": "best_compression",


### PR DESCRIPTION
### Description
Merge policy can only be set in OpenSearch versions 2.11+. Changing the if statement in the index.json for Big5 workload so that the merge policy cannot be set in versions less than 2.11.

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
