### PR TITLE
Semantic search NOAA workload - move params to files, cleanup redandant operations

### DIFF
--- a/noaa_semantic_search/README.md
+++ b/noaa_semantic_search/README.md
@@ -67,13 +67,13 @@ opensearch-benchmark execute-test \
     --kill-running-processes
 ```
 
-Below is another example of command. In this example we refer to a workload by its name, use file for workflow params and choose a non-default test procedure.
+Below is another example of command. In this example we refer to a workload by its name, use file for workflow params and choose a non-default test procedure. Keep workload parameters in file is helping to keep command for workload short and decreases chance of errors. Users are welcome to use one of example parameter files from `params` folder
 
 ```
 # OpenSearch Cluster End point url with hostname and port
 export ENDPOINT=  
 # Absolute file path of Workload param file
-export PARAMS_FILE=
+export PARAMS_FILE=./noaa_semantic_search/params/one_replica_with_concurrent_segment_search.json
 
 opensearch-benchmark execute-test \
     --target-hosts $ENDPOINT \

--- a/noaa_semantic_search/operations/hybrid_search.json
+++ b/noaa_semantic_search/operations/hybrid_search.json
@@ -90,77 +90,6 @@
       }
     },
     {
-      "name": "aggs-query-term-min",
-      "operation-type": "search",
-      "body": {
-        "size": 100,
-        "aggs": {
-          "station": {
-            "terms": {
-              "field": "station.id",
-              "size": 500
-            },
-            "aggs": {
-              "tmin": {
-                "min": {
-                  "field": "TMIN"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    {
-      "name": "aggs-query-term-min-bool",
-      "operation-type": "search",
-      "body": {
-        "size": 100,
-        "query": {
-          "bool": {
-              "should": [
-                  {
-                      "term": {
-                          "station.country_code": "JA"
-                      }
-                  },
-                  {
-                      "range": {
-                          "TRANGE": {
-                              "gte": 0,
-                              "lte": 30
-                          }
-                      }
-                  },
-                  {
-                    "range": {
-                        "date": {
-                            "gte": "2016-06-04",
-                            "format":"yyyy-MM-dd"
-                        }
-                    }
-                  }
-              ]
-          }
-        },
-        "aggs": {
-          "station": {
-            "terms": {
-              "field": "station.id",
-              "size": 500
-            },
-            "aggs": {
-              "tmin": {
-                "min": {
-                  "field": "TMIN"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    {
       "name": "aggs-query-term-min-hybrid",
       "operation-type": "search",
       "request-params": {
@@ -205,79 +134,6 @@
               "tmin": {
                 "min": {
                   "field": "TMIN"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    {
-      "name": "aggs-query-date-histo-geohash-grid",
-      "operation-type": "search",
-      "body": {
-        "size": 100,
-        "aggs": {
-          "date": {
-            "date_histogram": {
-              "field": "date",
-              "calendar_interval": "1M"
-            },
-            "aggs": {
-              "location": {
-                "geohash_grid": {
-                  "field": "station.location",
-                  "precision": 2
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    {
-      "name": "aggs-query-date-histo-geohash-grid-bool",
-      "operation-type": "search",
-      "body": {
-        "size": 100,
-        "query": {
-          "bool": {
-              "should": [
-                  {
-                      "term": {
-                          "station.country_code": "JA"
-                      }
-                  },
-                  {
-                      "range": {
-                          "TRANGE": {
-                              "gte": 0,
-                              "lte": 30
-                          }
-                      }
-                  },
-                  {
-                    "range": {
-                        "date": {
-                            "gte": "2016-06-04",
-                            "format":"yyyy-MM-dd"
-                        }
-                    }
-                  }
-              ]
-          }
-        },
-        "aggs": {
-          "date": {
-            "date_histogram": {
-              "field": "date",
-              "calendar_interval": "1M"
-            },
-            "aggs": {
-              "location": {
-                "geohash_grid": {
-                  "field": "station.location",
-                  "precision": 2
                 }
               }
             }
@@ -331,91 +187,6 @@
                 "geohash_grid": {
                   "field": "station.location",
                   "precision": 2
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    {
-      "name": "aggs-query-range-numeric-significant-terms",
-      "operation-type": "search",
-      "body": {
-        "size": 100,
-        "aggs": {
-          "tmax": {
-            "range": {
-              "field": "TMAX",
-              "ranges": [
-                {"to":   -10},
-                {"from": -10, "to":  0},
-                {"from":   0, "to": 10},
-                {"from":  10, "to": 20},
-                {"from":  20, "to": 30},
-                {"from":  30}
-              ]
-            },
-            "aggs": {
-              "date": {
-                "significant_terms": {
-                  "field": "date"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    {
-      "name": "aggs-query-range-numeric-significant-terms-bool",
-      "operation-type": "search",
-      "body": {
-        "size": 100,
-        "query": {
-          "bool": {
-              "should": [
-                  {
-                      "term": {
-                          "station.country_code": "JA"
-                      }
-                  },
-                  {
-                      "range": {
-                          "TRANGE": {
-                              "gte": 0,
-                              "lte": 30
-                          }
-                      }
-                  },
-                  {
-                    "range": {
-                        "date": {
-                            "gte": "2016-06-04",
-                            "format":"yyyy-MM-dd"
-                        }
-                    }
-                  }
-              ]
-          }
-        },
-        "aggs": {
-          "tmax": {
-            "range": {
-              "field": "TMAX",
-              "ranges": [
-                {"to":   -10},
-                {"from": -10, "to":  0},
-                {"from":   0, "to": 10},
-                {"from":  10, "to": 20},
-                {"from":  20, "to": 30},
-                {"from":  30}
-              ]
-            },
-            "aggs": {
-              "date": {
-                "significant_terms": {
-                  "field": "date"
                 }
               }
             }
@@ -483,81 +254,6 @@
       }
     },
     {
-      "name": "aggs-query-min-avg-sum",
-      "operation-type": "search",
-      "body": {
-        "size": 100,
-        "aggs": {
-          "max_temp": {
-              "max": {
-                  "field": "TMAX"
-              }
-          },
-          "avg_temp": {
-              "avg": {
-                  "field": "TAVG"
-              }
-          },
-          "sum_temp": {
-              "sum": {
-                  "field": "THIC"
-              }
-          }
-        }
-      }
-    },
-    {
-      "name": "aggs-query-min-avg-sum-bool",
-      "operation-type": "search",
-      "body": {
-        "size": 100,
-        "query": {
-          "bool": {
-              "should": [
-                  {
-                      "term": {
-                          "station.country_code": "JA"
-                      }
-                  },
-                  {
-                      "range": {
-                          "TRANGE": {
-                              "gte": 0,
-                              "lte": 30
-                          }
-                      }
-                  },
-                  {
-                    "range": {
-                        "date": {
-                            "gte": "2016-06-04",
-                            "format":"yyyy-MM-dd"
-                        }
-                    }
-                  }
-              ]
-          }
-        },
-        "aggs": {
-          "max_temp": {
-              "max": {
-                  "field": "TMAX"
-              }
-          },
-          "avg_temp": {
-              "avg": {
-                  "field": "TAVG"
-              }
-          },
-          "sum_temp": {
-              "sum": {
-                  "field": "THIC"
-              }
-          }
-        }
-      }
-    },
-    {
       "name": "aggs-query-min-avg-sum-hybrid",
       "operation-type": "search",
       "request-params": {
@@ -612,27 +308,6 @@
       }
     },
     {
-      "name": "bool-only-range",
-      "operation-type": "search",
-      "body": {
-        "size": 100,
-        "query": {
-          "bool": {
-              "should": [
-                  {
-                      "range": {
-                          "TRANGE": {
-                              "gte": -100,
-                              "lte": -50
-                          }
-                      }
-                  }
-              ]
-          }
-        }
-      }
-    },
-    {
       "name": "hybrid-query-only-range",
       "operation-type": "search",
       "request-params": {
@@ -652,42 +327,6 @@
                     }
                 }
             ]
-          }
-        }
-      }
-    },
-    {
-      "name": "aggs-query-term-min-bool-one-subquery",
-      "operation-type": "search",
-      "body": {
-        "size": 100,
-        "query": {
-          "bool": {
-              "should": [
-                  {
-                      "range": {
-                          "TRANGE": {
-                            "gte": -100,
-                            "lte": -50
-                          }
-                      }
-                  }
-              ]
-          }
-        },
-        "aggs": {
-          "station": {
-            "terms": {
-              "field": "station.id",
-              "size": 500
-            },
-            "aggs": {
-              "tmin": {
-                "min": {
-                  "field": "TMIN"
-                }
-              }
-            }
           }
         }
       }
@@ -732,43 +371,6 @@
       }
     },
     {
-      "name": "aggs-query-date-histo-geohash-grid-bool-one-subquery",
-      "operation-type": "search",
-      "body": {
-        "size": 100,
-        "query": {
-          "bool": {
-              "should": [
-                  {
-                      "range": {
-                          "TRANGE": {
-                            "gte": -100,
-                            "lte": -50
-                          }
-                      }
-                  }
-              ]
-          }
-        },
-        "aggs": {
-          "date": {
-            "date_histogram": {
-              "field": "date",
-              "calendar_interval": "1M"
-            },
-            "aggs": {
-              "location": {
-                "geohash_grid": {
-                  "field": "station.location",
-                  "precision": 2
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    {
       "name": "aggs-query-date-histo-geohash-grid-hybrid-one-subquery",
       "operation-type": "search",
       "request-params": {
@@ -801,49 +403,6 @@
                 "geohash_grid": {
                   "field": "station.location",
                   "precision": 2
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    {
-      "name": "aggs-query-range-numeric-significant-terms-bool-one-subquery",
-      "operation-type": "search",
-      "body": {
-        "size": 100,
-        "query": {
-          "bool": {
-              "should": [
-                  {
-                      "range": {
-                          "TRANGE": {
-                            "gte": -100,
-                            "lte": -50
-                          }
-                      }
-                  }
-              ]
-          }
-        },
-        "aggs": {
-          "tmax": {
-            "range": {
-              "field": "TMAX",
-              "ranges": [
-                {"to":   -10},
-                {"from": -10, "to":  0},
-                {"from":   0, "to": 10},
-                {"from":  10, "to": 20},
-                {"from":  20, "to": 30},
-                {"from":  30}
-              ]
-            },
-            "aggs": {
-              "date": {
-                "significant_terms": {
-                  "field": "date"
                 }
               }
             }
@@ -898,44 +457,6 @@
       }
     },
     {
-      "name": "aggs-query-min-avg-sum-bool-one-subquery",
-      "operation-type": "search",
-      "body": {
-        "size": 100,
-        "query": {
-          "bool": {
-              "should": [
-                  {
-                      "range": {
-                          "TRANGE": {
-                            "gte": -100,
-                            "lte": -50
-                          }
-                      }
-                  }
-              ]
-          }
-        },
-        "aggs": {
-          "max_temp": {
-              "max": {
-                  "field": "TMAX"
-              }
-          },
-          "avg_temp": {
-              "avg": {
-                  "field": "TAVG"
-              }
-          },
-          "sum_temp": {
-              "sum": {
-                  "field": "THIC"
-              }
-          }
-        }
-      }
-    },
-    {
       "name": "aggs-query-min-avg-sum-hybrid-one-subquery",
       "operation-type": "search",
       "request-params": {
@@ -977,27 +498,6 @@
       }
     },
     {
-      "name": "bool-only-range-medium-subset",
-      "operation-type": "search",
-      "body": {
-        "size": 100,
-        "query": {
-          "bool": {
-              "should": [
-                  {
-                      "range": {
-                        "TRANGE": {
-                          "gte": -90,
-                          "lte": -7
-                        }
-                      }
-                  }
-              ]
-          }
-        }
-      }
-    },
-    {
       "name": "hybrid-query-only-range-medium-subset",
       "operation-type": "search",
       "request-params": {
@@ -1021,42 +521,6 @@
         }
       }
     },    
-    {
-      "name": "aggs-query-term-min-bool-one-subquery-medium-subset",
-      "operation-type": "search",
-      "body": {
-        "size": 100,
-        "query": {
-          "bool": {
-              "should": [
-                  {
-                    "range": {
-                      "TRANGE": {
-                        "gte": -90,
-                        "lte": -7
-                      }
-                    }
-                  }
-              ]
-          }
-        },
-        "aggs": {
-          "station": {
-            "terms": {
-              "field": "station.id",
-              "size": 500
-            },
-            "aggs": {
-              "tmin": {
-                "min": {
-                  "field": "TMIN"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     {
       "name": "aggs-query-term-min-hybrid-one-subquery-medium-subset",
       "operation-type": "search",
@@ -1097,43 +561,6 @@
       }
     },
     {
-      "name": "aggs-query-date-histo-geohash-grid-bool-one-subquery-medium-subset",
-      "operation-type": "search",
-      "body": {
-        "size": 100,
-        "query": {
-          "bool": {
-              "should": [
-                  {
-                    "range": {
-                      "TRANGE": {
-                        "gte": -90,
-                        "lte": -7
-                      }
-                    }
-                  }
-              ]
-          }
-        },
-        "aggs": {
-          "date": {
-            "date_histogram": {
-              "field": "date",
-              "calendar_interval": "1M"
-            },
-            "aggs": {
-              "location": {
-                "geohash_grid": {
-                  "field": "station.location",
-                  "precision": 2
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    {
       "name": "aggs-query-date-histo-geohash-grid-hybrid-one-subquery-medium-subset",
       "operation-type": "search",
       "request-params": {
@@ -1166,49 +593,6 @@
                 "geohash_grid": {
                   "field": "station.location",
                   "precision": 2
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    {
-      "name": "aggs-query-range-numeric-significant-terms-bool-one-subquery-medium-subset",
-      "operation-type": "search",
-      "body": {
-        "size": 100,
-        "query": {
-          "bool": {
-              "should": [
-                  {
-                    "range": {
-                      "TRANGE": {
-                        "gte": -90,
-                        "lte": -7
-                      }
-                    }
-                  }
-              ]
-          }
-        },
-        "aggs": {
-          "tmax": {
-            "range": {
-              "field": "TMAX",
-              "ranges": [
-                {"to":   -10},
-                {"from": -10, "to":  0},
-                {"from":   0, "to": 10},
-                {"from":  10, "to": 20},
-                {"from":  20, "to": 30},
-                {"from":  30}
-              ]
-            },
-            "aggs": {
-              "date": {
-                "significant_terms": {
-                  "field": "date"
                 }
               }
             }
@@ -1263,44 +647,6 @@
       }
     },
     {
-      "name": "aggs-query-min-avg-sum-bool-one-subquery-medium-subset",
-      "operation-type": "search",
-      "body": {
-        "size": 100,
-        "query": {
-          "bool": {
-              "should": [
-                  {
-                    "range": {
-                      "TRANGE": {
-                        "gte": -90,
-                        "lte": -7
-                      }
-                    }
-                  }
-              ]
-          }
-        },
-        "aggs": {
-          "max_temp": {
-              "max": {
-                  "field": "TMAX"
-              }
-          },
-          "avg_temp": {
-              "avg": {
-                  "field": "TAVG"
-              }
-          },
-          "sum_temp": {
-              "sum": {
-                  "field": "THIC"
-              }
-          }
-        }
-      }
-    },
-    {
       "name": "aggs-query-min-avg-sum-hybrid-one-subquery-medium-subset",
       "operation-type": "search",
       "request-params": {
@@ -1342,27 +688,6 @@
       }
     },
     {
-      "name": "bool-only-range-large-subset",
-      "operation-type": "search",
-      "body": {
-        "size": 100,
-        "query": {
-          "bool": {
-              "should": [
-                  {
-                      "range": {
-                        "TRANGE": {
-                          "gte": 1,
-                          "lte": 35
-                        }
-                      }
-                  }
-              ]
-          }
-        }
-      }
-    },
-    {
       "name": "hybrid-query-only-range-large-subset",
       "operation-type": "search",
       "request-params": {
@@ -1382,42 +707,6 @@
                     }
                 }
             ]
-          }
-        }
-      }
-    },
-    {
-      "name": "aggs-query-term-min-bool-one-subquery-large-subset",
-      "operation-type": "search",
-      "body": {
-        "size": 100,
-        "query": {
-          "bool": {
-              "should": [
-                  {
-                      "range": {
-                        "TRANGE": {
-                          "gte": 1,
-                          "lte": 35
-                        }
-                      }
-                  }
-              ]
-          }
-        },
-        "aggs": {
-          "station": {
-            "terms": {
-              "field": "station.id",
-              "size": 500
-            },
-            "aggs": {
-              "tmin": {
-                "min": {
-                  "field": "TMIN"
-                }
-              }
-            }
           }
         }
       }
@@ -1462,43 +751,6 @@
       }
     },
     {
-      "name": "aggs-query-date-histo-geohash-grid-bool-one-subquery-large-subset",
-      "operation-type": "search",
-      "body": {
-        "size": 100,
-        "query": {
-          "bool": {
-              "should": [
-                  {
-                      "range": {
-                        "TRANGE": {
-                          "gte": 1,
-                          "lte": 35
-                        }
-                      }
-                  }
-              ]
-          }
-        },
-        "aggs": {
-          "date": {
-            "date_histogram": {
-              "field": "date",
-              "calendar_interval": "1M"
-            },
-            "aggs": {
-              "location": {
-                "geohash_grid": {
-                  "field": "station.location",
-                  "precision": 2
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    {
       "name": "aggs-query-date-histo-geohash-grid-hybrid-one-subquery-large-subset",
       "operation-type": "search",
       "request-params": {
@@ -1531,49 +783,6 @@
                 "geohash_grid": {
                   "field": "station.location",
                   "precision": 2
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    {
-      "name": "aggs-query-range-numeric-significant-terms-bool-one-subquery-large-subset",
-      "operation-type": "search",
-      "body": {
-        "size": 100,
-        "query": {
-          "bool": {
-              "should": [
-                  {
-                      "range": {
-                        "TRANGE": {
-                          "gte": 1,
-                          "lte": 35
-                        }
-                      }
-                  }
-              ]
-          }
-        },
-        "aggs": {
-          "tmax": {
-            "range": {
-              "field": "TMAX",
-              "ranges": [
-                {"to":   -10},
-                {"from": -10, "to":  0},
-                {"from":   0, "to": 10},
-                {"from":  10, "to": 20},
-                {"from":  20, "to": 30},
-                {"from":  30}
-              ]
-            },
-            "aggs": {
-              "date": {
-                "significant_terms": {
-                  "field": "date"
                 }
               }
             }
@@ -1623,44 +832,6 @@
                 }
               }
             }
-          }
-        }
-      }
-    },
-    {
-      "name": "aggs-query-min-avg-sum-bool-one-subquery-large-subset",
-      "operation-type": "search",
-      "body": {
-        "size": 100,
-        "query": {
-          "bool": {
-              "should": [
-                  {
-                      "range": {
-                        "TRANGE": {
-                          "gte": 1,
-                          "lte": 35
-                        }
-                      }
-                  }
-              ]
-          }
-        },
-        "aggs": {
-          "max_temp": {
-              "max": {
-                  "field": "TMAX"
-              }
-          },
-          "avg_temp": {
-              "avg": {
-                  "field": "TAVG"
-              }
-          },
-          "sum_temp": {
-              "sum": {
-                  "field": "THIC"
-              }
           }
         }
       }

--- a/noaa_semantic_search/params/one_replica_no_concurrent_segment_search.json
+++ b/noaa_semantic_search/params/one_replica_no_concurrent_segment_search.json
@@ -1,0 +1,6 @@
+{
+     "number_of_replicas": 1,
+     "number_of_shards" :6,
+     "max_num_segments" :8,
+     "concurrent_segment_search_enabled": "false"
+}

--- a/noaa_semantic_search/params/one_replica_with_concurrent_segment_search.json
+++ b/noaa_semantic_search/params/one_replica_with_concurrent_segment_search.json
@@ -1,0 +1,6 @@
+{
+     "number_of_replicas": 1,
+     "number_of_shards" :6,
+     "max_num_segments" :8,
+     "concurrent_segment_search_enabled": "true"
+}

--- a/noaa_semantic_search/test_procedures/semantic-search-common/multiple-subqueries-search.json
+++ b/noaa_semantic_search/test_procedures/semantic-search-common/multiple-subqueries-search.json
@@ -6,47 +6,12 @@
         "clients": {{ search_clients | default(1) }}
       },
       {
-        "operation": "bool-only-term-range-date",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },        
-      {
-        "operation": "aggs-query-min-avg-sum",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
-      {
-        "operation": "aggs-query-min-avg-sum-bool",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
-      {
         "operation": "aggs-query-min-avg-sum-hybrid",
         "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
         "iterations": {{ test_iterations | default(100) | tojson }},
         "target-throughput": {{ target_throughput | default(2) | tojson }},
         "clients": {{ search_clients | default(1) }}
       },        
-      {
-        "operation": "aggs-query-term-min",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
-      {
-        "operation": "aggs-query-term-min-bool",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
       {
         "operation": "aggs-query-term-min-hybrid",
         "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
@@ -55,35 +20,7 @@
         "clients": {{ search_clients | default(1) }}
       },
       {
-        "operation": "aggs-query-date-histo-geohash-grid",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
-      {
-        "operation": "aggs-query-date-histo-geohash-grid-bool",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
-      {
         "operation": "aggs-query-date-histo-geohash-grid-hybrid",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
-      {
-        "operation": "aggs-query-range-numeric-significant-terms",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
-      {
-        "operation": "aggs-query-range-numeric-significant-terms-bool",
         "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
         "iterations": {{ test_iterations | default(100) | tojson }},
         "target-throughput": {{ target_throughput | default(2) | tojson }},

--- a/noaa_semantic_search/test_procedures/semantic-search-common/profiler-workflow.json
+++ b/noaa_semantic_search/test_procedures/semantic-search-common/profiler-workflow.json
@@ -10,34 +10,6 @@
   }
 },
 {
-  "operation": "hybrid-query-only-range",
-  "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
-},
-{
-  "operation": "bool-only-range",
-  "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
-},       
-{
-  "operation": "aggs-query-term-min-bool-one-subquery",
-  "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
-},
-{
-  "operation": "aggs-query-term-min-hybrid-one-subquery",
-  "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
-},
-{
   "operation": "hybrid-query-only-range-medium-subset",
   "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
@@ -45,35 +17,7 @@
   "clients": {{ search_clients | default(1) }}
 },
 {
-  "operation": "bool-only-range-medium-subset",
-  "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
-},
-{
-  "operation": "hybrid-query-only-range-large-subset",
-  "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
-},
-{
-  "operation": "bool-only-range-large-subset",
-  "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
-},
-{
   "operation": "hybrid-query-only-term-range-date",
-  "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
-},
-{
-  "operation": "bool-only-term-range-date",
   "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
   "target-throughput": {{ target_throughput | default(2) | tojson }},

--- a/noaa_semantic_search/test_procedures/semantic-search-common/single-subquery-large-set-search.json
+++ b/noaa_semantic_search/test_procedures/semantic-search-common/single-subquery-large-set-search.json
@@ -6,49 +6,12 @@
         "clients": {{ search_clients | default(1) }}
       },
       {
-        "operation": "bool-only-range-large-subset",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
-      {
-        "operation": "aggs-query-min-avg-sum",
-        "name": "aggs query for min, avg and sum for one subquery large subset case",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
-      {
-        "operation": "aggs-query-min-avg-sum-bool-one-subquery-large-subset",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
-      {
         "operation": "aggs-query-min-avg-sum-hybrid-one-subquery-large-subset",
         "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
         "iterations": {{ test_iterations | default(100) | tojson }},
         "target-throughput": {{ target_throughput | default(2) | tojson }},
         "clients": {{ search_clients | default(1) }}
       },        
-      {
-        "operation": "aggs-query-term-min",
-        "name": "aggs query for term and min for one subquery large subset case",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
-      {
-        "operation": "aggs-query-term-min-bool-one-subquery-large-subset",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
       {
         "operation": "aggs-query-term-min-hybrid-one-subquery-large-subset",
         "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
@@ -57,37 +20,7 @@
         "clients": {{ search_clients | default(1) }}
       },
       {
-        "operation": "aggs-query-date-histo-geohash-grid",
-        "name": "aggs query for date historgram and geohash grid for one subquery large subset case",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
-      {
-        "operation": "aggs-query-date-histo-geohash-grid-bool-one-subquery-large-subset",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
-      {
         "operation": "aggs-query-date-histo-geohash-grid-hybrid-one-subquery-large-subset",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
-      {
-        "operation": "aggs-query-range-numeric-significant-terms",
-        "name": "aggs query for range and significant terms for one subquery large subset case",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
-      {
-        "operation": "aggs-query-range-numeric-significant-terms-bool-one-subquery-large-subset",
         "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
         "iterations": {{ test_iterations | default(100) | tojson }},
         "target-throughput": {{ target_throughput | default(2) | tojson }},

--- a/noaa_semantic_search/test_procedures/semantic-search-common/single-subquery-medium-set-search.json
+++ b/noaa_semantic_search/test_procedures/semantic-search-common/single-subquery-medium-set-search.json
@@ -6,41 +6,12 @@
         "clients": {{ search_clients | default(1) }}
       },
       {
-        "operation": "bool-only-range-medium-subset",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
-      {
-        "operation": "aggs-query-min-avg-sum-bool-one-subquery-medium-subset",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
-      {
         "operation": "aggs-query-min-avg-sum-hybrid-one-subquery-medium-subset",
         "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
         "iterations": {{ test_iterations | default(100) | tojson }},
         "target-throughput": {{ target_throughput | default(2) | tojson }},
         "clients": {{ search_clients | default(1) }}
       },        
-      {
-        "operation": "aggs-query-term-min",
-        "name": "aggs query for term and min for one subquery medium subset case",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
-      {
-        "operation": "aggs-query-term-min-bool-one-subquery-medium-subset",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
       {
         "operation": "aggs-query-term-min-hybrid-one-subquery-medium-subset",
         "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
@@ -49,37 +20,7 @@
         "clients": {{ search_clients | default(1) }}
       },
       {
-        "operation": "aggs-query-date-histo-geohash-grid",
-        "name": "aggs query for date historgram and geohash grid for one subquery medium subset case",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
-      {
-        "operation": "aggs-query-date-histo-geohash-grid-bool-one-subquery-medium-subset",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
-      {
         "operation": "aggs-query-date-histo-geohash-grid-hybrid-one-subquery-medium-subset",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
-      {
-        "operation": "aggs-query-range-numeric-significant-terms",
-        "name": "aggs query for range and significant terms for one subquery medium subset case",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
-      {
-        "operation": "aggs-query-range-numeric-significant-terms-bool-one-subquery-medium-subset",
         "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
         "iterations": {{ test_iterations | default(100) | tojson }},
         "target-throughput": {{ target_throughput | default(2) | tojson }},

--- a/noaa_semantic_search/test_procedures/semantic-search-common/single-subquery-small-set-search.json
+++ b/noaa_semantic_search/test_procedures/semantic-search-common/single-subquery-small-set-search.json
@@ -6,49 +6,12 @@
         "clients": {{ search_clients | default(1) }}
       },
       {
-        "operation": "bool-only-range",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
-      {
-        "operation": "aggs-query-min-avg-sum",
-        "name": "aggs query for min, avg and sum for one subquery case",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
-      {
-        "operation": "aggs-query-min-avg-sum-bool-one-subquery",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
-      {
         "operation": "aggs-query-min-avg-sum-hybrid-one-subquery",
         "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
         "iterations": {{ test_iterations | default(100) | tojson }},
         "target-throughput": {{ target_throughput | default(2) | tojson }},
         "clients": {{ search_clients | default(1) }}
       },        
-      {
-        "operation": "aggs-query-term-min",
-        "name": "aggs query for term and min for one subquery case",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
-      {
-        "operation": "aggs-query-term-min-bool-one-subquery",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
       {
         "operation": "aggs-query-term-min-hybrid-one-subquery",
         "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
@@ -57,37 +20,7 @@
         "clients": {{ search_clients | default(1) }}
       },
       {
-        "operation": "aggs-query-date-histo-geohash-grid",
-        "name": "aggs query for date historgram and geohash grid for one subquery case",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
-      {
-        "operation": "aggs-query-date-histo-geohash-grid-bool-one-subquery",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
-      {
         "operation": "aggs-query-date-histo-geohash-grid-hybrid-one-subquery",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
-      {
-        "operation": "aggs-query-range-numeric-significant-terms",
-        "name": "aggs query for range and significant terms for one subquery case",
-        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
-        "iterations": {{ test_iterations | default(100) | tojson }},
-        "target-throughput": {{ target_throughput | default(2) | tojson }},
-        "clients": {{ search_clients | default(1) }}
-      },
-      {
-        "operation": "aggs-query-range-numeric-significant-terms-bool-one-subquery",
         "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
         "iterations": {{ test_iterations | default(100) | tojson }},
         "target-throughput": {{ target_throughput | default(2) | tojson }},


### PR DESCRIPTION
### Description
Doing some cleanup for semantic search workload based on NOAA dataset:
- remove unused operations that are not related to hybrid query/search. those were added in initial version for testing purposes and are consuming resources (time and compute power) while not giving valuable info
- refactor parameters into files, so now changes in cluster or index config (e.g. increasing num of replicas) are decoupled from command that runs the workload
- update readme for workflow, mention param files

### Issues Resolved
https://github.com/opensearch-project/opensearch-benchmark-workloads/issues/291

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
