### PR TITLE
Fix vectorsearch train-test procedure

### DIFF
--- a/vectorsearch/README.md
+++ b/vectorsearch/README.md
@@ -235,12 +235,12 @@ This workload allows the following parameters to be specified using `--workload-
 | train_operation_poll_period             | Poll period for querying training operation in seconds                                       |
 | train_search_size                       | Number of results per [scroll query](http://opensearch.org/docs/latest/api-reference/scroll/)|
 | encoder                                 | Encoder for quantization. One of `flat`, `sq`, `pq`. Defaults to `flat` when not specified. [See here](https://opensearch.org/docs/latest/search-plugins/knn/knn-index/#supported-faiss-encoders)
-| faiss_encoder_code_size                 | PQ Encoding [code size setting](https://opensearch.org/docs/latest/search-plugins/knn/knn-index/#pq-parameters).
-| faiss_encoder_m                         | PQ Encoding [m setting](https://opensearch.org/docs/latest/search-plugins/knn/knn-index/#pq-parameters)
-| faiss_encoder_type                      | SQ Encoding [type setting](https://opensearch.org/docs/latest/search-plugins/knn/knn-index/#sq-parameters)
-| faiss_encoder_clip                      | SQ Encoding [clip setting](https://opensearch.org/docs/latest/search-plugins/knn/knn-index/#sq-parameters)
-| faiss_nprobes                           | Faiss IVF nprobes setting. [See here](https://opensearch.org/docs/latest/search-plugins/knn/knn-index/#ivf-parameters)|
-| faiss_nlist                             | Faiss IVF nlist setting. [See here](https://opensearch.org/docs/latest/search-plugins/knn/knn-index/#ivf-parameters)|
+| pq_encoder_code_size                 | PQ Encoding [code size setting](https://opensearch.org/docs/latest/search-plugins/knn/knn-index/#pq-parameters).
+| pq_encoder_m                         | PQ Encoding [m setting](https://opensearch.org/docs/latest/search-plugins/knn/knn-index/#pq-parameters)
+| encoder_type                      | SQ Encoding [type setting](https://opensearch.org/docs/latest/search-plugins/knn/knn-index/#sq-parameters)
+| encoder_clip                      | SQ Encoding [clip setting](https://opensearch.org/docs/latest/search-plugins/knn/knn-index/#sq-parameters)
+| nprobes                           | IVF nprobes setting. [See here](https://opensearch.org/docs/latest/search-plugins/knn/knn-index/#ivf-parameters)|
+| nlist                             | IVF nlist setting. [See here](https://opensearch.org/docs/latest/search-plugins/knn/knn-index/#ivf-parameters)|
 | hnsw_ef_search                          | HNSW ef search parameter                                                                     |
 | hnsw_ef_construction                    | HNSW ef construction parameter                                                               |
 | id_field_name                           | Name of field that will be used to identify documents in an index                            |

--- a/vectorsearch/README.md
+++ b/vectorsearch/README.md
@@ -234,6 +234,13 @@ This workload allows the following parameters to be specified using `--workload-
 | train_operation_retries                 | Number of retries for querying training operation to see if complete                         |
 | train_operation_poll_period             | Poll period for querying training operation in seconds                                       |
 | train_search_size                       | Number of results per [scroll query](http://opensearch.org/docs/latest/api-reference/scroll/)|
+| encoder                                 | Encoder for quantization. One of `flat`, `sq`, `pq`. Defaults to `flat` when not specified. [See here](https://opensearch.org/docs/latest/search-plugins/knn/knn-index/#supported-faiss-encoders)
+| faiss_encoder_code_size                 | PQ Encoding [code size setting](https://opensearch.org/docs/latest/search-plugins/knn/knn-index/#pq-parameters).
+| faiss_encoder_m                         | PQ Encoding [m setting](https://opensearch.org/docs/latest/search-plugins/knn/knn-index/#pq-parameters)
+| faiss_encoder_type                      | SQ Encoding [type setting](https://opensearch.org/docs/latest/search-plugins/knn/knn-index/#sq-parameters)
+| faiss_encoder_clip                      | SQ Encoding [clip setting](https://opensearch.org/docs/latest/search-plugins/knn/knn-index/#sq-parameters)
+| faiss_nprobes                           | Faiss IVF nprobes setting. [See here](https://opensearch.org/docs/latest/search-plugins/knn/knn-index/#ivf-parameters)|
+| faiss_nlist                             | Faiss IVF nlist setting. [See here](https://opensearch.org/docs/latest/search-plugins/knn/knn-index/#ivf-parameters)|
 | hnsw_ef_search                          | HNSW ef search parameter                                                                     |
 | hnsw_ef_construction                    | HNSW ef construction parameter                                                               |
 | id_field_name                           | Name of field that will be used to identify documents in an index                            |

--- a/vectorsearch/README.md
+++ b/vectorsearch/README.md
@@ -252,98 +252,382 @@ This workload allows the following parameters to be specified using `--workload-
 | query_body                              | Json properties that will be merged with search body                                         |
 | search_clients                          | Number of clients to use for running queries                                                 |
 
-#### Sample Output
+#### Sample Outputs
 
-The output of a sample test run is provided below. Metrics are captured in the result's data store as usual, and this can be configured to be 
-either in-memory, or an external OpenSearch cluster.
+Below are sample outputs for the Faiss IVF benchmarking procedure. For the sake of time we ran 100 search queries instead of the 10000 specified in the parameter files. The rest of the parameters are the same as those in the `params/train` folder. The first run is without quantization, the second run is with scalar quantization, and the third run is with product quantization. Note that quantization may cause search recall to drop.
+
+##### Faiss IVF -- no quantization/flat encoding
 
 ```
-------------------------------------------------------
-    _______             __   _____
-   / ____(_)___  ____ _/ /  / ___/_________  ________
-  / /_  / / __ \/ __ `/ /   \__ \/ ___/ __ \/ ___/ _ \
- / __/ / / / / / /_/ / /   ___/ / /__/ /_/ / /  /  __/
-/_/   /_/_/ /_/\__,_/_/   /____/\___/\____/_/   \___/
-------------------------------------------------------
-            
-|                                                         Metric |               Task |       Value |   Unit |
-|---------------------------------------------------------------:|-------------------:|------------:|-------:|
-|                     Cumulative indexing time of primary shards |                    |  0.00946667 |    min |
-|             Min cumulative indexing time across primary shards |                    |           0 |    min |
-|          Median cumulative indexing time across primary shards |                    |  0.00298333 |    min |
-|             Max cumulative indexing time across primary shards |                    |  0.00336667 |    min |
-|            Cumulative indexing throttle time of primary shards |                    |           0 |    min |
-|    Min cumulative indexing throttle time across primary shards |                    |           0 |    min |
-| Median cumulative indexing throttle time across primary shards |                    |           0 |    min |
-|    Max cumulative indexing throttle time across primary shards |                    |           0 |    min |
-|                        Cumulative merge time of primary shards |                    |           0 |    min |
-|                       Cumulative merge count of primary shards |                    |           0 |        |
-|                Min cumulative merge time across primary shards |                    |           0 |    min |
-|             Median cumulative merge time across primary shards |                    |           0 |    min |
-|                Max cumulative merge time across primary shards |                    |           0 |    min |
-|               Cumulative merge throttle time of primary shards |                    |           0 |    min |
-|       Min cumulative merge throttle time across primary shards |                    |           0 |    min |
-|    Median cumulative merge throttle time across primary shards |                    |           0 |    min |
-|       Max cumulative merge throttle time across primary shards |                    |           0 |    min |
-|                      Cumulative refresh time of primary shards |                    |  0.00861667 |    min |
-|                     Cumulative refresh count of primary shards |                    |          33 |        |
-|              Min cumulative refresh time across primary shards |                    |           0 |    min |
-|           Median cumulative refresh time across primary shards |                    |  0.00268333 |    min |
-|              Max cumulative refresh time across primary shards |                    |  0.00291667 |    min |
-|                        Cumulative flush time of primary shards |                    | 0.000183333 |    min |
-|                       Cumulative flush count of primary shards |                    |           2 |        |
-|                Min cumulative flush time across primary shards |                    |           0 |    min |
-|             Median cumulative flush time across primary shards |                    |           0 |    min |
-|                Max cumulative flush time across primary shards |                    | 0.000183333 |    min |
-|                                        Total Young Gen GC time |                    |       0.075 |      s |
-|                                       Total Young Gen GC count |                    |          17 |        |
-|                                          Total Old Gen GC time |                    |           0 |      s |
-|                                         Total Old Gen GC count |                    |           0 |        |
-|                                                     Store size |                    |  0.00869293 |     GB |
-|                                                  Translog size |                    | 2.56114e-07 |     GB |
-|                                         Heap used for segments |                    |           0 |     MB |
-|                                       Heap used for doc values |                    |           0 |     MB |
-|                                            Heap used for terms |                    |           0 |     MB |
-|                                            Heap used for norms |                    |           0 |     MB |
-|                                           Heap used for points |                    |           0 |     MB |
-|                                    Heap used for stored fields |                    |           0 |     MB |
-|                                                  Segment count |                    |           9 |        |
-|                                                 Min Throughput | custom-vector-bulk |       25527 | docs/s |
-|                                                Mean Throughput | custom-vector-bulk |       25527 | docs/s |
-|                                              Median Throughput | custom-vector-bulk |       25527 | docs/s |
-|                                                 Max Throughput | custom-vector-bulk |       25527 | docs/s |
-|                                        50th percentile latency | custom-vector-bulk |     36.3095 |     ms |
-|                                        90th percentile latency | custom-vector-bulk |     52.2662 |     ms |
-|                                       100th percentile latency | custom-vector-bulk |     68.6513 |     ms |
-|                                   50th percentile service time | custom-vector-bulk |     36.3095 |     ms |
-|                                   90th percentile service time | custom-vector-bulk |     52.2662 |     ms |
-|                                  100th percentile service time | custom-vector-bulk |     68.6513 |     ms |
-|                                                     error rate | custom-vector-bulk |           0 |      % |
-|                                                 Min Throughput |       prod-queries |      211.26 |  ops/s |
-|                                                Mean Throughput |       prod-queries |      213.85 |  ops/s |
-|                                              Median Throughput |       prod-queries |      213.48 |  ops/s |
-|                                                 Max Throughput |       prod-queries |      216.49 |  ops/s |
-|                                        50th percentile latency |       prod-queries |     3.43393 |     ms |
-|                                        90th percentile latency |       prod-queries |     4.01881 |     ms |
-|                                        99th percentile latency |       prod-queries |     5.56238 |     ms |
-|                                      99.9th percentile latency |       prod-queries |     9.95666 |     ms |
-|                                     99.99th percentile latency |       prod-queries |     39.7922 |     ms |
-|                                       100th percentile latency |       prod-queries |      62.415 |     ms |
-|                                   50th percentile service time |       prod-queries |     3.43405 |     ms |
-|                                   90th percentile service time |       prod-queries |      4.0191 |     ms |
-|                                   99th percentile service time |       prod-queries |     5.56316 |     ms |
-|                                 99.9th percentile service time |       prod-queries |     9.95666 |     ms |
-|                                99.99th percentile service time |       prod-queries |     39.7922 |     ms |
-|                                  100th percentile service time |       prod-queries |      62.415 |     ms |
-|                                                     error rate |       prod-queries |           0 |      % |
+|                                                         Metric |                     Task |       Value |   Unit |
+|---------------------------------------------------------------:|-------------------------:|------------:|-------:|
+|                     Cumulative indexing time of primary shards |                          |     11.7662 |    min |
+|             Min cumulative indexing time across primary shards |                          | 0.000266667 |    min |
+|          Median cumulative indexing time across primary shards |                          |      0.1423 |    min |
+|             Max cumulative indexing time across primary shards |                          |     11.6236 |    min |
+|            Cumulative indexing throttle time of primary shards |                          |           0 |    min |
+|    Min cumulative indexing throttle time across primary shards |                          |           0 |    min |
+| Median cumulative indexing throttle time across primary shards |                          |           0 |    min |
+|    Max cumulative indexing throttle time across primary shards |                          |           0 |    min |
+|                        Cumulative merge time of primary shards |                          |     1.09872 |    min |
+|                       Cumulative merge count of primary shards |                          |          21 |        |
+|                Min cumulative merge time across primary shards |                          |           0 |    min |
+|             Median cumulative merge time across primary shards |                          |     0.00045 |    min |
+|                Max cumulative merge time across primary shards |                          |     1.09827 |    min |
+|               Cumulative merge throttle time of primary shards |                          |    0.872417 |    min |
+|       Min cumulative merge throttle time across primary shards |                          |           0 |    min |
+|    Median cumulative merge throttle time across primary shards |                          |           0 |    min |
+|       Max cumulative merge throttle time across primary shards |                          |    0.872417 |    min |
+|                      Cumulative refresh time of primary shards |                          |    0.113733 |    min |
+|                     Cumulative refresh count of primary shards |                          |          59 |        |
+|              Min cumulative refresh time across primary shards |                          |     0.00235 |    min |
+|           Median cumulative refresh time across primary shards |                          |  0.00516667 |    min |
+|              Max cumulative refresh time across primary shards |                          |    0.106217 |    min |
+|                        Cumulative flush time of primary shards |                          |     0.01685 |    min |
+|                       Cumulative flush count of primary shards |                          |           8 |        |
+|                Min cumulative flush time across primary shards |                          |           0 |    min |
+|             Median cumulative flush time across primary shards |                          |  0.00791667 |    min |
+|                Max cumulative flush time across primary shards |                          |  0.00893333 |    min |
+|                                        Total Young Gen GC time |                          |       5.442 |      s |
+|                                       Total Young Gen GC count |                          |        3739 |        |
+|                                          Total Old Gen GC time |                          |           0 |      s |
+|                                         Total Old Gen GC count |                          |           0 |        |
+|                                                     Store size |                          |      1.3545 |     GB |
+|                                                  Translog size |                          |   0.0304573 |     GB |
+|                                         Heap used for segments |                          |           0 |     MB |
+|                                       Heap used for doc values |                          |           0 |     MB |
+|                                            Heap used for terms |                          |           0 |     MB |
+|                                            Heap used for norms |                          |           0 |     MB |
+|                                           Heap used for points |                          |           0 |     MB |
+|                                    Heap used for stored fields |                          |           0 |     MB |
+|                                                  Segment count |                          |          14 |        |
+|                                                 Min Throughput | custom-vector-bulk-train |     32222.6 | docs/s |
+|                                                Mean Throughput | custom-vector-bulk-train |     32222.6 | docs/s |
+|                                              Median Throughput | custom-vector-bulk-train |     32222.6 | docs/s |
+|                                                 Max Throughput | custom-vector-bulk-train |     32222.6 | docs/s |
+|                                        50th percentile latency | custom-vector-bulk-train |     26.5199 |     ms |
+|                                        90th percentile latency | custom-vector-bulk-train |     34.9823 |     ms |
+|                                        99th percentile latency | custom-vector-bulk-train |     196.712 |     ms |
+|                                       100th percentile latency | custom-vector-bulk-train |     230.342 |     ms |
+|                                   50th percentile service time | custom-vector-bulk-train |     26.5158 |     ms |
+|                                   90th percentile service time | custom-vector-bulk-train |     34.9823 |     ms |
+|                                   99th percentile service time | custom-vector-bulk-train |     196.712 |     ms |
+|                                  100th percentile service time | custom-vector-bulk-train |     230.342 |     ms |
+|                                                     error rate | custom-vector-bulk-train |           0 |      % |
+|                                                 Min Throughput |             delete-model |       10.58 |  ops/s |
+|                                                Mean Throughput |             delete-model |       10.58 |  ops/s |
+|                                              Median Throughput |             delete-model |       10.58 |  ops/s |
+|                                                 Max Throughput |             delete-model |       10.58 |  ops/s |
+|                                       100th percentile latency |             delete-model |     93.6958 |     ms |
+|                                  100th percentile service time |             delete-model |     93.6958 |     ms |
+|                                                     error rate |             delete-model |           0 |      % |
+|                                                 Min Throughput |          train-knn-model |        0.63 |  ops/s |
+|                                                Mean Throughput |          train-knn-model |        0.63 |  ops/s |
+|                                              Median Throughput |          train-knn-model |        0.63 |  ops/s |
+|                                                 Max Throughput |          train-knn-model |        0.63 |  ops/s |
+|                                       100th percentile latency |          train-knn-model |     1577.49 |     ms |
+|                                  100th percentile service time |          train-knn-model |     1577.49 |     ms |
+|                                                     error rate |          train-knn-model |           0 |      % |
+|                                                 Min Throughput |       custom-vector-bulk |       11055 | docs/s |
+|                                                Mean Throughput |       custom-vector-bulk |     14163.8 | docs/s |
+|                                              Median Throughput |       custom-vector-bulk |     12878.9 | docs/s |
+|                                                 Max Throughput |       custom-vector-bulk |     33841.3 | docs/s |
+|                                        50th percentile latency |       custom-vector-bulk |     81.6677 |     ms |
+|                                        90th percentile latency |       custom-vector-bulk |     117.848 |     ms |
+|                                        99th percentile latency |       custom-vector-bulk |     202.484 |     ms |
+|                                      99.9th percentile latency |       custom-vector-bulk |     406.209 |     ms |
+|                                     99.99th percentile latency |       custom-vector-bulk |     458.823 |     ms |
+|                                       100th percentile latency |       custom-vector-bulk |     459.417 |     ms |
+|                                   50th percentile service time |       custom-vector-bulk |     81.6621 |     ms |
+|                                   90th percentile service time |       custom-vector-bulk |     117.843 |     ms |
+|                                   99th percentile service time |       custom-vector-bulk |     202.294 |     ms |
+|                                 99.9th percentile service time |       custom-vector-bulk |     406.209 |     ms |
+|                                99.99th percentile service time |       custom-vector-bulk |     458.823 |     ms |
+|                                  100th percentile service time |       custom-vector-bulk |     459.417 |     ms |
+|                                                     error rate |       custom-vector-bulk |           0 |      % |
+|                                                 Min Throughput |     force-merge-segments |         0.1 |  ops/s |
+|                                                Mean Throughput |     force-merge-segments |         0.1 |  ops/s |
+|                                              Median Throughput |     force-merge-segments |         0.1 |  ops/s |
+|                                                 Max Throughput |     force-merge-segments |         0.1 |  ops/s |
+|                                       100th percentile latency |     force-merge-segments |     10017.4 |     ms |
+|                                  100th percentile service time |     force-merge-segments |     10017.4 |     ms |
+|                                                     error rate |     force-merge-segments |           0 |      % |
+|                                                 Min Throughput |           warmup-indices |        9.63 |  ops/s |
+|                                                Mean Throughput |           warmup-indices |        9.63 |  ops/s |
+|                                              Median Throughput |           warmup-indices |        9.63 |  ops/s |
+|                                                 Max Throughput |           warmup-indices |        9.63 |  ops/s |
+|                                       100th percentile latency |           warmup-indices |     103.228 |     ms |
+|                                  100th percentile service time |           warmup-indices |     103.228 |     ms |
+|                                                     error rate |           warmup-indices |           0 |      % |
+|                                                 Min Throughput |             prod-queries |      120.06 |  ops/s |
+|                                                Mean Throughput |             prod-queries |      120.06 |  ops/s |
+|                                              Median Throughput |             prod-queries |      120.06 |  ops/s |
+|                                                 Max Throughput |             prod-queries |      120.06 |  ops/s |
+|                                        50th percentile latency |             prod-queries |     1.75219 |     ms |
+|                                        90th percentile latency |             prod-queries |     2.29527 |     ms |
+|                                        99th percentile latency |             prod-queries |     50.4419 |     ms |
+|                                       100th percentile latency |             prod-queries |     97.9905 |     ms |
+|                                   50th percentile service time |             prod-queries |     1.75219 |     ms |
+|                                   90th percentile service time |             prod-queries |     2.29527 |     ms |
+|                                   99th percentile service time |             prod-queries |     50.4419 |     ms |
+|                                  100th percentile service time |             prod-queries |     97.9905 |     ms |
+|                                                     error rate |             prod-queries |           0 |      % |
+|                                                  Mean recall@k |             prod-queries |        0.96 |        |
+|                                                  Mean recall@1 |             prod-queries |        0.99 |        |
 
 
 ---------------------------------
-[INFO] SUCCESS (took 119 seconds)
+[INFO] SUCCESS (took 218 seconds)
 ---------------------------------
-
 ```
 
+##### Faiss IVF with Scalar Quantization (100 search queries)
+
+```         
+|                                                         Metric |                     Task |       Value |   Unit |
+|---------------------------------------------------------------:|-------------------------:|------------:|-------:|
+|                     Cumulative indexing time of primary shards |                          |        11.5 |    min |
+|             Min cumulative indexing time across primary shards |                          | 0.000283333 |    min |
+|          Median cumulative indexing time across primary shards |                          |     0.10915 |    min |
+|             Max cumulative indexing time across primary shards |                          |     11.3905 |    min |
+|            Cumulative indexing throttle time of primary shards |                          |           0 |    min |
+|    Min cumulative indexing throttle time across primary shards |                          |           0 |    min |
+| Median cumulative indexing throttle time across primary shards |                          |           0 |    min |
+|    Max cumulative indexing throttle time across primary shards |                          |           0 |    min |
+|                        Cumulative merge time of primary shards |                          |     1.03638 |    min |
+|                       Cumulative merge count of primary shards |                          |          22 |        |
+|                Min cumulative merge time across primary shards |                          |           0 |    min |
+|             Median cumulative merge time across primary shards |                          | 0.000266667 |    min |
+|                Max cumulative merge time across primary shards |                          |     1.03612 |    min |
+|               Cumulative merge throttle time of primary shards |                          |    0.798767 |    min |
+|       Min cumulative merge throttle time across primary shards |                          |           0 |    min |
+|    Median cumulative merge throttle time across primary shards |                          |           0 |    min |
+|       Max cumulative merge throttle time across primary shards |                          |    0.798767 |    min |
+|                      Cumulative refresh time of primary shards |                          |    0.107117 |    min |
+|                     Cumulative refresh count of primary shards |                          |          61 |        |
+|              Min cumulative refresh time across primary shards |                          |  0.00236667 |    min |
+|           Median cumulative refresh time across primary shards |                          |  0.00543333 |    min |
+|              Max cumulative refresh time across primary shards |                          |   0.0993167 |    min |
+|                        Cumulative flush time of primary shards |                          |   0.0193167 |    min |
+|                       Cumulative flush count of primary shards |                          |           9 |        |
+|                Min cumulative flush time across primary shards |                          |           0 |    min |
+|             Median cumulative flush time across primary shards |                          |  0.00871667 |    min |
+|                Max cumulative flush time across primary shards |                          |      0.0106 |    min |
+|                                        Total Young Gen GC time |                          |       5.267 |      s |
+|                                       Total Young Gen GC count |                          |        3688 |        |
+|                                          Total Old Gen GC time |                          |           0 |      s |
+|                                         Total Old Gen GC count |                          |           0 |        |
+|                                                     Store size |                          |     1.11609 |     GB |
+|                                                  Translog size |                          |   0.0304573 |     GB |
+|                                         Heap used for segments |                          |           0 |     MB |
+|                                       Heap used for doc values |                          |           0 |     MB |
+|                                            Heap used for terms |                          |           0 |     MB |
+|                                            Heap used for norms |                          |           0 |     MB |
+|                                           Heap used for points |                          |           0 |     MB |
+|                                    Heap used for stored fields |                          |           0 |     MB |
+|                                                  Segment count |                          |          18 |        |
+|                                                 Min Throughput | custom-vector-bulk-train |     35950.5 | docs/s |
+|                                                Mean Throughput | custom-vector-bulk-train |     35950.5 | docs/s |
+|                                              Median Throughput | custom-vector-bulk-train |     35950.5 | docs/s |
+|                                                 Max Throughput | custom-vector-bulk-train |     35950.5 | docs/s |
+|                                        50th percentile latency | custom-vector-bulk-train |     22.8328 |     ms |
+|                                        90th percentile latency | custom-vector-bulk-train |      34.864 |     ms |
+|                                        99th percentile latency | custom-vector-bulk-train |      99.471 |     ms |
+|                                       100th percentile latency | custom-vector-bulk-train |     210.424 |     ms |
+|                                   50th percentile service time | custom-vector-bulk-train |      22.823 |     ms |
+|                                   90th percentile service time | custom-vector-bulk-train |      34.864 |     ms |
+|                                   99th percentile service time | custom-vector-bulk-train |      99.471 |     ms |
+|                                  100th percentile service time | custom-vector-bulk-train |     210.424 |     ms |
+|                                                     error rate | custom-vector-bulk-train |           0 |      % |
+|                                                 Min Throughput |             delete-model |        8.39 |  ops/s |
+|                                                Mean Throughput |             delete-model |        8.39 |  ops/s |
+|                                              Median Throughput |             delete-model |        8.39 |  ops/s |
+|                                                 Max Throughput |             delete-model |        8.39 |  ops/s |
+|                                       100th percentile latency |             delete-model |     118.241 |     ms |
+|                                  100th percentile service time |             delete-model |     118.241 |     ms |
+|                                                     error rate |             delete-model |           0 |      % |
+|                                                 Min Throughput |          train-knn-model |        0.64 |  ops/s |
+|                                                Mean Throughput |          train-knn-model |        0.64 |  ops/s |
+|                                              Median Throughput |          train-knn-model |        0.64 |  ops/s |
+|                                                 Max Throughput |          train-knn-model |        0.64 |  ops/s |
+|                                       100th percentile latency |          train-knn-model |     1564.44 |     ms |
+|                                  100th percentile service time |          train-knn-model |     1564.44 |     ms |
+|                                                     error rate |          train-knn-model |           0 |      % |
+|                                                 Min Throughput |       custom-vector-bulk |     11313.1 | docs/s |
+|                                                Mean Throughput |       custom-vector-bulk |     14065.7 | docs/s |
+|                                              Median Throughput |       custom-vector-bulk |     12894.8 | docs/s |
+|                                                 Max Throughput |       custom-vector-bulk |     30050.8 | docs/s |
+|                                        50th percentile latency |       custom-vector-bulk |     81.4293 |     ms |
+|                                        90th percentile latency |       custom-vector-bulk |     111.812 |     ms |
+|                                        99th percentile latency |       custom-vector-bulk |      196.45 |     ms |
+|                                      99.9th percentile latency |       custom-vector-bulk |     370.543 |     ms |
+|                                     99.99th percentile latency |       custom-vector-bulk |     474.156 |     ms |
+|                                       100th percentile latency |       custom-vector-bulk |     499.048 |     ms |
+|                                   50th percentile service time |       custom-vector-bulk |     81.4235 |     ms |
+|                                   90th percentile service time |       custom-vector-bulk |     111.833 |     ms |
+|                                   99th percentile service time |       custom-vector-bulk |     197.125 |     ms |
+|                                 99.9th percentile service time |       custom-vector-bulk |     370.543 |     ms |
+|                                99.99th percentile service time |       custom-vector-bulk |     474.156 |     ms |
+|                                  100th percentile service time |       custom-vector-bulk |     499.048 |     ms |
+|                                                     error rate |       custom-vector-bulk |           0 |      % |
+|                                                 Min Throughput |     force-merge-segments |         0.1 |  ops/s |
+|                                                Mean Throughput |     force-merge-segments |         0.1 |  ops/s |
+|                                              Median Throughput |     force-merge-segments |         0.1 |  ops/s |
+|                                                 Max Throughput |     force-merge-segments |         0.1 |  ops/s |
+|                                       100th percentile latency |     force-merge-segments |     10015.2 |     ms |
+|                                  100th percentile service time |     force-merge-segments |     10015.2 |     ms |
+|                                                     error rate |     force-merge-segments |           0 |      % |
+|                                                 Min Throughput |           warmup-indices |          19 |  ops/s |
+|                                                Mean Throughput |           warmup-indices |          19 |  ops/s |
+|                                              Median Throughput |           warmup-indices |          19 |  ops/s |
+|                                                 Max Throughput |           warmup-indices |          19 |  ops/s |
+|                                       100th percentile latency |           warmup-indices |     52.1685 |     ms |
+|                                  100th percentile service time |           warmup-indices |     52.1685 |     ms |
+|                                                     error rate |           warmup-indices |           0 |      % |
+|                                                 Min Throughput |             prod-queries |      159.49 |  ops/s |
+|                                                Mean Throughput |             prod-queries |      159.49 |  ops/s |
+|                                              Median Throughput |             prod-queries |      159.49 |  ops/s |
+|                                                 Max Throughput |             prod-queries |      159.49 |  ops/s |
+|                                        50th percentile latency |             prod-queries |     1.92377 |     ms |
+|                                        90th percentile latency |             prod-queries |     2.63867 |     ms |
+|                                        99th percentile latency |             prod-queries |      48.513 |     ms |
+|                                       100th percentile latency |             prod-queries |      90.543 |     ms |
+|                                   50th percentile service time |             prod-queries |     1.92377 |     ms |
+|                                   90th percentile service time |             prod-queries |     2.63867 |     ms |
+|                                   99th percentile service time |             prod-queries |      48.513 |     ms |
+|                                  100th percentile service time |             prod-queries |      90.543 |     ms |
+|                                                     error rate |             prod-queries |           0 |      % |
+|                                                  Mean recall@k |             prod-queries |        0.96 |        |
+|                                                  Mean recall@1 |             prod-queries |        0.98 |        |
+
+
+---------------------------------
+[INFO] SUCCESS (took 218 seconds)
+---------------------------------
+```
+
+##### Faiss IVF with Product Quantization (100 search queries)
+```            
+|                                                         Metric |                     Task |       Value |   Unit |
+|---------------------------------------------------------------:|-------------------------:|------------:|-------:|
+|                     Cumulative indexing time of primary shards |                          |     11.3862 |    min |
+|             Min cumulative indexing time across primary shards |                          |      0.0003 |    min |
+|          Median cumulative indexing time across primary shards |                          |     0.12735 |    min |
+|             Max cumulative indexing time across primary shards |                          |     11.2586 |    min |
+|            Cumulative indexing throttle time of primary shards |                          |           0 |    min |
+|    Min cumulative indexing throttle time across primary shards |                          |           0 |    min |
+| Median cumulative indexing throttle time across primary shards |                          |           0 |    min |
+|    Max cumulative indexing throttle time across primary shards |                          |           0 |    min |
+|                        Cumulative merge time of primary shards |                          |     1.50842 |    min |
+|                       Cumulative merge count of primary shards |                          |          19 |        |
+|                Min cumulative merge time across primary shards |                          |           0 |    min |
+|             Median cumulative merge time across primary shards |                          | 0.000233333 |    min |
+|                Max cumulative merge time across primary shards |                          |     1.50818 |    min |
+|               Cumulative merge throttle time of primary shards |                          |     0.58095 |    min |
+|       Min cumulative merge throttle time across primary shards |                          |           0 |    min |
+|    Median cumulative merge throttle time across primary shards |                          |           0 |    min |
+|       Max cumulative merge throttle time across primary shards |                          |     0.58095 |    min |
+|                      Cumulative refresh time of primary shards |                          |      0.2059 |    min |
+|                     Cumulative refresh count of primary shards |                          |          61 |        |
+|              Min cumulative refresh time across primary shards |                          |  0.00238333 |    min |
+|           Median cumulative refresh time across primary shards |                          |  0.00526667 |    min |
+|              Max cumulative refresh time across primary shards |                          |     0.19825 |    min |
+|                        Cumulative flush time of primary shards |                          |   0.0254667 |    min |
+|                       Cumulative flush count of primary shards |                          |          10 |        |
+|                Min cumulative flush time across primary shards |                          |           0 |    min |
+|             Median cumulative flush time across primary shards |                          |   0.0118333 |    min |
+|                Max cumulative flush time across primary shards |                          |   0.0136333 |    min |
+|                                        Total Young Gen GC time |                          |       6.477 |      s |
+|                                       Total Young Gen GC count |                          |        3565 |        |
+|                                          Total Old Gen GC time |                          |           0 |      s |
+|                                         Total Old Gen GC count |                          |           0 |        |
+|                                                     Store size |                          |    0.892541 |     GB |
+|                                                  Translog size |                          |   0.0304573 |     GB |
+|                                         Heap used for segments |                          |           0 |     MB |
+|                                       Heap used for doc values |                          |           0 |     MB |
+|                                            Heap used for terms |                          |           0 |     MB |
+|                                            Heap used for norms |                          |           0 |     MB |
+|                                           Heap used for points |                          |           0 |     MB |
+|                                    Heap used for stored fields |                          |           0 |     MB |
+|                                                  Segment count |                          |          21 |        |
+|                                                 Min Throughput | custom-vector-bulk-train |       31931 | docs/s |
+|                                                Mean Throughput | custom-vector-bulk-train |       31931 | docs/s |
+|                                              Median Throughput | custom-vector-bulk-train |       31931 | docs/s |
+|                                                 Max Throughput | custom-vector-bulk-train |       31931 | docs/s |
+|                                        50th percentile latency | custom-vector-bulk-train |     25.3297 |     ms |
+|                                        90th percentile latency | custom-vector-bulk-train |     35.3864 |     ms |
+|                                        99th percentile latency | custom-vector-bulk-train |     144.372 |     ms |
+|                                       100th percentile latency | custom-vector-bulk-train |      209.37 |     ms |
+|                                   50th percentile service time | custom-vector-bulk-train |     25.3226 |     ms |
+|                                   90th percentile service time | custom-vector-bulk-train |     35.3864 |     ms |
+|                                   99th percentile service time | custom-vector-bulk-train |     144.372 |     ms |
+|                                  100th percentile service time | custom-vector-bulk-train |      209.37 |     ms |
+|                                                     error rate | custom-vector-bulk-train |           0 |      % |
+|                                                 Min Throughput |             delete-model |        8.65 |  ops/s |
+|                                                Mean Throughput |             delete-model |        8.65 |  ops/s |
+|                                              Median Throughput |             delete-model |        8.65 |  ops/s |
+|                                                 Max Throughput |             delete-model |        8.65 |  ops/s |
+|                                       100th percentile latency |             delete-model |     114.725 |     ms |
+|                                  100th percentile service time |             delete-model |     114.725 |     ms |
+|                                                     error rate |             delete-model |           0 |      % |
+|                                                 Min Throughput |          train-knn-model |        0.03 |  ops/s |
+|                                                Mean Throughput |          train-knn-model |        0.03 |  ops/s |
+|                                              Median Throughput |          train-knn-model |        0.03 |  ops/s |
+|                                                 Max Throughput |          train-knn-model |        0.03 |  ops/s |
+|                                       100th percentile latency |          train-knn-model |     37222.2 |     ms |
+|                                  100th percentile service time |          train-knn-model |     37222.2 |     ms |
+|                                                     error rate |          train-knn-model |           0 |      % |
+|                                                 Min Throughput |       custom-vector-bulk |     10669.3 | docs/s |
+|                                                Mean Throughput |       custom-vector-bulk |     14468.6 | docs/s |
+|                                              Median Throughput |       custom-vector-bulk |     12496.1 | docs/s |
+|                                                 Max Throughput |       custom-vector-bulk |     35027.8 | docs/s |
+|                                        50th percentile latency |       custom-vector-bulk |     74.2584 |     ms |
+|                                        90th percentile latency |       custom-vector-bulk |     113.426 |     ms |
+|                                        99th percentile latency |       custom-vector-bulk |     293.075 |     ms |
+|                                      99.9th percentile latency |       custom-vector-bulk |     1774.41 |     ms |
+|                                     99.99th percentile latency |       custom-vector-bulk |     1969.99 |     ms |
+|                                       100th percentile latency |       custom-vector-bulk |     1971.29 |     ms |
+|                                   50th percentile service time |       custom-vector-bulk |     74.2577 |     ms |
+|                                   90th percentile service time |       custom-vector-bulk |     113.477 |     ms |
+|                                   99th percentile service time |       custom-vector-bulk |     292.481 |     ms |
+|                                 99.9th percentile service time |       custom-vector-bulk |     1774.41 |     ms |
+|                                99.99th percentile service time |       custom-vector-bulk |     1969.99 |     ms |
+|                                  100th percentile service time |       custom-vector-bulk |     1971.29 |     ms |
+|                                                     error rate |       custom-vector-bulk |           0 |      % |
+|                                                 Min Throughput |     force-merge-segments |        0.05 |  ops/s |
+|                                                Mean Throughput |     force-merge-segments |        0.05 |  ops/s |
+|                                              Median Throughput |     force-merge-segments |        0.05 |  ops/s |
+|                                                 Max Throughput |     force-merge-segments |        0.05 |  ops/s |
+|                                       100th percentile latency |     force-merge-segments |     20015.2 |     ms |
+|                                  100th percentile service time |     force-merge-segments |     20015.2 |     ms |
+|                                                     error rate |     force-merge-segments |           0 |      % |
+|                                                 Min Throughput |           warmup-indices |       47.06 |  ops/s |
+|                                                Mean Throughput |           warmup-indices |       47.06 |  ops/s |
+|                                              Median Throughput |           warmup-indices |       47.06 |  ops/s |
+|                                                 Max Throughput |           warmup-indices |       47.06 |  ops/s |
+|                                       100th percentile latency |           warmup-indices |     20.6798 |     ms |
+|                                  100th percentile service time |           warmup-indices |     20.6798 |     ms |
+|                                                     error rate |           warmup-indices |           0 |      % |
+|                                                 Min Throughput |             prod-queries |       87.76 |  ops/s |
+|                                                Mean Throughput |             prod-queries |       87.76 |  ops/s |
+|                                              Median Throughput |             prod-queries |       87.76 |  ops/s |
+|                                                 Max Throughput |             prod-queries |       87.76 |  ops/s |
+|                                        50th percentile latency |             prod-queries |     1.81677 |     ms |
+|                                        90th percentile latency |             prod-queries |     2.80454 |     ms |
+|                                        99th percentile latency |             prod-queries |     51.2039 |     ms |
+|                                       100th percentile latency |             prod-queries |     98.2032 |     ms |
+|                                   50th percentile service time |             prod-queries |     1.81677 |     ms |
+|                                   90th percentile service time |             prod-queries |     2.80454 |     ms |
+|                                   99th percentile service time |             prod-queries |     51.2039 |     ms |
+|                                  100th percentile service time |             prod-queries |     98.2032 |     ms |
+|                                                     error rate |             prod-queries |           0 |      % |
+|                                                  Mean recall@k |             prod-queries |        0.62 |        |
+|                                                  Mean recall@1 |             prod-queries |        0.52 |        |
+
+---------------------------------
+[INFO] SUCCESS (took 413 seconds)
+---------------------------------
+```
 
 ### Custom Runners
 

--- a/vectorsearch/indices/faiss-index.json
+++ b/vectorsearch/indices/faiss-index.json
@@ -21,6 +21,9 @@
         "target_field": {
           "type": "knn_vector",
           "dimension": {{ target_index_dimension }},
+          {%- if train_model_id is defined %}
+          "model_id": "{{ train_model_id }}"
+          {%- else %}
           "method": {
             "name": "hnsw",
             "space_type": "{{ target_index_space_type }}",
@@ -43,6 +46,7 @@
               {%- endif %}
             }
           }
+          {%- endif %}
         }
       }
     }

--- a/vectorsearch/params/train/train-faiss-sift-128-l2-pq.json
+++ b/vectorsearch/params/train/train-faiss-sift-128-l2-pq.json
@@ -21,7 +21,7 @@
     "train_index_bulk_index_data_set_format": "hdf5",
     "train_index_bulk_index_data_set_path": "/tmp/sift-128-euclidean.hdf5",
     "train_index_bulk_indexing_clients": 10,
-    "train_index_num_vectors": 1000,
+    "train_index_num_vectors": 50000,
     
     "train_model_id": "test-model",
     "train_operation_retries": 100,
@@ -29,8 +29,10 @@
     "train_search_size": 10000,
     
     "encoder": "pq",
-    "faiss_encoder_code_size": 2,
-    "faiss_encoder_m": 4,
+    "faiss_encoder_code_size": 8,
+    "faiss_encoder_m": 16,
+    "faiss_nlist": 128,
+    "faiss_nprobes": 8,
 
     "target_index_max_num_segments": 1,
     "target_index_force_merge_timeout": 300,

--- a/vectorsearch/params/train/train-faiss-sift-128-l2-pq.json
+++ b/vectorsearch/params/train/train-faiss-sift-128-l2-pq.json
@@ -36,8 +36,7 @@
 
     "target_index_max_num_segments": 1,
     "target_index_force_merge_timeout": 300,
-    "hnsw_ef_search": 100,
-    "hnsw_ef_construction": 100,
+    
     "query_k": 100,
     "query_body": {
          "docvalue_fields" : ["_id"],

--- a/vectorsearch/params/train/train-faiss-sift-128-l2-pq.json
+++ b/vectorsearch/params/train/train-faiss-sift-128-l2-pq.json
@@ -29,10 +29,10 @@
     "train_search_size": 10000,
     
     "encoder": "pq",
-    "faiss_encoder_code_size": 8,
-    "faiss_encoder_m": 16,
-    "faiss_nlist": 128,
-    "faiss_nprobes": 8,
+    "pq_encoder_code_size": 8,
+    "pq_encoder_m": 16,
+    "nlist": 128,
+    "nprobes": 8,
 
     "target_index_max_num_segments": 1,
     "target_index_force_merge_timeout": 300,

--- a/vectorsearch/params/train/train-faiss-sift-128-l2-pq.json
+++ b/vectorsearch/params/train/train-faiss-sift-128-l2-pq.json
@@ -46,5 +46,5 @@
 
     "query_data_set_format": "hdf5",
     "query_data_set_path":"/tmp/sift-128-euclidean.hdf5",
-    "query_count": 100
+    "query_count": 10000
   }

--- a/vectorsearch/params/train/train-faiss-sift-128-l2-sq.json
+++ b/vectorsearch/params/train/train-faiss-sift-128-l2-sq.json
@@ -29,10 +29,10 @@
     "train_search_size": 10000,
     
     "encoder": "sq",
-    "faiss_encoder_type": "fp16",
-    "faiss_encoder_clip": false,
-    "faiss_nlist": 128,
-    "faiss_nprobes": 8,
+    "encoder_type": "fp16",
+    "encoder_clip": false,
+    "nlist": 128,
+    "nprobes": 8,
 
     "target_index_max_num_segments": 1,
     "target_index_force_merge_timeout": 300,

--- a/vectorsearch/params/train/train-faiss-sift-128-l2-sq.json
+++ b/vectorsearch/params/train/train-faiss-sift-128-l2-sq.json
@@ -31,6 +31,8 @@
     "encoder": "sq",
     "faiss_encoder_type": "fp16",
     "faiss_encoder_clip": false,
+    "faiss_nlist": 128,
+    "faiss_nprobes": 8,
 
     "target_index_max_num_segments": 1,
     "target_index_force_merge_timeout": 300,
@@ -44,5 +46,5 @@
 
     "query_data_set_format": "hdf5",
     "query_data_set_path":"/tmp/sift-128-euclidean.hdf5",
-    "query_count": 100
+    "query_count": 10000
   }

--- a/vectorsearch/params/train/train-faiss-sift-128-l2-sq.json
+++ b/vectorsearch/params/train/train-faiss-sift-128-l2-sq.json
@@ -21,7 +21,7 @@
     "train_index_bulk_index_data_set_format": "hdf5",
     "train_index_bulk_index_data_set_path": "/tmp/sift-128-euclidean.hdf5",
     "train_index_bulk_indexing_clients": 10,
-    "train_index_num_vectors": 1000,
+    "train_index_num_vectors": 50000,
     
     "train_model_id": "test-model",
     "train_operation_retries": 100,

--- a/vectorsearch/params/train/train-faiss-sift-128-l2-sq.json
+++ b/vectorsearch/params/train/train-faiss-sift-128-l2-sq.json
@@ -36,8 +36,7 @@
 
     "target_index_max_num_segments": 1,
     "target_index_force_merge_timeout": 300,
-    "hnsw_ef_search": 100,
-    "hnsw_ef_construction": 100,
+
     "query_k": 100,
     "query_body": {
          "docvalue_fields" : ["_id"],

--- a/vectorsearch/params/train/train-faiss-sift-128-l2.json
+++ b/vectorsearch/params/train/train-faiss-sift-128-l2.json
@@ -21,7 +21,7 @@
     "train_index_bulk_index_data_set_format": "hdf5",
     "train_index_bulk_index_data_set_path": "/tmp/sift-128-euclidean.hdf5",
     "train_index_bulk_indexing_clients": 10,
-    "train_index_num_vectors": 1000,
+    "train_index_num_vectors": 50000,
     
     "train_model_id": "test-model",
     "train_operation_retries": 100,

--- a/vectorsearch/params/train/train-faiss-sift-128-l2.json
+++ b/vectorsearch/params/train/train-faiss-sift-128-l2.json
@@ -27,6 +27,9 @@
     "train_operation_retries": 100,
     "train_operation_poll_period": 0.5,
     "train_search_size": 10000,
+
+    "faiss_nlist": 128,
+    "faiss_nprobes": 8,
      
     "target_index_max_num_segments": 1,
     "target_index_force_merge_timeout": 300,
@@ -40,5 +43,5 @@
 
     "query_data_set_format": "hdf5",
     "query_data_set_path":"/tmp/sift-128-euclidean.hdf5",
-    "query_count": 100
+    "query_count": 10000
   }

--- a/vectorsearch/params/train/train-faiss-sift-128-l2.json
+++ b/vectorsearch/params/train/train-faiss-sift-128-l2.json
@@ -33,8 +33,7 @@
      
     "target_index_max_num_segments": 1,
     "target_index_force_merge_timeout": 300,
-    "hnsw_ef_search": 100,
-    "hnsw_ef_construction": 100,
+
     "query_k": 100,
     "query_body": {
          "docvalue_fields" : ["_id"],

--- a/vectorsearch/params/train/train-faiss-sift-128-l2.json
+++ b/vectorsearch/params/train/train-faiss-sift-128-l2.json
@@ -28,8 +28,8 @@
     "train_operation_poll_period": 0.5,
     "train_search_size": 10000,
 
-    "faiss_nlist": 128,
-    "faiss_nprobes": 8,
+    "nlist": 128,
+    "nprobes": 8,
      
     "target_index_max_num_segments": 1,
     "target_index_force_merge_timeout": 300,

--- a/vectorsearch/test_procedures/common/train-model-schedule.json
+++ b/vectorsearch/test_procedures/common/train-model-schedule.json
@@ -103,8 +103,4 @@
         "has_attributes": 0
     },
     "clients": {{ target_index_bulk_indexing_clients | default(1)}}
-},
-{
-    "name" : "refresh-target-index",
-    "operation" : "refresh-target-index"
 }

--- a/vectorsearch/test_procedures/common/train-model-schedule.json
+++ b/vectorsearch/test_procedures/common/train-model-schedule.json
@@ -1,5 +1,13 @@
 {
     "operation": {
+        "name": "possibly-delete-target-index-before-model-train",
+        "operation-type": "delete-index",
+        "only-if-exists": true,
+        "index": "{{ target_index_name | default('target_index') }}"
+    }
+},
+{
+    "operation": {
         "operation-type": "delete-knn-model",
         "name": "delete-model",
         "model_id": "{{ train_model_id }}",

--- a/vectorsearch/test_procedures/common/train-model-schedule.json
+++ b/vectorsearch/test_procedures/common/train-model-schedule.json
@@ -33,32 +33,32 @@
                 "engine": "{{ train_method_engine | default('faiss') }}",
                 "space_type": "{{ target_index_space_type | default('l2') }}", 
                 "parameters": {
-                        {%- if faiss_nlist is defined and faiss_nlist %}
-                        {{ train_knn_model_comma() }} "nlist": {{ faiss_nlist }}
+                        {%- if nlist is defined and nlist %}
+                        {{ train_knn_model_comma() }} "nlist": {{ nlist }}
                         {%- endif %}
 
-                        {%- if faiss_nprobes is defined and faiss_nprobes %}
-                        {{ train_knn_model_comma() }} "nprobes": {{ faiss_nprobes}} 
+                        {%- if nprobes is defined and nprobes %}
+                        {{ train_knn_model_comma() }} "nprobes": {{ nprobes}} 
                         {%- endif %}
 
                         {%- if encoder is defined and encoder %}
                         {{ train_knn_model_comma() }} "encoder": {
                             "name": "{{ encoder }}",
                             "parameters": {
-                                {%- if faiss_encoder_code_size is defined and faiss_encoder_code_size %}
-                                    {{ train_knn_model_encoder_comma() }} "code_size": {{ faiss_encoder_code_size }}
+                                {%- if pq_encoder_code_size is defined and pq_encoder_code_size %}
+                                    {{ train_knn_model_encoder_comma() }} "code_size": {{ pq_encoder_code_size }}
                                 {%- endif %}
                                 
-                                {%- if faiss_encoder_m is defined and faiss_encoder_m %}
-                                    {{ train_knn_model_encoder_comma() }} "m": {{ faiss_encoder_m }}
+                                {%- if pq_encoder_m is defined and pq_encoder_m %}
+                                    {{ train_knn_model_encoder_comma() }} "m": {{ pq_encoder_m }}
                                 {%- endif %}
 
-                                {%- if faiss_encoder_type is defined and faiss_encoder_type %}
-                                    {{ train_knn_model_encoder_comma() }} "type": "{{ faiss_encoder_type }}"
+                                {%- if encoder_type is defined and encoder_type %}
+                                    {{ train_knn_model_encoder_comma() }} "type": "{{ encoder_type }}"
                                 {%- endif %}
 
-                                {%- if faiss_encoder_clip is defined and faiss_encoder_clip %}
-                                    {{ train_knn_model_encoder_comma() }} "clip": "{{ faiss_encoder_clip }}"
+                                {%- if encoder_clip is defined and encoder_clip %}
+                                    {{ train_knn_model_encoder_comma() }} "clip": "{{ encoder_clip }}"
                                 {%- endif %}
                             }
                         }

--- a/vectorsearch/test_procedures/common/train-model-schedule.json
+++ b/vectorsearch/test_procedures/common/train-model-schedule.json
@@ -1,3 +1,5 @@
+{% set train_knn_model_comma = joiner(",") %}
+{% set train_knn_model_encoder_comma = joiner(",") %}
 {
     "operation": {
         "name": "delete-target-index-before-model-training",
@@ -32,43 +34,31 @@
                 "space_type": "{{ target_index_space_type | default('l2') }}", 
                 "parameters": {
                         {%- if faiss_nlist is defined and faiss_nlist %}
-                        "nlist": {{ faiss_nlist }}
+                        {{ train_knn_model_comma() }} "nlist": {{ faiss_nlist }}
                         {%- endif %}
 
                         {%- if faiss_nprobes is defined and faiss_nprobes %}
-                            {%- if faiss_nlist is defined and faiss_nlist %}
-                        ,
-                            {%- endif %}
-                        "nprobes": {{ faiss_nprobes}} 
+                        {{ train_knn_model_comma() }} "nprobes": {{ faiss_nprobes}} 
                         {%- endif %}
 
                         {%- if encoder is defined and encoder %}
-                            {%- if faiss_nprobes is defined and faiss_nprobes %} 
-                            ,
-                            {%- endif %}
-                        "encoder": {
+                        {{ train_knn_model_comma() }} "encoder": {
                             "name": "{{ encoder }}",
                             "parameters": {
                                 {%- if faiss_encoder_code_size is defined and faiss_encoder_code_size %}
-                                    "code_size": {{ faiss_encoder_code_size }}
+                                    {{ train_knn_model_encoder_comma() }} "code_size": {{ faiss_encoder_code_size }}
                                 {%- endif %}
                                 
                                 {%- if faiss_encoder_m is defined and faiss_encoder_m %}
-                                    {%- if faiss_encoder_code_size is defined and faiss_encoder_code_size %}
-                                        ,
-                                    {%- endif %}
-                                    "m": {{ faiss_encoder_m }}
+                                    {{ train_knn_model_encoder_comma() }} "m": {{ faiss_encoder_m }}
                                 {%- endif %}
 
                                 {%- if faiss_encoder_type is defined and faiss_encoder_type %}
-                                    "type": "{{ faiss_encoder_type }}"
+                                    {{ train_knn_model_encoder_comma() }} "type": "{{ faiss_encoder_type }}"
                                 {%- endif %}
 
                                 {%- if faiss_encoder_clip is defined and faiss_encoder_clip %}
-                                    {%- if faiss_encoder_type is defined and faiss_encoder_type %}
-                                        ,
-                                    {%- endif %}
-                                    "clip": "{{ faiss_encoder_clip }}"
+                                    {{ train_knn_model_encoder_comma() }} "clip": "{{ faiss_encoder_clip }}"
                                 {%- endif %}
                             }
                         }

--- a/vectorsearch/test_procedures/common/train-model-schedule.json
+++ b/vectorsearch/test_procedures/common/train-model-schedule.json
@@ -1,6 +1,6 @@
 {
     "operation": {
-        "name": "possibly-delete-target-index-before-model-train",
+        "name": "delete-target-index-before-model-training",
         "operation-type": "delete-index",
         "only-if-exists": true,
         "index": "{{ target_index_name | default('target_index') }}"
@@ -37,7 +37,7 @@
 
                         {%- if faiss_nprobes is defined and faiss_nprobes %}
                             {%- if faiss_nlist is defined and faiss_nlist %}
-                            ,
+                        ,
                             {%- endif %}
                         "nprobes": {{ faiss_nprobes}} 
                         {%- endif %}
@@ -80,4 +80,31 @@
         "retries": {{ train_operation_retries | default(1000) }}, 
         "poll_period": {{ train_operation_poll_period | default(0.5) }}
     }
+},
+{
+    "operation": {
+        "name": "create-target-index",
+        "operation-type": "create-index",
+        "index": "{{ target_index_name | default('target_index') }}"
+    }
+},
+{
+    "operation": {
+        "name": "custom-vector-bulk",
+        "operation-type": "bulk-vector-data-set",
+        "index": "{{ target_index_name | default('target_index') }}",
+        "field": "{{ target_field_name | default('target_field') }}",
+        "bulk_size": {{ target_index_bulk_size | default(500)}},
+        "data_set_format": "{{ target_index_bulk_index_data_set_format | default('hdf5') }}",
+        "data_set_path": "{{ target_index_bulk_index_data_set_path  }}",
+        "data_set_corpus": "{{ target_index_bulk_index_data_set_corpus  }}",
+        "num_vectors": {{ target_index_num_vectors | default(-1) }},
+        "id-field-name": "{{ id_field_name }}",
+        "has_attributes": 0
+    },
+    "clients": {{ target_index_bulk_indexing_clients | default(1)}}
+},
+{
+    "name" : "refresh-target-index",
+    "operation" : "refresh-target-index"
 }

--- a/vectorsearch/test_procedures/default.json
+++ b/vectorsearch/test_procedures/default.json
@@ -56,7 +56,7 @@
     "schedule": [
         {{ benchmark.collect(parts="common/train-index-only-schedule.json") }},
         {{ benchmark.collect(parts="common/train-model-schedule.json") }},
-        {{ benchmark.collect(parts="common/index-only-schedule.json") }},
+        {{ benchmark.collect(parts="common/force-merge-schedule.json") }},
         {{ benchmark.collect(parts="common/search-only-schedule.json") }}
     ]
 }

--- a/vectorsearch/test_procedures/default.json
+++ b/vectorsearch/test_procedures/default.json
@@ -4,6 +4,7 @@
     "default": true,
     "schedule": [
        {{ benchmark.collect(parts="common/index-only-schedule.json") }},
+       {{ benchmark.collect(parts="common/force-merge-schedule.json") }},
        {{ benchmark.collect(parts="common/search-only-schedule.json") }}
     ]
 },

--- a/vectorsearch/test_procedures/default.json
+++ b/vectorsearch/test_procedures/default.json
@@ -4,7 +4,6 @@
     "default": true,
     "schedule": [
        {{ benchmark.collect(parts="common/index-only-schedule.json") }},
-       {{ benchmark.collect(parts="common/force-merge-schedule.json") }},
        {{ benchmark.collect(parts="common/search-only-schedule.json") }}
     ]
 },
@@ -56,8 +55,8 @@
     "default": false,
     "schedule": [
         {{ benchmark.collect(parts="common/train-index-only-schedule.json") }},
-        {{ benchmark.collect(parts="common/index-only-schedule.json") }},
         {{ benchmark.collect(parts="common/train-model-schedule.json") }},
+        {{ benchmark.collect(parts="common/index-only-schedule.json") }},
         {{ benchmark.collect(parts="common/search-only-schedule.json") }}
     ]
 }


### PR DESCRIPTION
### Description
Currently the `train-test` procedure in vectorsearch runs steps in the incorrect order. This PR fixes that by only creating the target index after model training is complete, which allows the target index segments to be built by the model. Additionally this PR changes the training parameters to be the same as k-NN's `perf-tool` utility. 

### Testing
Integration tests running at: https://github.com/finnroblin/opensearch-benchmark/actions/runs/10152043240

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
