### PR TITLE
Term query for '/var/log/messages/fuschiashoulder' has no hits

### DIFF
--- a/big5/operations/default.json
+++ b/big5/operations/default.json
@@ -23,7 +23,7 @@
         "query": {
           "term": {
             "log.file.path": {
-              "value": "/var/log/messages/fuschiashoulder"
+              "value": "/var/log/messages/birdknight"
             }
           }
         }
@@ -371,7 +371,7 @@
       "operation-type": "search",
       "request-timeout": 7200,
       "index": "{{index_name | default('big5')}}",
-      "body": 
+      "body":
         {
           "track_total_hits": false,
           "size": 0,

--- a/big5/queries/term.json
+++ b/big5/queries/term.json
@@ -2,7 +2,7 @@
   "query": {
     "term": {
       "log.file.path": {
-        "value": "/var/log/messages/fuschiashoulder"
+        "value": "/var/log/messages/birdknight"
       }
     }
   }


### PR DESCRIPTION
### Description
The term query of the big5 workload doesn't appear to have any hits.
```
curl -X POST "http://localhost:9200/_search" \
-H "Content-Type: application/json" \
-d '{
  "query": {
    "term": {
      "log.file.path": {
        "value": "/var/log/messages/fuschiashoulder"
      }
    }
  }
}'
```
```
{"took":2,"timed_out":false,"_shards":{"total":5,"successful":5,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]}}
```

Same query with `"value": "/var/log/messages/birdknight"`

```
{"took":353,"timed_out":false,"_shards":{"total":5,"successful":5,"skipped":0,"failed":0},"hits":{"total":{"value":10000,"relation":"gte"},"max_score":9.20723,"hits":[ ...
```

### Issues Resolved
None

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
