### PR TITLE
add configurable throughput and client params to nested, noaa, pmc workloads

### DIFF
--- a/http_logs/test_procedures/default.json
+++ b/http_logs/test_procedures/default.json
@@ -79,14 +79,16 @@
           "clients": {{ range_search_clients or search_clients | default(1) }}
         },
         {
-          "operation": "status-200s-in-range",
+          "operation": "200s-in-range",
+          "name": "status-200s-in-range",
           "warmup-iterations": 500,
           "iterations": 100,
           "target-throughput": {{ status_200s_in_range_target_throughput or target_throughput | default(33) | tojson }},
           "clients": {{ status_200s_in_range_search_clients or search_clients | default(1) }}
         },
         {
-          "operation": "status-400s-in-range",
+          "operation": "400s-in-range",
+          "name": "status-400s-in-range",
           "warmup-iterations": 500,
           "iterations": 100,
           "target-throughput": {{ status_400s_in_range_target_throughput or target_throughput | default(50) | tojson }},
@@ -294,14 +296,16 @@
           "clients": {{ range_search_clients or search_clients | default(1) }}
         },
         {
-          "operation": "status-200s-in-range",
+          "operation": "200s-in-range",
+          "name": "status-200s-in-range",
           "warmup-iterations": 500,
           "iterations": 100,
           "target-throughput": {{ status_200s_in_range_target_throughput or target_throughput | default(33) | tojson }},
           "clients": {{ status_200s_in_range_search_clients or search_clients | default(1) }}
         },
         {
-          "operation": "status-400s-in-range",
+          "operation": "400s-in-range",
+          "name": "status-400s-in-range",
           "warmup-iterations": 500,
           "iterations": 100,
           "target-throughput": {{ status_400s_in_range_target_throughput or target_throughput | default(50) | tojson }},

--- a/nested/test_procedures/default.json
+++ b/nested/test_procedures/default.json
@@ -61,114 +61,51 @@
         {
           "operation": "randomized-nested-queries",
           "warmup-iterations": 500,
-          "iterations": 1000
-          {%- if not target_throughput %}
-          ,"target-throughput": 20
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 2
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 1000,
+          "target-throughput": {{ randomized_nested_queries_target_throughput or target_throughput | default(20) | tojson }},
+          "clients": {{ randomized_nested_queries_search_clients or search_clients | default(2) }}
         },
         {
           "operation": "randomized-term-queries",
           "warmup-iterations": 500,
-          "iterations": 200
-          {%- if not target_throughput %}
-          ,"target-throughput": 25
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 2
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 200,
+          "target-throughput": {{ randomized_term_queries_target_throughput or target_throughput | default(25) | tojson }},
+          "clients": {{ randomized_term_queries_search_clients or search_clients | default(2) }}
         },
         {
           "operation": "randomized-sorted-term-queries",
           "warmup-iterations": 500,
-          "iterations": 200
-          {%- if not target_throughput %}
-          ,"target-throughput": 16
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 2
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 200,
+          "target-throughput": {{ randomized_sorted_term_queries_target_throughput or target_throughput | default(16) | tojson }},
+          "clients": {{ randomized_sorted_term_queries_search_clients or search_clients | default(2) }}
         },
         {
           "operation": "match-all",
           "warmup-iterations": 500,
-          "iterations": 200
-          {%- if not target_throughput %}
-          ,"target-throughput": 5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 2
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 200,
+          "target-throughput": {{ match_all_target_throughput or target_throughput | default(5) | tojson }},
+          "clients": {{ match_all_search_clients or search_clients | default(2) }}
         },
         {
           "operation": "nested-date-histo",
           "warmup-iterations": 100,
-          "iterations": 200
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 2
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 200,
+          "target-throughput": {{ nested_date_histo_target_throughput or target_throughput | default(1) | tojson }},
+          "clients": {{ nested_date_histo_search_clients or search_clients | default(2) }}
         },
         {
           "operation": "randomized-nested-queries-with-inner-hits_default",
           "warmup-iterations": 500,
-          "iterations": 1000
-          {%- if not target_throughput %}
-          ,"target-throughput": 18
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 2
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 1000,
+          "target-throughput": {{ randomized_nested_queries_with_inner_hits_default_target_throughput or target_throughput | default(18) | tojson }},
+          "clients": {{ randomized_nested_queries_with_inner_hits_default_search_clients or search_clients | default(2) }}
         },
         {
           "operation": "randomized-nested-queries-with-inner-hits_default_big_size",
           "warmup-iterations": 500,
-          "iterations": 1000
-          {%- if not target_throughput %}
-          ,"target-throughput": 16
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 2
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 1000,
+          "target-throughput": {{ randomized_nested_queries_with_inner_hits_default_big_size_target_throughput or target_throughput | default(16) | tojson }},
+          "clients": {{ randomized_nested_queries_with_inner_hits_default_big_size_search_clients or search_clients | default(2) }}
         }
       ]
     },

