### PR TITLE
Move ef_search param from index to mapping

### DIFF
--- a/vectorsearch/indices/faiss-index.json
+++ b/vectorsearch/indices/faiss-index.json
@@ -8,9 +8,6 @@
         {%- if target_index_replica_shards is defined and target_index_replica_shards %}
         ,"number_of_replicas": {{ target_index_replica_shards }}
         {%- endif %}
-        {%- if hnsw_ef_search is defined and hnsw_ef_search %}
-        ,"knn.algo_param.ef_search": {{ hnsw_ef_search }}
-        {%- endif %}
       }
     },
     "mappings": {
@@ -24,15 +21,21 @@
             "space_type": "{{ target_index_space_type }}",
             "engine": "faiss",
             "parameters": {
-            {%- if hnsw_ef_construction is defined and hnsw_ef_construction %}
-            "ef_construction": {{ hnsw_ef_construction }}
-            {%- endif %}
-            {%- if hnsw_m is defined and hnsw_m %}
-            {%- if hnsw_ef_construction is defined and hnsw_ef_construction %}
-            ,
-            {%- endif %}
-            "m": {{ hnsw_m }}
-            {%- endif %}
+              {%- if hnsw_ef_search is defined and hnsw_ef_search %}
+                "ef_search": {{ hnsw_ef_search }}
+              {%- endif %}
+              {%- if hnsw_ef_construction is defined and hnsw_ef_construction %}
+              {%- if hnsw_ef_search is defined and hnsw_ef_search %}
+                ,
+              {%- endif %}
+                "ef_construction": {{ hnsw_ef_construction }}
+              {%- endif %}
+              {%- if hnsw_m is defined and hnsw_m %}
+              {%- if hnsw_ef_construction is defined and hnsw_ef_construction %}
+                ,
+              {%- endif %}
+                "m": {{ hnsw_m }}
+              {%- endif %}
             }
           }
         }

--- a/vectorsearch/test_procedures/default.json
+++ b/vectorsearch/test_procedures/default.json
@@ -22,7 +22,7 @@
     "default": false,
     "schedule": [
        {{ benchmark.collect(parts="common/index-only-schedule.json") }},
-       {{ benchmark.collect(parts="common/force-merge-schedule.json") }},
+       {{ benchmark.collect(parts="common/force-merge-schedule.json") }}
     ]
 },
 {


### PR DESCRIPTION
### Description
faiss accepts ef_search as mapping param instead of indexing param.

### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
