### PR TITLE
Add missing quotes to _big5_ Jinja template

### DIFF
--- a/big5/README.md
+++ b/big5/README.md
@@ -65,7 +65,7 @@ This workload allows the following parameters to be specified using `--workload-
 * `requests_cache_enabled` (default: false): Whether the requests cache should be enabled.
 * `search_clients`: (default: 1): Number of clients that issue search requests.
 * `test_iterations` (default: 200): Number of test iterations per query that will have their latency and throughput measured.
-* `target_throughput` (default: 2): Target throughput for each query operation in requests per second, use "" for no limit.
+* `target_throughput` (default: 2): Target throughput for each query operation in requests per second, use 0 or "" for no throughput throttling.
 * `warmup_iterations` (default: 100): Number of warmup query iterations prior to actual measurements commencing.
 
 

--- a/big5/workload.json
+++ b/big5/workload.json
@@ -35,7 +35,7 @@
             "compressed-bytes": 53220934846,
             "uncompressed-bytes": 943679382267
           }
-        {% elif corpus_size == 1000-full %}
+        {% elif corpus_size == "1000-full" %}
           {
             "source-file": "documents-1000-full.json.bz2",
             "document-count": 1160800000,


### PR DESCRIPTION
### Description
Minor fix to _big5_ workload; missing quotes were causing subsequent corpus sizes in `workload.json` to raise errors.

### Testing
Verified that all corpus sizes available are accepted and do not raise errors.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
