### PR TITLE
Add HNSW PQ train procedure

### DIFF
--- a/vectorsearch/params/train/train-faiss-sift-128-hnsw-pq.json
+++ b/vectorsearch/params/train/train-faiss-sift-128-hnsw-pq.json
@@ -1,0 +1,50 @@
+{
+    "target_index_name": "target_index",
+    "target_field_name": "target_field",
+    "target_index_body": "indices/faiss-index.json",
+    "target_index_primary_shards": 1,
+    "target_index_dimension": 128,
+    "target_index_space_type": "l2",
+    "target_index_bulk_size": 100,
+    "target_index_bulk_index_data_set_format": "hdf5",
+    "target_index_bulk_index_data_set_path": "/tmp/sift-128-euclidean.hdf5",
+    "target_index_bulk_indexing_clients": 10,
+    
+    "train_index_name": "train_index",
+    "train_field_name": "train_field",
+    "train_method_engine": "faiss",
+    "train_index_body": "indices/train-index.json",
+    "train_index_primary_shards": 1,
+    "train_index_replica_shards": 1, 
+
+    "train_index_bulk_size": 100,
+    "train_index_bulk_index_data_set_format": "hdf5",
+    "train_index_bulk_index_data_set_path": "/tmp/sift-128-euclidean.hdf5",
+    "train_index_bulk_indexing_clients": 10,
+    "train_index_num_vectors": 50000,
+    
+    "train_model_id": "test-model",
+    "train_operation_retries": 100,
+    "train_operation_poll_period": 0.5,
+    "train_search_size": 10000,
+    "train_method_name": "hnsw",
+    
+    "encoder": "pq",
+    "faiss_encoder_code_size": 8,
+    "faiss_encoder_m": 16,
+
+    "target_index_max_num_segments": 1,
+    "target_index_force_merge_timeout": 300,
+    "hnsw_ef_search": 256,
+    "hnsw_ef_construction": 256,
+    "hnsw_m": 16,
+    "query_k": 100,
+    "query_body": {
+         "docvalue_fields" : ["_id"],
+         "stored_fields" : "_none_"
+    },
+
+    "query_data_set_format": "hdf5",
+    "query_data_set_path":"/tmp/sift-128-euclidean.hdf5",
+    "query_count": 100
+  }

