### PR TITLE
add configurable throughput + client params for http_logs

### DIFF
--- a/http_logs/operations/default.json
+++ b/http_logs/operations/default.json
@@ -141,7 +141,7 @@
       ]
     },
     {
-      "name": "200s-in-range",
+      "name": "status-200s-in-range",
       "operation-type": "search",
       "index": "logs-*",
       "body": {
@@ -175,7 +175,7 @@
       ]
     },
     {
-      "name": "400s-in-range",
+      "name": "status-400s-in-range",
       "operation-type": "search",
       "index": "logs-*",
       "body": {

--- a/http_logs/test_procedures/default.json
+++ b/http_logs/test_procedures/default.json
@@ -59,101 +59,52 @@
         {
           "operation": "default",
           "warmup-iterations": 500,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 8
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ default_target_throughput or target_throughput | default(8) | tojson }},
+          "clients": {{ default_search_clients or search_clients | default(1) }}
         },
         {
           "name": "term",
           "operation": "term",
           "warmup-iterations": 500,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 50
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ term_target_throughput or target_throughput | default(50) | tojson }},
+          "clients": {{ term_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "range",
           "warmup-iterations": 100,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ range_target_throughput or target_throughput | default(1) | tojson }},
+          "clients": {{ range_search_clients or search_clients | default(1) }}
         },
         {
-          "operation": "200s-in-range",
+          "operation": "status-200s-in-range",
           "warmup-iterations": 500,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 33
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ status_200s_in_range_target_throughput or target_throughput | default(33) | tojson }},
+          "clients": {{ status_200s_in_range_search_clients or search_clients | default(1) }}
         },
         {
-          "operation": "400s-in-range",
+          "operation": "status-400s-in-range",
           "warmup-iterations": 500,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 50
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ status_400s_in_range_target_throughput or target_throughput | default(50) | tojson }},
+          "clients": {{ status_400s_in_range_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "hourly_agg",
           "warmup-iterations": 50,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ hourly_agg_target_throughput or target_throughput | default(0.2) | tojson }},
+          "clients": {{ hourly_agg_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "multi_term_agg",
           "warmup-iterations": 50,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ multi_term_agg_target_throughput or target_throughput | default(0.2) | tojson }},
+          "clients": {{ multi_term_agg_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "scroll",
@@ -165,86 +116,44 @@
         {
           "operation": "desc_sort_size",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ desc_sort_size_target_throughput or target_throughput | default(0.5) | tojson }},
+          "clients": {{ desc_sort_size_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "asc_sort_size",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ asc_sort_size_target_throughput or target_throughput | default(0.5) | tojson }},
+          "clients": {{ asc_sort_size_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "desc_sort_timestamp",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ desc_sort_timestamp_target_throughput or target_throughput | default(0.5) | tojson }},
+          "clients": {{ desc_sort_timestamp_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "asc_sort_timestamp",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ asc_sort_timestamp_target_throughput or target_throughput | default(0.5) | tojson }},
+          "clients": {{ asc_sort_timestamp_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "desc_sort_with_after_timestamp",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ desc_sort_with_after_timestamp_target_throughput or target_throughput | default(0.5) | tojson }},
+          "clients": {{ desc_sort_with_after_timestamp_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "asc_sort_with_after_timestamp",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ asc_sort_with_after_timestamp_target_throughput or target_throughput | default(0.5) | tojson }},
+          "clients": {{ asc_sort_with_after_timestamp_search_clients or search_clients | default(1) }}
         },
         {
           "name": "force-merge-1-seg",
@@ -275,61 +184,33 @@
           "name": "desc-sort-timestamp-after-force-merge-1-seg",
           "operation": "desc_sort_timestamp",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ desc_sort_timestamp_target_throughput or target_throughput | default(2) | tojson }},
+          "clients": {{ desc_sort_timestamp_search_clients or search_clients | default(1) }}
         },
         {
           "name": "asc-sort-timestamp-after-force-merge-1-seg",
           "operation": "asc_sort_timestamp",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ asc_sort_timestamp_target_throughput or target_throughput | default(2) | tojson }},
+          "clients": {{ asc_sort_timestamp_search_clients or search_clients | default(1) }}
         },
         {
           "name": "desc-sort-with-after-timestamp-after-force-merge-1-seg",
           "operation": "desc_sort_with_after_timestamp",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ desc_sort_with_after_timestamp_target_throughput or target_throughput | default(0.5) | tojson }},
