### PR TITLE
Update Big5 README Documentation

### DIFF
--- a/big5/README.md
+++ b/big5/README.md
@@ -68,15 +68,7 @@ This workload allows the following parameters to be specified using `--workload-
 * `target_throughput` (default: 2): Target throughput for each query operation in requests per second, use 0 or "" for no throughput throttling.
 * `warmup_iterations` (default: 100): Number of warmup query iterations prior to actual measurements commencing.
 
-NOTE: If disabling `target_throughput` when using OSB in a bash script, use `0` or do not specify quotations after `target_throughput`. See the following code for invalid and valid examples:
-```
-# In a bash script, this will be invalid
---workload-params=target_throughput:""
-
-# In a bash script, these two lines will be valid
---workload-params=target_throughput:0
---workload-params=target_throughput:
-```
+NOTE: If disabling `target_throughput`, know that `target_throughput:""` is snynonymous with `target_throughput:0`.
 
 ### Data Document Structure
 

--- a/big5/README.md
+++ b/big5/README.md
@@ -68,6 +68,15 @@ This workload allows the following parameters to be specified using `--workload-
 * `target_throughput` (default: 2): Target throughput for each query operation in requests per second, use 0 or "" for no throughput throttling.
 * `warmup_iterations` (default: 100): Number of warmup query iterations prior to actual measurements commencing.
 
+NOTE: If disabling `target_throughput` when using OSB in a bash script, use `0` or do not specify quotations after `target_throughput`. See the following code for invalid and valid examples:
+```
+# In a bash script, this will be invalid
+--workload-params=target_throughput:""
+
+# In a bash script, these two lines will be valid
+--workload-params=target_throughput:0
+--workload-params=target_throughput:
+```
 
 ### Data Document Structure
 


### PR DESCRIPTION
### Description
It's unclear to users on how to disable `target_throughput` in a bash script. The following blurb is added to the Big5 README to avoid confusion. We are also working to rephrase some of the target throughput documentation in the official OSB documentation. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