--- a/vectorsearch/test_procedures/common/train-model-schedule.json
+++ b/vectorsearch/test_procedures/common/train-model-schedule.json
@@ -1,3 +1,13 @@
+{% set train_knn_model_comma = joiner(",") %}
+{% set train_knn_model_encoder_comma = joiner(",") %}
+{
+    "operation": {
+        "name": "delete-target-index-before-model-training",
+        "operation-type": "delete-index",
+        "only-if-exists": true,
+        "index": "{{ target_index_name | default('target_index') }}"
+    }
+},
 {
     "operation": {
         "operation-type": "delete-knn-model",
@@ -23,75 +33,36 @@
                 "engine": "{{ train_method_engine | default('faiss') }}",
                 "space_type": "{{ target_index_space_type | default('l2') }}", 
                 "parameters": {
-                        {%- if train_method_name is defined and train_method_name == "hnsw" %}
-                            {%- if hnsw_ef_search is defined and hnsw_ef_search %}
-                            "ef_search": {{ hnsw_ef_search }}
-                            {%- endif %}
-                            {%- if hnsw_ef_construction is defined and hnsw_ef_construction %}
-                            {%- if hnsw_ef_search is defined and hnsw_ef_search %}
-                                ,
-                            {%- endif %}
-                                "ef_construction": {{ hnsw_ef_construction }}
-                            {%- endif %}
-                            {%- if hnsw_m is defined and hnsw_m %}
-                            {%- if hnsw_ef_construction is defined and hnsw_ef_construction %}
-                                ,
-                            {%- endif %}
-                                "m": {{ hnsw_m }}
-                            {%- endif %}
-
-                        {%- elif train_method_name is not defined or train_method_name == "ivf" %}
-                            {%- if faiss_nlist is defined and faiss_nlist %}
-                            "nlist": {{ faiss_nlist }}
-                            {%- endif %}
-
-                        {%- if faiss_nprobes is defined and faiss_nprobes %}
-                            {%- if faiss_nlist is defined and faiss_nlist %}
-                            ,
-                            {%- endif %}
-                        "nprobes": {{ faiss_nprobes}} 
+                        {%- if nlist is defined and nlist %}
+                        {{ train_knn_model_comma() }} "nlist": {{ nlist }}
                         {%- endif %}
-                            {%- if faiss_nprobes is defined and faiss_nprobes %}
-                                {%- if faiss_nlist is defined and faiss_nlist %}
-                            ,
-                                {%- endif %}
-                            "nprobes": {{ faiss_nprobes}} 
-                            {%- endif %}
 
-                            
-
+                        {%- if nprobes is defined and nprobes %}
+                        {{ train_knn_model_comma() }} "nprobes": {{ nprobes}} 
                         {%- endif %}
+
                         {%- if encoder is defined and encoder %}
-                                {%- if (faiss_nprobes is defined and faiss_nprobes) or (hnsw_m is defined)%} 
-                                ,
+                        {{ train_knn_model_comma() }} "encoder": {
+                            "name": "{{ encoder }}",
+                            "parameters": {
+                                {%- if pq_encoder_code_size is defined and pq_encoder_code_size %}
+                                    {{ train_knn_model_encoder_comma() }} "code_size": {{ pq_encoder_code_size }}
                                 {%- endif %}
-                            "encoder": {
-                                "name": "{{ encoder }}",
-                                "parameters": {
-                                    {%- if faiss_encoder_code_size is defined and faiss_encoder_code_size %}
-                                        "code_size": {{ faiss_encoder_code_size }}
-                                    {%- endif %}
-                                    
-                                    {%- if faiss_encoder_m is defined and faiss_encoder_m %}
-                                        {%- if faiss_encoder_code_size is defined and faiss_encoder_code_size %}
-                                            ,
-                                        {%- endif %}
-                                        "m": {{ faiss_encoder_m }}
-                                    {%- endif %}
+                                
+                                {%- if pq_encoder_m is defined and pq_encoder_m %}
+                                    {{ train_knn_model_encoder_comma() }} "m": {{ pq_encoder_m }}
+                                {%- endif %}
 
-                                    {%- if faiss_encoder_type is defined and faiss_encoder_type %}
-                                        "type": "{{ faiss_encoder_type }}"
-                                    {%- endif %}
+                                {%- if encoder_type is defined and encoder_type %}
+                                    {{ train_knn_model_encoder_comma() }} "type": "{{ encoder_type }}"
+                                {%- endif %}
 
-                                    {%- if faiss_encoder_clip is defined and faiss_encoder_clip %}
-                                        {%- if faiss_encoder_type is defined and faiss_encoder_type %}
-                                            ,
-                                        {%- endif %}
-                                        "clip": "{{ faiss_encoder_clip }}"
-                                    {%- endif %}
-                                }
+                                {%- if encoder_clip is defined and encoder_clip %}
+                                    {{ train_knn_model_encoder_comma() }} "clip": "{{ encoder_clip }}"
+                                {%- endif %}
                             }
-                            {%- endif %}
+                        }
+                        {%- endif %}
                 }
             }
         },
@@ -99,4 +70,27 @@
         "retries": {{ train_operation_retries | default(1000) }}, 
         "poll_period": {{ train_operation_poll_period | default(0.5) }}
     }
+},
+{
+    "operation": {
+        "name": "create-target-index",
+        "operation-type": "create-index",
+        "index": "{{ target_index_name | default('target_index') }}"
+    }
+},
+{
+    "operation": {
+        "name": "custom-vector-bulk",
+        "operation-type": "bulk-vector-data-set",
+        "index": "{{ target_index_name | default('target_index') }}",
+        "field": "{{ target_field_name | default('target_field') }}",
+        "bulk_size": {{ target_index_bulk_size | default(500)}},
+        "data_set_format": "{{ target_index_bulk_index_data_set_format | default('hdf5') }}",
+        "data_set_path": "{{ target_index_bulk_index_data_set_path  }}",
+        "data_set_corpus": "{{ target_index_bulk_index_data_set_corpus  }}",
+        "num_vectors": {{ target_index_num_vectors | default(-1) }},
+        "id-field-name": "{{ id_field_name }}",
+        "has_attributes": 0
+    },
+    "clients": {{ target_index_bulk_indexing_clients | default(1)}}
 }