+          "clients": {{ desc_sort_with_after_timestamp_search_clients or search_clients | default(1) }}
         },
         {
           "name": "asc-sort-with-after-timestamp-after-force-merge-1-seg",
           "operation": "asc_sort_with_after_timestamp",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ asc_sort_with_after_timestamp_target_throughput or target_throughput | default(0.5) | tojson }},
+          "clients": {{ asc_sort_with_after_timestamp_search_clients or search_clients | default(1) }}
         }
       ]
     },
@@ -393,87 +274,45 @@
         {
           "operation": "default",
           "warmup-iterations": 500,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 8
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ default_target_throughput or target_throughput | default(8) | tojson }},
+          "clients": {{ default_search_clients or search_clients | default(1) }}
         },
         {
           "name": "term",
           "operation": "term",
           "warmup-iterations": 500,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 50
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ term_target_throughput or target_throughput | default(50) | tojson }},
+          "clients": {{ term_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "range",
           "warmup-iterations": 100,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ range_target_throughput or target_throughput | default(1) | tojson }},
+          "clients": {{ range_search_clients or search_clients | default(1) }}
         },
         {
-          "operation": "200s-in-range",
+          "operation": "status-200s-in-range",
           "warmup-iterations": 500,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 33
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ status_200s_in_range_target_throughput or target_throughput | default(33) | tojson }},
+          "clients": {{ status_200s_in_range_search_clients or search_clients | default(1) }}
         },
         {
-          "operation": "400s-in-range",
+          "operation": "status-400s-in-range",
           "warmup-iterations": 500,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 50
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ status_400s_in_range_target_throughput or target_throughput | default(50) | tojson }},
+          "clients": {{ status_400s_in_range_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "hourly_agg",
           "warmup-iterations": 50,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ hourly_agg_target_throughput or target_throughput | default(0.2) | tojson }},
+          "clients": {{ hourly_agg_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "scroll",
@@ -485,86 +324,44 @@
         {
           "operation": "desc_sort_size",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ desc_sort_size_target_throughput or target_throughput | default(0.5) | tojson }},
+          "clients": {{ desc_sort_size_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "asc_sort_size",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ asc_sort_size_target_throughput or target_throughput | default(0.5) | tojson }},
+          "clients": {{ asc_sort_size_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "desc_sort_timestamp",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ desc_sort_timestamp_target_throughput or target_throughput | default(0.5) | tojson }},
+          "clients": {{ desc_sort_timestamp_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "asc_sort_timestamp",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ asc_sort_timestamp_target_throughput or target_throughput | default(0.5) | tojson }},
+          "clients": {{ asc_sort_timestamp_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "desc_sort_with_after_timestamp",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ desc_sort_with_after_timestamp_target_throughput or target_throughput | default(0.5) | tojson }},
+          "clients": {{ desc_sort_with_after_timestamp_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "asc_sort_with_after_timestamp",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ asc_sort_with_after_timestamp_target_throughput or target_throughput | default(0.5) | tojson }},
+          "clients": {{ asc_sort_with_after_timestamp_search_clients or search_clients | default(1) }}
         },
         {
           "name": "force-merge-1-seg",
@@ -595,61 +392,33 @@
           "name": "desc-sort-timestamp-after-force-merge-1-seg",
           "operation": "desc_sort_timestamp",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ desc_sort_timestamp_target_throughput or target_throughput | default(2) | tojson }},
+          "clients": {{ desc_sort_timestamp_search_clients or search_clients | default(1) }}
         },
         {
           "name": "asc-sort-timestamp-after-force-merge-1-seg",
           "operation": "asc_sort_timestamp",
           "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ asc_sort_timestamp_target_throughput or target_throughput | default(2) | tojson }},
+          "clients": {{ asc_sort_timestamp_search_clients or search_clients | default(1) }}
         },
         {
           "name": "desc-sort-with-after-timestamp-after-force-merge-1-seg",
           "operation": "desc_sort_with_after_timestamp",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ desc_sort_with_after_timestamp_target_throughput or target_throughput | default(0.5) | tojson }},
+          "clients": {{ desc_sort_with_after_timestamp_search_clients or search_clients | default(1) }}
         },
         {
           "name": "asc-sort-with-after-timestamp-after-force-merge-1-seg",
           "operation": "asc_sort_with_after_timestamp",
           "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ asc_sort_with_after_timestamp_target_throughput or target_throughput | default(0.5) | tojson }},
+          "clients": {{ asc_sort_with_after_timestamp_search_clients or search_clients | default(1) }}
         }
       ]
     },
