### PR TITLE
add configurable warmup iterations + iterations to geoshape, geopoint…

### DIFF
--- a/geopoint/test_procedures/default.json
+++ b/geopoint/test_procedures/default.json
@@ -61,29 +61,29 @@
         },
         {
           "operation": "polygon",
-          "warmup-iterations": 200,
-          "iterations": 100,
+          "warmup-iterations": {{ polygon_warmup_iterations or warmup_iterations | default(200) | tojson }},
+          "iterations": {{ polygon_iterations or iterations | default(100) | tojson }},
           "target-throughput": {{ polygon_target_throughput or target_throughput | default(2) | tojson }},
           "clients": {{ polygon_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "bbox",
-          "warmup-iterations": 200,
-          "iterations": 100,
+          "warmup-iterations": {{ bbox_warmup_iterations or warmup_iterations | default(200) | tojson }},
+          "iterations": {{ bbox_iterations or iterations | default(100) | tojson }},
           "target-throughput": {{ bbox_target_throughput or target_throughput | default(2) | tojson }},
           "clients": {{ bbox_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "distance",
-          "warmup-iterations": 200,
-          "iterations": 100,
+          "warmup-iterations": {{ distance_warmup_iterations or warmup_iterations | default(200) | tojson }},
+          "iterations": {{ distance_iterations or iterations | default(100) | tojson }},
           "target-throughput": {{ distance_target_throughput or target_throughput | default(5) | tojson }},
           "clients": {{ distance_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "distanceRange",
-          "warmup-iterations": 200,
-          "iterations": 100,
+          "warmup-iterations": {{ distanceRange_warmup_iterations or warmup_iterations | default(200) | tojson }},
+          "iterations": {{ distanceRange_iterations or iterations | default(100) | tojson }},
           "target-throughput": {{ distanceRange_target_throughput or target_throughput | default(0.5) | tojson }},
           "clients": {{ distanceRange_search_clients or search_clients | default(1) }}
         }

--- a/geopointshape/test_procedures/default.json
+++ b/geopointshape/test_procedures/default.json
@@ -59,15 +59,15 @@
         },
         {
           "operation": "polygon",
-          "warmup-iterations": 200,
-          "iterations": 100,
+          "warmup-iterations": {{ polygon_warmup_iterations or warmup_iterations | default(200) | tojson }},
+          "iterations": {{ polygon_iterations or iterations | default(100) | tojson }},
           "target-throughput": {{ polygon_target_throughput or target_throughput | default(2) | tojson }},
           "clients": {{ polygon_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "bbox",
-          "warmup-iterations": 200,
-          "iterations": 100,
+          "warmup-iterations": {{ bbox_warmup_iterations or warmup_iterations | default(200) | tojson }},
+          "iterations": {{ bbox_iterations or iterations | default(100) | tojson }},
           "target-throughput": {{ bbox_target_throughput or target_throughput | default(2) | tojson }},
           "clients": {{ bbox_search_clients or search_clients | default(1) }}
         }

--- a/geoshape/test_procedures/default.json
+++ b/geoshape/test_procedures/default.json
@@ -126,15 +126,15 @@
         },
         {
           "operation": "polygon",
-          "warmup-iterations": 200,
-          "iterations": 100,
+          "warmup-iterations": {{ polygon_warmup_iterations or warmup_iterations | default(200) | tojson }},
+          "iterations": {{ polygon_iterations or iterations | default(100) | tojson }},
           "target-throughput": {{ polygon_target_throughput or target_throughput | default(0.3) | tojson }},
           "clients": {{ polygon_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "bbox",
-          "warmup-iterations": 200,
-          "iterations": 100,
+          "warmup-iterations": {{ bbox_warmup_iterations or warmup_iterations | default(200) | tojson }},
+          "iterations": {{ bbox_iterations or iterations | default(100) | tojson }},
           "target-throughput": {{ bbox_target_throughput or target_throughput | default(0.25) | tojson }},
           "clients": {{ bbox_search_clients or search_clients | default(1) }}
         }


### PR DESCRIPTION
### Description
Adds configurable iterations + warmup iterations to geoshape, geopoint, and geopointshape workloads

### Issues Resolved
#398 , #399 , #400 

### Testing
- [x] New functionality includes testing

Tested by cherry-picking changes to branches 1, 3 and 7 and running [integ tests](https://github.com/OVI3D0/opensearch-benchmark/actions/runs/11263852489/job/31322669168)

### Backport to Branches:
- [ ] 6
- [x] 7
- [x] 1
- [x] 2
- [x] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
