### PR TITLE
add range agg in noaa and big5 workloads

### DIFF
--- a/big5/operations/default.json
+++ b/big5/operations/default.json
@@ -637,6 +637,77 @@
       }
     },
     {
+      "name": "range-agg-1",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "size": 0,
+        "aggs": {
+          "tmax": {
+            "range": {
+              "field": "metrics.size",
+              "ranges": [
+                {
+                  "to": -10
+                },
+                {
+                  "from": -10,
+                  "to": 10
+                },
+                {
+                  "from": 10,
+                  "to": 100
+                },
+                {
+                  "from": 100,
+                  "to": 1000
+                },
+                {
+                  "from": 1000,
+                  "to": 2000
+                },
+                {
+                  "from": 2000
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "range-agg-2",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "request-timeout": 7200,
+      "body": {
+        "size": 0,
+        "aggs": {
+          "tmax": {
+            "range": {
+              "field": "metrics.size",
+              "ranges": [
+                {
+                  "to": 100
+                },
+                {
+                  "from": 100,
+                  "to": 1000
+                },
+                {
+                  "from": 1000,
+                  "to": 2000
+                },
+                {
+                  "from": 2000
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
       "name": "multi_terms-keyword",
       "operation-type": "search",
       "index": "{{index_name | default('big5')}}",

--- a/big5/operations/default.json
+++ b/big5/operations/default.json
@@ -679,7 +679,6 @@
       "name": "range-agg-2",
       "operation-type": "search",
       "index": "{{index_name | default('big5')}}",
-      "request-timeout": 7200,
       "body": {
         "size": 0,
         "aggs": {

--- a/big5/test_procedures/common/big5-schedule.json
+++ b/big5/test_procedures/common/big5-schedule.json
@@ -315,4 +315,18 @@
   "iterations": {{ test_iterations | default(100) | tojson }},
   "target-throughput": {{ target_throughput | default(2) | tojson }},
   "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "range-agg-1",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "range-agg-2",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 }

--- a/noaa/operations/default.json
+++ b/noaa/operations/default.json
@@ -1129,6 +1129,28 @@
       }
     },
     {
+      "name": "range-aggregation",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "aggs": {
+          "tmax": {
+            "range": {
+              "field": "TMAX",
+              "ranges": [
+                {"to":   -10},
+                {"from": -10, "to":  0},
+                {"from":   0, "to": 10},
+                {"from":  10, "to": 20},
+                {"from":  20, "to": 30},
+                {"from":  30}
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
       "name": "range-numeric-significant-terms",
       "operation-type": "search",
       "body": {

--- a/noaa/test_procedures/default.json
+++ b/noaa/test_procedures/default.json
@@ -753,6 +753,13 @@
           "target-interval": 4
         },
         {
+          "operation": "range-aggregation",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "target-interval": 3
+        },
+        {
           "operation": "range-numeric-significant-terms",
           "clients": 1,
           "warmup-iterations": 10,


### PR DESCRIPTION
### Description

In [OpenSearch 13865](https://github.com/opensearch-project/OpenSearch/pull/13865), previous date histogram aggregation optimization is now applied to range aggregation. So adding operations to track the performance from now on.

### Issues Resolved
Related https://github.com/opensearch-project/OpenSearch/pull/13865

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
