### PR TITLE
Adding new aoss vector search param fields `target_throughput`, `repetitions` and `time_period`

### DIFF
--- a/vectorsearch/README.md
+++ b/vectorsearch/README.md
@@ -97,6 +97,9 @@ This workload allows the following parameters to be specified using `--workload-
 | query_count                             | Number of queries for search operation                                   |
 | query_body                              | Json properties that will be merged with search body                     |
 | search_clients                          | Number of clients to use for running queries                             |
+| repetitions                             | Number of repetitions until the data set is exhausted                    |
+| target_throughput                       | Target throughput for each query operation in requests per second (default 10) |
+| time_period                             | The period of time dedicated for the benchmark execution (in seconds)    |
 
 
 

--- a/vectorsearch/README.md
+++ b/vectorsearch/README.md
@@ -97,9 +97,9 @@ This workload allows the following parameters to be specified using `--workload-
 | query_count                             | Number of queries for search operation                                   |
 | query_body                              | Json properties that will be merged with search body                     |
 | search_clients                          | Number of clients to use for running queries                             |
-| repetitions                             | Number of repetitions until the data set is exhausted                    |
+| repetitions                             | Number of repetitions until the data set is exhausted (default 1)                    |
 | target_throughput                       | Target throughput for each query operation in requests per second (default 10) |
-| time_period                             | The period of time dedicated for the benchmark execution (in seconds)    |
+| time_period                             | The period of time dedicated for the benchmark execution in seconds (default 900)    |
 
 
 

--- a/vectorsearch/test_procedures/aoss/search-only-schedule.json
+++ b/vectorsearch/test_procedures/aoss/search-only-schedule.json
@@ -5,6 +5,7 @@
         "index": "{{ target_index_name | default('target_index') }}",
         "detailed-results": true,
         "k": {{ query_k  | default(100) }},
+        "repetitions": {{ repetitions }},
         "field" : "{{ target_field_name | default('target_field') }}",
         "data_set_format" : "{{ query_data_set_format | default('hdf5') }}",
         "data_set_path" : "{{ query_data_set_path }}",
@@ -16,5 +17,7 @@
         "id-field-name": "{{ id_field_name }}",
         "body": {{ query_body | default ({}) | tojson }}    
     },
-    "clients": {{ search_clients | default(1)}}
+    "clients": {{ search_clients | default(1)}},
+    "target-throughput": {{ target_throughput | default(10) }},
+    "time-period": {{ time_period | default(900) }}
 }

--- a/vectorsearch/test_procedures/aoss/search-only-schedule.json
+++ b/vectorsearch/test_procedures/aoss/search-only-schedule.json
@@ -5,7 +5,7 @@
         "index": "{{ target_index_name | default('target_index') }}",
         "detailed-results": true,
         "k": {{ query_k  | default(100) }},
-        "repetitions": {{ repetitions }},
+        "repetitions": {{ repetitions | default(1) }},
         "field" : "{{ target_field_name | default('target_field') }}",
         "data_set_format" : "{{ query_data_set_format | default('hdf5') }}",
         "data_set_path" : "{{ query_data_set_path }}",


### PR DESCRIPTION
### Description
_Describe what this change achieves._