@@ -1059,16 +828,9 @@
           "name": "match-all",
           "operation": "default",
           "warmup-iterations": 500,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 8
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ default_target_throughput or target_throughput | default(8) | tojson }},
+          "clients": {{ default_search_clients or search_clients | default(1) }}
         },
         {
           "name": "match-all-baseline-search-pipeline",
@@ -1077,16 +839,9 @@
             "search-pipeline": "http-log-baseline-search-pipeline"
           },
           "warmup-iterations": 500,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 8
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ default_target_throughput or target_throughput | default(8) | tojson }},
+          "clients": {{ default_search_clients or search_clients | default(1) }}
         },
         {
           "name": "match-all-status-filter-search-pipeline",
@@ -1095,16 +850,9 @@
             "search-pipeline": "http-log-status-filter-search-pipeline"
           },
           "warmup-iterations": 500,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 8
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ default_target_throughput or target_throughput | default(8) | tojson }},
+          "clients": {{ default_search_clients or search_clients | default(1) }}
         },
         {
           "name": "match-all-rename-field-search-pipeline",
@@ -1113,16 +861,9 @@
             "search-pipeline": "http-log-rename-field-search-pipeline"
           },
           "warmup-iterations": 500,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 8
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ default_target_throughput or target_throughput | default(8) | tojson }},
+          "clients": {{ default_search_clients or search_clients | default(1) }}
         },
         {
           "name": "match-all-rename-100-field-search-pipeline",
@@ -1131,16 +872,9 @@
             "search-pipeline": "http-log-rename-100-field-search-pipeline"
           },
           "warmup-iterations": 500,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 8
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ default_target_throughput or target_throughput | default(8) | tojson }},
+          "clients": {{ default_search_clients or search_clients | default(1) }}
         },
         {
           "name": "match-all-dummy-scripting-search-pipeline",
@@ -1149,16 +883,9 @@
             "search-pipeline": "http-log-dummy-scripting-search-pipeline"
           },
           "warmup-iterations": 500,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 8
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ default_target_throughput or target_throughput | default(8) | tojson }},
+          "clients": {{ default_search_clients or search_clients | default(1) }}
         },
         {
           "name": "match-all-100-dummy-scripting-search-pipeline",
@@ -1167,16 +894,9 @@
             "search-pipeline": "http-log-100-dummy-scripting-search-pipeline"
           },
           "warmup-iterations": 500,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 8
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ default_target_throughput or target_throughput | default(8) | tojson }},
+          "clients": {{ default_search_clients or search_clients | default(1) }}
         },
         {
           "name": "match-all-all-processors-search-pipeline",
@@ -1185,31 +905,17 @@
             "search-pipeline": "http-log-all-processors-search-pipeline"
           },
           "warmup-iterations": 500,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 8
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ default_target_throughput or target_throughput | default(8) | tojson }},
+          "clients": {{ default_search_clients or search_clients | default(1) }}
         },
         {
           "name": "multi-term-filter",
           "operation": "multi-term-filter",
           "warmup-iterations": 500,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 50
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ multi_term_filter_target_throughput or target_throughput | default(50) | tojson }},
+          "clients": {{ multi_term_filter_search_clients or search_clients | default(1) }}
         },
         {
           "name": "term-status-filter-search-pipeline",
@@ -1218,31 +924,17 @@
           "request-params": {
             "search-pipeline": "http-log-status-filter-search-pipeline"
           },
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 50
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ term_target_throughput or target_throughput | default(50) | tojson }},
+          "clients": {{ term_search_clients or search_clients | default(1) }}
         },
         {
           "name": "range",
           "operation": "range",
           "warmup-iterations": 100,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ range_target_throughput or target_throughput | default(1) | tojson }},
+          "clients": {{ range_search_clients or search_clients | default(1) }}
         },
         {
           "name": "range-all-processors-search-pipeline",
@@ -1251,16 +943,9 @@
             "search-pipeline": "http-log-all-processors-search-pipeline"
           },
           "warmup-iterations": 100,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%-if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "iterations": 100,
+          "target-throughput": {{ range_target_throughput or target_throughput | default(1) | tojson }},
+          "clients": {{ range_search_clients or search_clients | default(1) }}
         }
       ]
     }


### PR DESCRIPTION
### Description
Adds configurable throughput & client params for the http_logs workload
Tested by cherry picking changes to branches `1`, `2`, `3`, and `7` and running [integration tests](https://github.com/OVI3D0/opensearch-benchmark/actions/runs/11039301138) on my fork

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
