### PR TITLE
Allow publishing results for operations

### DIFF
--- a/vectorsearch/operations/default.json
+++ b/vectorsearch/operations/default.json
@@ -2,7 +2,7 @@
     "name": "warmup-indices",
     "operation-type": "warmup-knn-indices",
     "index": "{{ target_index_name | default('target_index') }}",
-    "include-in-results_publishing": false
+    "include-in-results_publishing": true
 },
 {
     "name": "force-merge",
@@ -11,7 +11,7 @@
     "index": "{{ target_index_name | default('target_index') }}",
     "mode": "polling",
     "max-num-segments": {{ target_index_max_num_segments | default(1) }},
-    "include-in-results_publishing": false
+    "include-in-results_publishing": true
 },
 {
     "name": "refresh-target-index",


### PR DESCRIPTION
### Description
Allow publishing metrics for force-merge and warm up operation.


### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