--- a/vectorsearch/test_procedures/common/train-model-schedule.json
+++ b/vectorsearch/test_procedures/common/train-model-schedule.json
@@ -23,9 +23,27 @@
                 "engine": "{{ train_method_engine | default('faiss') }}",
                 "space_type": "{{ target_index_space_type | default('l2') }}", 
                 "parameters": {
-                        {%- if faiss_nlist is defined and faiss_nlist %}
-                        "nlist": {{ faiss_nlist }}
-                        {%- endif %}
+                        {%- if train_method_name is defined and train_method_name == "hnsw" %}
+                            {%- if hnsw_ef_search is defined and hnsw_ef_search %}
+                            "ef_search": {{ hnsw_ef_search }}
+                            {%- endif %}
+                            {%- if hnsw_ef_construction is defined and hnsw_ef_construction %}
+                            {%- if hnsw_ef_search is defined and hnsw_ef_search %}
+                                ,
+                            {%- endif %}
+                                "ef_construction": {{ hnsw_ef_construction }}
+                            {%- endif %}
+                            {%- if hnsw_m is defined and hnsw_m %}
+                            {%- if hnsw_ef_construction is defined and hnsw_ef_construction %}
+                                ,
+                            {%- endif %}
+                                "m": {{ hnsw_m }}
+                            {%- endif %}
+
+                        {%- elif train_method_name is not defined or train_method_name == "ivf" %}
+                            {%- if faiss_nlist is defined and faiss_nlist %}
+                            "nlist": {{ faiss_nlist }}
+                            {%- endif %}
 
                         {%- if faiss_nprobes is defined and faiss_nprobes %}
                             {%- if faiss_nlist is defined and faiss_nlist %}
@@ -33,38 +51,47 @@
                             {%- endif %}
                         "nprobes": {{ faiss_nprobes}} 
                         {%- endif %}
-
-                        {%- if encoder is defined and encoder %}
-                            {%- if faiss_nprobes is defined and faiss_nprobes %} 
+                            {%- if faiss_nprobes is defined and faiss_nprobes %}
+                                {%- if faiss_nlist is defined and faiss_nlist %}
                             ,
+                                {%- endif %}
+                            "nprobes": {{ faiss_nprobes}} 
                             {%- endif %}
-                        "encoder": {
-                            "name": "{{ encoder }}",
-                            "parameters": {
-                                {%- if faiss_encoder_code_size is defined and faiss_encoder_code_size %}
-                                    "code_size": {{ faiss_encoder_code_size }}
-                                {%- endif %}
-                                
-                                {%- if faiss_encoder_m is defined and faiss_encoder_m %}
-                                    {%- if faiss_encoder_code_size is defined and faiss_encoder_code_size %}
-                                        ,
-                                    {%- endif %}
-                                    "m": {{ faiss_encoder_m }}
-                                {%- endif %}
 
-                                {%- if faiss_encoder_type is defined and faiss_encoder_type %}
-                                    "type": "{{ faiss_encoder_type }}"
-                                {%- endif %}
+                            
 
-                                {%- if faiss_encoder_clip is defined and faiss_encoder_clip %}
-                                    {%- if faiss_encoder_type is defined and faiss_encoder_type %}
-                                        ,
-                                    {%- endif %}
-                                    "clip": "{{ faiss_encoder_clip }}"
-                                {%- endif %}
-                            }
-                        }
                         {%- endif %}
+                        {%- if encoder is defined and encoder %}
+                                {%- if (faiss_nprobes is defined and faiss_nprobes) or (hnsw_m is defined)%} 
+                                ,
+                                {%- endif %}
+                            "encoder": {
+                                "name": "{{ encoder }}",
+                                "parameters": {
+                                    {%- if faiss_encoder_code_size is defined and faiss_encoder_code_size %}
+                                        "code_size": {{ faiss_encoder_code_size }}
+                                    {%- endif %}
+                                    
+                                    {%- if faiss_encoder_m is defined and faiss_encoder_m %}
+                                        {%- if faiss_encoder_code_size is defined and faiss_encoder_code_size %}
+                                            ,
+                                        {%- endif %}
+                                        "m": {{ faiss_encoder_m }}
+                                    {%- endif %}
+
+                                    {%- if faiss_encoder_type is defined and faiss_encoder_type %}
+                                        "type": "{{ faiss_encoder_type }}"
+                                    {%- endif %}
+
+                                    {%- if faiss_encoder_clip is defined and faiss_encoder_clip %}
+                                        {%- if faiss_encoder_type is defined and faiss_encoder_type %}
+                                            ,
+                                        {%- endif %}
+                                        "clip": "{{ faiss_encoder_clip }}"
+                                    {%- endif %}
+                                }
+                            }
+                            {%- endif %}
                 }
             }
         },


### PR DESCRIPTION
### Description
Adds procedure to test Faiss HNSW method with PQ encoder. 

This PR includes changes to [vectorsearch/test_procedures/common/train-model-schedule.json](https://github.com/opensearch-project/opensearch-benchmark-workloads/commit/3935c1141287db8647f01e298aa367aa9c602137#diff-1caebee7d6e7a001714f1834e5b4e07b6a700e72b6f3fe5786110e7193497a1d), so it may have a merge conflict with #359 (but both changes to the schedule are needed).

### Testing
Integration tests passing: https://github.com/finnroblin/opensearch-benchmark/actions/runs/10153897372/job/28078103766

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
