### PR TITLE
Add Vijayan as Maintainer of OpenSearch Benchmark Workloads

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @IanHoang @gkamat @beaioun @cgchinmay @rishabh6788
+* @IanHoang @gkamat @beaioun @cgchinmay @rishabh6788 @VijayanB

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,10 +4,11 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer       | GitHub ID                                             | Affiliation |
-| ---------------- | ----------------------------------------------------- | ----------- |
-| Ian Hoang        | [IanHoang](https://github.com/IanHoang)               | Amazon      |
-| Govind Kamat     | [gkamat](https://github.com/gkamat)                   | Amazon      |
-| Mingyang Shi     | [beaioun](https://github.com/beaioun)                 | OSCI        |
-| Chinmay Gadgil   | [cgchinmay](https://github.com/cgchinmay)             | Amazon      |
-| Rishabh Singh    | [rishabh6788](https://github.com/rishabh6788)         | Amazon      |
+| Maintainer              | GitHub ID                                             | Affiliation |
+| ----------------------- | ----------------------------------------------------- | ----------- |
+| Ian Hoang               | [IanHoang](https://github.com/IanHoang)               | Amazon      |
+| Govind Kamat            | [gkamat](https://github.com/gkamat)                   | Amazon      |
+| Mingyang Shi            | [beaioun](https://github.com/beaioun)                 | OSCI        |
+| Chinmay Gadgil          | [cgchinmay](https://github.com/cgchinmay)             | Amazon      |
+| Rishabh Singh           | [rishabh6788](https://github.com/rishabh6788)         | Amazon      |
+| Vijayan Balasubramanian | [VijayanB](https://github.com/VijayanB)               | Amazon      |


### PR DESCRIPTION
### Description
Adding @VijayanB as a maintainer as voted upon by the existing maintainers of OpenSearch Benchmark project per the [maintainer guidelines](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#becoming-a-maintainer).

Vijayan has made numerous contributions to OSB code that supports running benchmarks on vector workloads.

Please find all his contributions below:
- [OpenSearch Benchmark Repository Contributions](https://github.com/opensearch-project/opensearch-benchmark/pulls?q=is%3Apr+author%3AVijayanB)
- [OpenSearch Benchmark Workloads Repository Contributions](https://github.com/opensearch-project/opensearch-benchmark-workloads/pulls?q=is%3Apr+is%3Aclosed+author%3AVijayanB)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
