### PR TITLE
add configurable throughput + client parameters to the pmc workload

### DIFF
--- a/pmc/test_procedures/default.json
+++ b/pmc/test_procedures/default.json
@@ -72,43 +72,43 @@
           "operation": "default",
           "warmup-iterations": 500,
           "iterations": 200,
-          "target-throughput": {{ target_throughput | default(20) | tojson }},
-          "clients": {{ search_clients | default(1) }}
+          "target-throughput": {{ default_target_throughput or target_throughput | default(20) | tojson }},
+          "clients": {{ default_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "term",
           "warmup-iterations": 500,
           "iterations": 200,
-          "target-throughput": {{ target_throughput | default(20) | tojson }},
-          "clients": {{ search_clients | default(1) }}
+          "target-throughput": {{ term_target_throughput or target_throughput | default(20) | tojson }},
+          "clients": {{ term_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "phrase",
           "warmup-iterations": 500,
           "iterations": 200,
-          "target-throughput": {{ target_throughput | default(20) | tojson }},
-          "clients": {{ search_clients | default(1) }}
+          "target-throughput": {{ phrase_target_throughput or target_throughput | default(20) | tojson }},
+          "clients": {{ phrase_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "articles_monthly_agg_uncached",
           "warmup-iterations": 500,
           "iterations": 200,
-          "target-throughput": {{ target_throughput | default(20) | tojson }},
-          "clients": {{ search_clients | default(1) }}
+          "target-throughput": {{ articles_monthly_agg_uncached_target_throughput or target_throughput | default(20) | tojson }},
+          "clients": {{ articles_monthly_agg_uncached_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "articles_monthly_agg_cached",
           "warmup-iterations": 500,
           "iterations": 200,
-          "target-throughput": {{ target_throughput | default(20) | tojson }},
-          "clients": {{ search_clients | default(1) }}
+          "target-throughput": {{ articles_monthly_agg_cached_target_throughput or target_throughput | default(20) | tojson }},
+          "clients": {{ articles_monthly_agg_cached_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "scroll",
           "warmup-iterations": 50,
           "iterations": 100,
-          "target-throughput": {{ target_throughput | default(0.5) | tojson }},
-          "clients": {{ search_clients | default(1) }}
+          "target-throughput": {{ scroll_target_throughput or target_throughput | default(0.5) | tojson }},
+          "clients": {{ scroll_search_clients or search_clients | default(1) }}
         }
       ]
     },

--- a/pmc/test_procedures/indexing-querying.json
+++ b/pmc/test_procedures/indexing-querying.json
@@ -92,43 +92,43 @@
             "operation": "default",
             "warmup-iterations": 500,
             "iterations": 200,
-            "target-throughput": {{ target_throughput | default(20) | tojson }},
-            "clients": {{ search_clients | default(1) }}
+            "target-throughput": {{ default_target_throughput or target_throughput | default(20) | tojson }},
+            "clients": {{ default_search_clients or search_clients | default(1) }}
           },
           {
             "operation": "term",
             "warmup-iterations": 500,
             "iterations": 200,
-            "target-throughput": {{ target_throughput | default(20) | tojson }},
-            "clients": {{ search_clients | default(1) }}
+            "target-throughput": {{ term_target_throughput or target_throughput | default(20) | tojson }},
+            "clients": {{ term_search_clients or search_clients | default(1) }}
           },
           {
             "operation": "phrase",
             "warmup-iterations": 500,
             "iterations": 200,
-            "target-throughput": {{ target_throughput | default(20) | tojson }},
-            "clients": {{ search_clients | default(1) }}
+            "target-throughput": {{ phrase_target_throughput or target_throughput | default(20) | tojson }},
+            "clients": {{ phrase_search_clients or search_clients | default(1) }}
           },
           {
             "operation": "articles_monthly_agg_uncached",
             "warmup-iterations": 500,
             "iterations": 200,
-            "target-throughput": {{ target_throughput | default(20) | tojson }},
-            "clients": {{ search_clients | default(1) }}
+            "target-throughput": {{ articles_monthly_agg_uncached_target_throughput or target_throughput | default(20) | tojson }},
+            "clients": {{ articles_monthly_agg_uncached_search_clients or search_clients | default(1) }}
           },
           {
             "operation": "articles_monthly_agg_cached",
             "warmup-iterations": 500,
             "iterations": 200,
-            "target-throughput": {{ target_throughput | default(20) | tojson }},
-            "clients": {{ search_clients | default(1) }}
+            "target-throughput": {{ articles_monthly_agg_cached_target_throughput or target_throughput | default(20) | tojson }},
+            "clients": {{ articles_monthly_agg_cached_search_clients or search_clients | default(1) }}
           },
           {
             "operation": "scroll",
             "warmup-iterations": 50,
             "iterations": 100,
-            "target-throughput": {{ target_throughput | default(0.5) | tojson }},
-            "clients": {{ search_clients | default(1) }}
+            "target-throughput": {{ scroll_target_throughput or target_throughput | default(0.5) | tojson }},
+            "clients": {{ scroll_search_clients or search_clients | default(1) }}
           }
         ]
       }


### PR DESCRIPTION
### Description
add configurable throughput + client parameters to the pmc workload
Tested by cherry-picking changes onto main, 1, 2, 3, and 7, then running integ tests. Results [here](https://github.com/OVI3D0/opensearch-benchmark/actions/runs/11111126682/job/30870342817)

### Issues Resolved
#132 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