--- a/noaa/test_procedures/default.json
+++ b/noaa/test_procedures/default.json
@@ -61,114 +61,58 @@
         {
           "operation": "range_field_big_range",
           "warmup-iterations": 100,
-          "iterations": 500
-          {%- if not target_throughput %}
-          ,"target-throughput": 6
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 500,
+          "target-throughput": {{ range_field_big_range_target_throughput or target_throughput | default(6) | tojson }},
+          "clients": {{ range_field_big_range_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "range_field_small_range",
           "warmup-iterations": 100,
-          "iterations": 500
-          {%- if not target_throughput %}
-          ,"target-throughput": 10
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 500,
+          "target-throughput": {{ range_field_small_range_target_throughput or target_throughput | default(10) | tojson }},
+          "clients": {{ range_field_small_range_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "range_field_conjunction_big_range_small_term_query",
           "warmup-iterations": 100,
-          "iterations": 500
-          {%- if not target_throughput %}
-          ,"target-throughput": 10
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 500,
+          "target-throughput": {{ range_field_conjunction_big_range_small_term_query_target_throughput or target_throughput | default(10) | tojson }},
+          "clients": {{ range_field_conjunction_big_range_small_term_query_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "range_field_conjunction_small_range_small_term_query",
           "warmup-iterations": 100,
-          "iterations": 500
-          {%- if not target_throughput %}
-          ,"target-throughput": 10
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 500,
+          "target-throughput": {{ range_field_conjunction_small_range_small_term_query_target_throughput or target_throughput | default(10) | tojson }},
+          "clients": {{ range_field_conjunction_small_range_small_term_query_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "range_field_conjunction_small_range_big_term_query",
           "warmup-iterations": 100,
-          "iterations": 500
-          {%- if not target_throughput %}
-          ,"target-throughput": 4
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 500,
+          "target-throughput": {{ range_field_conjunction_small_range_big_term_query_target_throughput or target_throughput | default(4) | tojson }},
+          "clients": {{ range_field_conjunction_small_range_big_term_query_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "range_field_conjunction_big_range_big_term_query",
           "warmup-iterations": 100,
-          "iterations": 500
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 500,
+          "target-throughput": {{ range_field_conjunction_big_range_big_term_query_target_throughput or target_throughput | default(1) | tojson }},
+          "clients": {{ range_field_conjunction_big_range_big_term_query_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "range_field_disjunction_small_range_small_term_query",
           "warmup-iterations": 100,
-          "iterations": 500
-          {%- if not target_throughput %}
-          ,"target-throughput": 10
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 500,
+          "target-throughput": {{ range_field_disjunction_small_range_small_term_query_target_throughput or target_throughput | default(10) | tojson }},
+          "clients": {{ range_field_disjunction_small_range_small_term_query_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "range_field_disjunction_big_range_small_term_query",
           "warmup-iterations": 100,
-          "iterations": 500
-          {%- if not target_throughput %}
-          ,"target-throughput": 6
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 500,
+          "target-throughput": {{ range_field_disjunction_big_range_small_term_query_target_throughput or target_throughput | default(6) | tojson }},
+          "clients": {{ range_field_disjunction_big_range_small_term_query_search_clients or search_clients | default(1) }}
         }
       ]
     },
@@ -283,306 +227,135 @@
         {
           "operation": "max_temp",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 4
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ max_temp_target_throughput or target_throughput | default(4) | tojson }},
+          "clients": {{ max_temp_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "last_max_temp_top_hits",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 4
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ last_max_temp_top_hits_target_throughput or target_throughput | default(4) | tojson }},
+          "clients": {{ last_max_temp_top_hits_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "last_max_temp_top_metrics",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 4
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ last_max_temp_top_metrics_target_throughput or target_throughput | default(4) | tojson }},
+          "clients": {{ last_max_temp_top_metrics_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "max_temp_per_station_10",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ max_temp_per_station_10_target_throughput or target_throughput | default(2) | tojson }},
+          "clients": {{ max_temp_per_station_10_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "last_max_temp_per_station_top_hits_10",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ last_max_temp_per_station_top_hits_10_target_throughput or target_throughput | default(2) | tojson }},
+          "clients": {{ last_max_temp_per_station_top_hits_10_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "last_max_temp_per_station_top_metrics_10",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ last_max_temp_per_station_top_metrics_10_target_throughput or target_throughput | default(2) | tojson }},
+          "clients": {{ last_max_temp_per_station_top_metrics_10_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "last_min_and_max_temp_per_station_top_metrics_10",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ last_min_and_max_temp_per_station_top_metrics_10_target_throughput or target_throughput | default(2) | tojson }},
+          "clients": {{ last_min_and_max_temp_per_station_top_metrics_10_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "last_five_max_temp_per_station_top_metrics_10",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ last_five_max_temp_per_station_top_metrics_10_target_throughput or target_throughput | default(2) | tojson }},
+          "clients": {{ last_five_max_temp_per_station_top_metrics_10_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "max_temp_per_station_10_depth_first",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ max_temp_per_station_10_depth_first_target_throughput or target_throughput | default(2) | tojson }},
+          "clients": {{ max_temp_per_station_10_depth_first_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "last_max_temp_per_station_top_hits_10_depth_first",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ last_max_temp_per_station_top_hits_10_depth_first_target_throughput or target_throughput | default(1) | tojson }},
+          "clients": {{ last_max_temp_per_station_top_hits_10_depth_first_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "last_max_temp_per_station_top_metrics_10_depth_first",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ last_max_temp_per_station_top_metrics_10_depth_first_target_throughput or target_throughput | default(1) | tojson }},
+          "clients": {{ last_max_temp_per_station_top_metrics_10_depth_first_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "last_max_temp_per_station_top_metrics_10_sort_by",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ last_max_temp_per_station_top_metrics_10_sort_by_target_throughput or target_throughput | default(1) | tojson }},
+          "clients": {{ last_max_temp_per_station_top_metrics_10_sort_by_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "max_temp_per_station_5000",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ max_temp_per_station_5000_target_throughput or target_throughput | default(1) | tojson }},
+          "clients": {{ max_temp_per_station_5000_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "last_max_temp_per_station_top_hits_5000",
           "warmup-iterations": 10,
-          "iterations": 50
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 50,
+          "target-throughput": {{ last_max_temp_per_station_top_hits_5000_target_throughput or target_throughput | default(1) | tojson }},
+          "clients": {{ last_max_temp_per_station_top_hits_5000_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "last_max_temp_per_station_top_hits_5000_via_source",
           "warmup-iterations": 10,
-          "iterations": 50
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 50,
+          "target-throughput": {{ last_max_temp_per_station_top_hits_5000_via_source_target_throughput or target_throughput | default(1) | tojson }},
+          "clients": {{ last_max_temp_per_station_top_hits_5000_via_source_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "last_max_temp_per_station_top_metrics_5000",
           "warmup-iterations": 10,
-          "iterations": 50
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 50,
+          "target-throughput": {{ last_max_temp_per_station_top_metrics_5000_target_throughput or target_throughput | default(1) | tojson }},
+          "clients": {{ last_max_temp_per_station_top_metrics_5000_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "last_min_and_max_temp_per_station_top_metrics_5000",
           "warmup-iterations": 10,
-          "iterations": 50
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 50,
+          "target-throughput": {{ last_min_and_max_temp_per_station_top_metrics_5000_target_throughput or target_throughput | default(1) | tojson }},
+          "clients": {{ last_min_and_max_temp_per_station_top_metrics_5000_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "last_five_max_temp_per_station_top_metrics_5000",
           "warmup-iterations": 10,
-          "iterations": 50
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 50,
+          "target-throughput": {{ last_five_max_temp_per_station_top_metrics_5000_target_throughput or target_throughput | default(1) | tojson }},
+          "clients": {{ last_five_max_temp_per_station_top_metrics_5000_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "last_country_code_per_station_top_metrics_5000",
           "warmup-iterations": 10,
-          "iterations": 50
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 50,
+          "target-throughput": {{ last_country_code_per_station_top_metrics_5000_target_throughput or target_throughput | default(1) | tojson }},
+          "clients": {{ last_country_code_per_station_top_metrics_5000_search_clients or search_clients | default(1) }}
         }
       ]
     },

--- a/pmc/test_procedures/default.json
+++ b/pmc/test_procedures/default.json
@@ -72,43 +72,43 @@
           "operation": "default",
           "warmup-iterations": 500,
           "iterations": 200,
-          "target-throughput": {{ target_throughput | default(20) | tojson }},
-          "clients": {{ search_clients | default(1) }}
+          "target-throughput": {{ default_target_throughput or target_throughput | default(20) | tojson }},
+          "clients": {{ default_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "term",
           "warmup-iterations": 500,
           "iterations": 200,
-          "target-throughput": {{ target_throughput | default(20) | tojson }},
-          "clients": {{ search_clients | default(1) }}
+          "target-throughput": {{ term_target_throughput or target_throughput | default(20) | tojson }},
+          "clients": {{ term_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "phrase",
           "warmup-iterations": 500,
           "iterations": 200,
-          "target-throughput": {{ target_throughput | default(20) | tojson }},
-          "clients": {{ search_clients | default(1) }}
+          "target-throughput": {{ phrase_target_throughput or target_throughput | default(20) | tojson }},
+          "clients": {{ phrase_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "articles_monthly_agg_uncached",
           "warmup-iterations": 500,
           "iterations": 200,
-          "target-throughput": {{ target_throughput | default(20) | tojson }},
-          "clients": {{ search_clients | default(1) }}
+          "target-throughput": {{ articles_monthly_agg_uncached_target_throughput or target_throughput | default(20) | tojson }},
+          "clients": {{ articles_monthly_agg_uncached_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "articles_monthly_agg_cached",
           "warmup-iterations": 500,
           "iterations": 200,
-          "target-throughput": {{ target_throughput | default(20) | tojson }},
-          "clients": {{ search_clients | default(1) }}
+          "target-throughput": {{ articles_monthly_agg_cached_target_throughput or target_throughput | default(20) | tojson }},
+          "clients": {{ articles_monthly_agg_cached_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "scroll",
           "warmup-iterations": 50,
           "iterations": 100,
-          "target-throughput": {{ target_throughput | default(0.5) | tojson }},
-          "clients": {{ search_clients | default(1) }}
+          "target-throughput": {{ scroll_target_throughput or target_throughput | default(0.5) | tojson }},
+          "clients": {{ scroll_search_clients or search_clients | default(1) }}
         }
       ]
     },


### PR DESCRIPTION
add configurable throughput and client params to nested, noaa, pmc workloads

### Issues Resolved
#130 , #131 , #132 

#407 Bug fix
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
