### PR TITLE
Fix IT bug

### DIFF
--- a/vectorsearch/indices/train-index.json
+++ b/vectorsearch/indices/train-index.json
@@ -13,7 +13,7 @@
       "properties": {
         "{{ train_field_name }}": {
           "type": "knn_vector",
-          "dimension": {{ target_index_dimension }}
+          "dimension": {{ target_index_dimension | default(-1) }}
         }
       }
     }

--- a/vectorsearch/test_procedures/common/train-model-schedule.json
+++ b/vectorsearch/test_procedures/common/train-model-schedule.json
@@ -14,7 +14,7 @@
             "training_index": "{{ train_index_name | default('train_index') }}",
             "training_field": "{{ train_field_name | default('train_field') }}",
             "search_size": "{{ train_search_size | default(10000) }}", 
-            "dimension": {{ target_index_dimension }},
+            "dimension": {{ target_index_dimension | default(-1) }},
             {%- if train_max_vector_count is defined and train_max_vector_count %}
                 "max_training_vector_count": "{{ train_max_vector_count }}", 
             {%- endif %}

--- a/vectorsearch/workload.json
+++ b/vectorsearch/workload.json
@@ -4,11 +4,11 @@
     "description": "Benchmark vector search engine performance for different engine types like faiss, lucene and nmslib",
     "indices": [
         {
-            "name": "{{ target_index_name }}",
+            "name": "{{ target_index_name | default('target_index') }}",
             "body": "{{ target_index_body }}"
         },
         {
-            "name": "{{ train_index_name }}",
+            "name": "{{ train_index_name | default('train_index') }}",
             "body": "{{ train_index_body }}"
         }
     ],


### PR DESCRIPTION
### Description

Adds default values to vector search workload.json and procedures to fix failing "list workloads" integration test (https://github.com/opensearch-project/opensearch-benchmark-workloads/issues/348).

Dimension defaults to -1 to pass validation for `list workloads` command and to indicate that `target_index_dimension` is a required parameter in the `train-test` procedure. 

Tested manually and the previously failing integration tests [on my fork pass](https://github.com/finnroblin/opensearch-benchmark/actions/runs/10000029628/job/27641831753#step:16:1301). A `http_logs` execute-test [command](https://github.com/finnroblin/opensearch-benchmark/actions/runs/10000029628/job/27641831753#step:16:676) fails, but I think is unrelated as I didn't make changes to that code path as part of this or the earlier PR.
### Issues Resolved

Closes https://github.com/opensearch-project/opensearch-benchmark-workloads/issues/348

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).