As per request in [issue 317](https://github.com/opensearch-project/opensearch-benchmark-workloads/issues/317), AOSS would like to have granular control over of load during benchmarking by controlling the targeted TPS for workload as well as the duration of the load.

This PR adds the fields `target_throughput`, `time_period` and `repetitions` to AOSS' vector search procedure. This was tested, and I was able to validate it locally. 

**Local test details**

Tested with the following params:
```
{
    "target_index_name": "target_index",
    "target_field_name": "target_field",
    "target_index_body": "indices/nmslib-index.json",
    "target_index_dimension": 768,
    "target_index_space_type": "innerproduct",
    "id_field_name": "id",

    "target_index_bulk_size": 100,
    "target_index_bulk_index_data_set_format": "hdf5",
    "target_index_bulk_index_data_set_corpus": "cohere-100k",
    "target_index_bulk_indexing_clients": 10,
    "repetitions": 2,

    "hnsw_ef_search": 256,
    "hnsw_ef_construction": 256,

    "query_k": 10,
    "query_body": {
         "docvalue_fields" : ["id"],
         "stored_fields" : "_none_"
    },

    "query_data_set_format": "hdf5",
    "query_data_set_corpus":"cohere-100k",
    "neighbors_data_set_corpus":"cohere-100k",
    "neighbors_data_set_format":"hdf5",
    "query_count": 10000,
    "target_throughput": 15,
    "time_period": 1500
}
```

Ran command:
```
opensearch-benchmark execute-test \
--target-hosts=$ENDPOINT \
--pipeline=benchmark-only \
--workload=vectorsearch \
--workload-repository aoss/benchmarking/opensearch-benchmark-workloads \
--workload-params=aoss/benchmarking/opensearch-benchmark-workloads/vectorsearch/params/aoss/custom_params.json \
--client-options=timeout:120,amazon_aws_log_in:client_option,aws_access_key_id:$ACCESS_KEY,aws_secret_access_key:$SECRET_ACCESS_KEY,region:$region,service:aoss \
--distribution-version=2.1.1 \
--test-procedure=search-only \
--kill-running-processes
```

Output, which I observed the max throughput did not exceed 15 and the test did not last over 1500s:
```
   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/

[INFO] [Test Execution ID]: f1adadb3-0e3d-4385-ac87-8d0c0bed6151
[INFO] Executing test with workload [vectorsearch], test_procedure [search-only] and provision_config_instance ['external'] with version [None].

Running prod-queries                                                           [100% done]

------------------------------------------------------
    _______             __   _____
   / ____(_)___  ____ _/ /  / ___/_________  ________
  / /_  / / __ \/ __ `/ /   \__ \/ ___/ __ \/ ___/ _ \
 / __/ / / / / / /_/ / /   ___/ / /__/ /_/ / /  /  __/
/_/   /_/_/ /_/\__,_/_/   /____/\___/\____/_/   \___/
------------------------------------------------------

|                          Metric |         Task |   Value |   Unit |
|--------------------------------:|-------------:|--------:|-------:|
|         Total Young Gen GC time |              |       0 |      s |
|        Total Young Gen GC count |              |       0 |        |
|           Total Old Gen GC time |              |       0 |      s |
|          Total Old Gen GC count |              |       0 |        |
|                  Min Throughput | prod-queries |   13.36 |  ops/s |
|                 Mean Throughput | prod-queries |   14.99 |  ops/s |
|               Median Throughput | prod-queries |      15 |  ops/s |
|                  Max Throughput | prod-queries |      15 |  ops/s |
|         50th percentile latency | prod-queries | 33.3555 |     ms |
|         90th percentile latency | prod-queries | 38.4205 |     ms |
|         99th percentile latency | prod-queries | 59.1448 |     ms |
|       99.9th percentile latency | prod-queries | 213.361 |     ms |
|      99.99th percentile latency | prod-queries | 278.935 |     ms |
|        100th percentile latency | prod-queries | 281.683 |     ms |
|    50th percentile service time | prod-queries | 31.2444 |     ms |
|    90th percentile service time | prod-queries | 36.1528 |     ms |
|    99th percentile service time | prod-queries | 47.7218 |     ms |
|  99.9th percentile service time | prod-queries | 105.628 |     ms |
| 99.99th percentile service time | prod-queries | 276.917 |     ms |
|   100th percentile service time | prod-queries | 279.344 |     ms |
|                      error rate | prod-queries |       0 |      % |


----------------------------------
[INFO] SUCCESS (took 1347 seconds)
----------------------------------
```

### Issues Resolved
- Closes [317: VectorSearch - Ability to control target-throughput and time-period](https://github.com/opensearch-project/opensearch-benchmark-workloads/issues/317)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
