### PR TITLE
Reconcile version-specific features in big5 workload

### DIFF
--- a/big5/README.md
+++ b/big5/README.md
@@ -50,7 +50,7 @@ This workload allows the following parameters to be specified using `--workload-
 * `document_file`: If specifying an alternate data corpus, the file name of the corpus.
 * `document_uncompressed_size_in_bytes`: If specifying an alternate data corpus, the uncompressed size of the corpus.
 * `document_url`:  If specifying an alternate data corpus, the full path to the corpus file (optional).
-* `distribution_version` (default 2.11):  Used to specify the target cluster's version so as to select the appropriate mappings for that version.  This is distinct from the command line option.
+* `distribution_version` (default 2.11.0):  Used to specify the target cluster's version so as to select the appropriate mappings for that version.  This is distinct from the command line option and should be in the 3-part dotted semantic version format.
 * `error_level` (default: "non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
 * `index_body` (default: "index.json"): The name of the file containing the index settings and mappings.
 * `index_name` (default: "big5"): The name of the index the workload should create and use for its operations.

--- a/big5/index.json
+++ b/big5/index.json
@@ -1,4 +1,9 @@
-{% if distribution_version is defined and distribution_version > 2.11 and distribution_version < 6.0 %}
+
+{% if distribution_version is not defined %}
+  {% set distribution_version = "2.11.0" %}
+{% endif %}
+
+{% if distribution_version.split('.') | map('int') | list  >= "2.12.0".split('.') | map('int') | list and distribution_version.split('.') | map('int') | list  < "6.0.0".split('.') | map('int') | list %}
   {% set match_only_text = "match_only_text" %}
 {% else %}
   {% set match_only_text = "text" %}
@@ -10,7 +15,7 @@
     "index.number_of_replicas": {{number_of_replicas | default(1)}},
     "index.queries.cache.enabled": {{query_cache_enabled | default(false) | tojson}},
     "index.requests.cache.enable": {{requests_cache_enabled | default(false) | tojson}},
-    {% if ( (distribution_version is not defined) or (distribution_version > 2.11 and distribution_version < 6.0) ) %}
+    {% if distribution_version.split('.') | map('int') | list  >= "2.11.0".split('.') | map('int') | list and distribution_version.split('.') | map('int') | list  < "6.0.0".split('.') | map('int') | list %}
       "index.merge.policy": "{{index_merge_policy | default('log_byte_size') }}",
     {% endif %}
     "index.codec": "best_compression",
@@ -24,7 +29,7 @@
     "_data_stream_timestamp": {
       "enabled": true
     },
-    {% if distribution_version is not defined or distribution_version < 6.0 %}
+    {% if distribution_version.split('.') | map('int') | list  < "6.0.0".split('.') | map('int') | list %}
       "dynamic_templates": [
 	{
 	  "match_ip": {

--- a/big5/test_procedures/common/big5-schedule.json
+++ b/big5/test_procedures/common/big5-schedule.json
@@ -125,7 +125,7 @@
   "target-throughput": {{ target_throughput | default(2) | tojson }},
   "clients": {{ search_clients | default(1) }}
 },
-{%- if distribution_version is not defined or distribution_version < 6.0 %}
+{% if distribution_version.split('.') | map('int') | list  >= "2.11.0".split('.') | map('int') | list and distribution_version.split('.') | map('int') | list  < "6.0.0".split('.') | map('int') | list %}
   {
     "operation": "multi_terms-keyword",
     "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
@@ -133,7 +133,7 @@
     "target-throughput": {{ target_throughput | default(2) | tojson }},
     "clients": {{ search_clients | default(1) }}
   },
-{%- endif %}
+{% endif %}
 {
   "operation": "keyword-terms",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},

--- a/big5/workload.json
+++ b/big5/workload.json
@@ -1,3 +1,8 @@
+
+{% if distribution_version is not defined %}
+  {% set distribution_version = "2.11.0" %}
+{% endif %}
+
 {
   "version": 2,
   "description": "Big5 workload based on synthetically generated data corpus",


### PR DESCRIPTION
### Description
Fix version number comparisons in the _big5_ workload.

### Testing
Ran the workload against a few cluster versions and carried out integration tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
