### PR TITLE
Add cardinality aggregation in big5

### DIFF
--- a/big5/operations/default.json
+++ b/big5/operations/default.json
@@ -778,6 +778,36 @@
       }
     },
     {
+      "name": "cardinality-agg-low",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "size": 0,
+        "aggs": {
+          "region": {
+            "cardinality": {
+              "field": "cloud.region"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "cardinality-agg-high",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "size": 0,
+        "aggs": {
+          "agent": {
+            "cardinality": {
+              "field": "agent.name"
+            }
+          }
+        }
+      }
+    },
+    {
       "name": "query-string-on-message",
       "operation-type": "search",
       "index": "{{index_name | default('big5')}}",

--- a/big5/test_procedures/common/big5-schedule.json
+++ b/big5/test_procedures/common/big5-schedule.json
@@ -315,4 +315,18 @@
   "iterations": {{ test_iterations | default(100) | tojson }},
   "target-throughput": {{ target_throughput | default(2) | tojson }},
   "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "cardinality-agg-low",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "cardinality-agg-high",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 }


### PR DESCRIPTION
### Description

Add cardinality operations in big5 to track the performance related change in [OpenSearch 13821](https://github.com/opensearch-project/OpenSearch/pull/13821)

### Issues Resolved
Related: https://github.com/opensearch-project/OpenSearch/pull/13821

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
