### PR TITLE
Support target_throughput=none for big5

### DIFF
--- a/big5/test_procedures/common/big5-schedule.json
+++ b/big5/test_procedures/common/big5-schedule.json
@@ -58,63 +58,108 @@
   "operation": "default",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "desc_sort_timestamp",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "asc_sort_timestamp",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "desc_sort_with_after_timestamp",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "asc_sort_with_after_timestamp",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "desc_sort_timestamp_can_match_shortcut",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "desc_sort_timestamp_no_can_match_shortcut",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "asc_sort_timestamp_can_match_shortcut",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "asc_sort_timestamp_no_can_match_shortcut",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
@@ -122,7 +167,12 @@
   "operation": "term",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {% if distribution_version.split('.') | map('int') | list  >= "2.11.0".split('.') | map('int') | list and distribution_version.split('.') | map('int') | list  < "6.0.0".split('.') | map('int') | list %}
@@ -130,7 +180,12 @@
     "operation": "multi_terms-keyword",
     "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
     "iterations": {{ test_iterations | default(100) | tojson }},
-    "target-throughput": {{ target_throughput | default(2) | tojson }},
+    {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
     "clients": {{ search_clients | default(1) }}
   },
 {% endif %}
@@ -138,181 +193,311 @@
   "operation": "keyword-terms",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "keyword-terms-low-cardinality",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "composite-terms",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "composite_terms-keyword",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "composite-date_histogram-daily",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "range",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "range-numeric",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "keyword-in-range",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "date_histogram_hourly_agg",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "date_histogram_minute_agg",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "scroll",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "query-string-on-message",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "query-string-on-message-filtered",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "query-string-on-message-filtered-sorted-num",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "sort_keyword_can_match_shortcut",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "sort_keyword_no_can_match_shortcut",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "sort_numeric_desc",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "sort_numeric_asc",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "sort_numeric_desc_with_match",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "sort_numeric_asc_with_match",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "range_field_conjunction_big_range_big_term_query",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "range_field_disjunction_big_range_small_term_query",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "range_field_conjunction_small_range_small_term_query",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "range_field_conjunction_small_range_big_term_query",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "range-auto-date-histo",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 },
 {
   "operation": "range-auto-date-histo-with-metrics",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  {%- if not target_throughput %}
+  "target-throughput": 2,
+  {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
+  {%- else %}
+  "target-throughput": {{ target_throughput | tojson }},
+  {%- endif %}
   "clients": {{ search_clients | default(1) }}
 }


### PR DESCRIPTION
### Description
Add support for `target_throughput:none` to big5 workload.

Tested on cli, all following scenarios pass:
```
./Library/Python/3.9/bin/opensearch-benchmark execute-test --workload=big5 --pipeline=benchmark-only --test-procedure=test --target-hosts=opense-clust-tFncA2PxB4im-27a28ec1e07ac294.elb.us-east-1.amazonaws.com:80 --kill-running-processes --workload-params="target_throughput:none,warmup_iterations:5,test_iterations:5"
```
```
./Library/Python/3.9/bin/opensearch-benchmark execute-test --workload=big5 --pipeline=benchmark-only --test-procedure=test --target-hosts=opense-clust-tFncA2PxB4im-27a28ec1e07ac294.elb.us-east-1.amazonaws.com:80 --kill-running-processes --workload-params="target_throughput:0,warmup_iterations:5,test_iterations:5"
```
```
./Library/Python/3.9/bin/opensearch-benchmark execute-test --workload=big5 --pipeline=benchmark-only --test-procedure=test --target-hosts=opense-clust-tFncA2PxB4im-27a28ec1e07ac294.elb.us-east-1.amazonaws.com:80 --kill-running-processes --workload-params="target_throughput:4,warmup_iterations:5,test_iterations:5"
```
```
/Library/Python/3.9/bin/opensearch-benchmark execute-test --workload=big5 --pipeline=benchmark-only --test-procedure=test --target-hosts=opense-clust-tFncA2PxB4im-27a28ec1e07ac294.elb.us-east-1.amazonaws.com:80 --kill-running-processes --workload-params="warmup_iterations:5,test_iterations:5"
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
