### PR TITLE
For Semantic search on NOAA increasing number of search clients to 8

### DIFF
--- a/noaa_semantic_search/params/one_replica_no_concurrent_segment_search.json
+++ b/noaa_semantic_search/params/one_replica_no_concurrent_segment_search.json
@@ -2,5 +2,6 @@
      "number_of_replicas": 1,
      "number_of_shards" :6,
      "max_num_segments" :8,
-     "concurrent_segment_search_enabled": "false"
+     "concurrent_segment_search_enabled": "false",
+     "search_clients" : 8
 }

--- a/noaa_semantic_search/params/one_replica_with_concurrent_segment_search.json
+++ b/noaa_semantic_search/params/one_replica_with_concurrent_segment_search.json
@@ -2,5 +2,6 @@
      "number_of_replicas": 1,
      "number_of_shards" :6,
      "max_num_segments" :8,
-     "concurrent_segment_search_enabled": "true"
+     "concurrent_segment_search_enabled": "true",
+     "search_clients" : 8
 }


### PR DESCRIPTION
### Description
Increasing number of search clients for semantic search workload that is based on noaa dataset. I'm setting number of search clients to 8. That will make throughput results more reliable comparing to what we have today. Currently we don't have any custom setting for number of search clients in param files, that means we're using default number which is 1. Below is example of throughput metrics from the same system for 7 days period, expectation is that graph is more or less smooth, but it has some spikes:

![image](https://github.com/opensearch-project/opensearch-benchmark-workloads/assets/94878159/252c8c02-433d-4291-b696-ef801536b273)


### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
