### PR TITLE
add configurable throughput and client parameters

### DIFF
--- a/nyc_taxis/test_procedures/default.json
+++ b/nyc_taxis/test_procedures/default.json
@@ -56,100 +56,51 @@
         {
           "operation": "default",
           "warmup-iterations": 50,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 3
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ operation_name_target_throughput or target_throughput | default(default_value) | tojson }},
+          "clients": {{ operation_name_search_clients or search_clients | default(default_value) }}
         },
         {
           "operation": "range",
           "warmup-iterations": 50,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.7
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ operation_name_target_throughput or target_throughput | default(default_value) | tojson }},
+          "clients": {{ operation_name_search_clients or search_clients | default(default_value) }}
         },
         {
           "operation": "distance_amount_agg",
           "warmup-iterations": 50,
-          "iterations": 50
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 50,
+          "target-throughput": {{ operation_name_target_throughput or target_throughput | default(default_value) | tojson }},
+          "clients": {{ operation_name_search_clients or search_clients | default(default_value) }}
         },
         {
           "operation": "autohisto_agg",
           "warmup-iterations": 50,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ operation_name_target_throughput or target_throughput | default(default_value) | tojson }},
+          "clients": {{ operation_name_search_clients or search_clients | default(default_value) }}
         },
         {
           "operation": "date_histogram_agg",
           "warmup-iterations": 50,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ operation_name_target_throughput or target_throughput | default(default_value) | tojson }},
+          "clients": {{ operation_name_search_clients or search_clients | default(default_value) }}
         },
         {
           "operation": "desc_sort_tip_amount",
           "warmup-iterations": 50,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ operation_name_target_throughput or target_throughput | default(default_value) | tojson }},
+          "clients": {{ operation_name_search_clients or search_clients | default(default_value) }}
         },
         {
           "operation": "asc_sort_tip_amount",
           "warmup-iterations": 50,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ operation_name_target_throughput or target_throughput | default(default_value) | tojson }},
+          "clients": {{ operation_name_search_clients or search_clients | default(default_value) }}
         }
       ]
     },


### PR DESCRIPTION
### Description
Adds configurable throughput and client parameters to the nyc_taxis workload

### Issues Resolved
[#123](https://github.com/opensearch-project/opensearch-benchmark-workloads/issues/123)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
