### PR TITLE
On-boarding Disk-based-Vector on Nightly runs

### DIFF
--- a/vectorsearch/indices/faiss-index.json
+++ b/vectorsearch/indices/faiss-index.json
@@ -21,6 +21,9 @@
         "target_field": {
           "type": "knn_vector",
           "dimension": {{ target_index_dimension }},
+          {%- if mode is defined %}
+          "mode": "{{ mode }}",
+          {%- endif %}
           {%- if train_model_id is defined %}
           "model_id": "{{ train_model_id }}"
           {%- else %}

--- a/vectorsearch/params/corpus/10million/faiss-cohere-768-disk-based-vector.json
+++ b/vectorsearch/params/corpus/10million/faiss-cohere-768-disk-based-vector.json
@@ -1,0 +1,28 @@
+{
+    "target_index_name": "target_index",
+    "target_field_name": "target_field",
+    "target_index_body": "indices/faiss-index.json",
+    "target_index_primary_shards": 5,
+    "target_index_replica_shards": 1,
+    "target_index_dimension": 768,
+    "target_index_space_type": "innerproduct",
+
+    "target_index_bulk_size": 100,
+    "target_index_bulk_index_data_set_format": "hdf5",
+    "target_index_bulk_index_data_set_corpus": "cohere-10m",
+    "target_index_bulk_indexing_clients": 10,
+
+    "target_index_max_num_segments": 1,
+    "hnsw_ef_search": 256,
+    "hnsw_ef_construction": 256,
+    "mode": "on_disk",
+    "query_k": 100,
+    "query_body": {
+         "docvalue_fields" : ["_id"],
+         "stored_fields" : "_none_"
+    },
+
+    "query_data_set_format": "hdf5",
+    "query_data_set_corpus": "cohere-10m",
+    "query_count": 10000
+  }


### PR DESCRIPTION
### Description
This change introduces disk-based vector search with 32x compression for the Cohere 10M dataset, designed to run as part of nightly tests.

### Issues Resolved
[List any issues this PR will resolve]

### Testing
1. Test Case 1:- Without Mode OnDisk 

> |---------------------------------------------------------------:|---------------------:|------------:|-------:|
|                     Cumulative indexing time of primary shards |                      |  0.00683333 |    min |
|             Min cumulative indexing time across primary shards |                      | 0.000166667 |    min |
|          Median cumulative indexing time across primary shards |                      |  0.00134167 |    min |
|             Max cumulative indexing time across primary shards |                      |     0.00145 |    min |
|            Cumulative indexing throttle time of primary shards |                      |           0 |    min |
|    Min cumulative indexing throttle time across primary shards |                      |           0 |    min |
| Median cumulative indexing throttle time across primary shards |                      |           0 |    min |
|    Max cumulative indexing throttle time across primary shards |                      |           0 |    min |
|                        Cumulative merge time of primary shards |                      |  0.00193333 |    min |
|                       Cumulative merge count of primary shards |                      |           5 |        |
|                Min cumulative merge time across primary shards |                      |           0 |    min |
|             Median cumulative merge time across primary shards |                      |    0.000375 |    min |
|                Max cumulative merge time across primary shards |                      |     0.00045 |    min |
|               Cumulative merge throttle time of primary shards |                      |           0 |    min |
|       Min cumulative merge throttle time across primary shards |                      |           0 |    min |
|    Median cumulative merge throttle time across primary shards |                      |           0 |    min |
|       Max cumulative merge throttle time across primary shards |                      |           0 |    min |
|                      Cumulative refresh time of primary shards |                      |     0.00365 |    min |
|                     Cumulative refresh count of primary shards |                      |          63 |        |
|              Min cumulative refresh time across primary shards |                      |      0.0003 |    min |
|           Median cumulative refresh time across primary shards |                      |    0.000625 |    min |
|              Max cumulative refresh time across primary shards |                      | 0.000866667 |    min |
|                        Cumulative flush time of primary shards |                      | 6.66667e-05 |    min |
|                       Cumulative flush count of primary shards |                      |           1 |        |
|                Min cumulative flush time across primary shards |                      |           0 |    min |
|             Median cumulative flush time across primary shards |                      |           0 |    min |
|                Max cumulative flush time across primary shards |                      | 6.66667e-05 |    min |
|                                        Total Young Gen GC time |                      |           0 |      s |
|                                       Total Young Gen GC count |                      |           0 |        |
|                                          Total Old Gen GC time |                      |           0 |      s |
|                                         Total Old Gen GC count |                      |           0 |        |
|                                                     Store size |                      |   0.0342202 |     GB |
|                                                  Translog size |                      |  2.5332e-06 |     GB |
|                                         Heap used for segments |                      |           0 |     MB |
|                                       Heap used for doc values |                      |           0 |     MB |
|                                            Heap used for terms |                      |           0 |     MB |
|                                            Heap used for norms |                      |           0 |     MB |
|                                           Heap used for points |                      |           0 |     MB |
|                                    Heap used for stored fields |                      |           0 |     MB |
|                                                  Segment count |                      |           6 |        |
|                                                 Min Throughput |   custom-vector-bulk |     4978.94 | docs/s |
|                                                Mean Throughput |   custom-vector-bulk |     4978.94 | docs/s |
|                                              Median Throughput |   custom-vector-bulk |     4978.94 | docs/s |
|                                                 Max Throughput |   custom-vector-bulk |     4978.94 | docs/s |
|                                        50th percentile latency |   custom-vector-bulk |     64.4296 |     ms |
|                                        90th percentile latency |   custom-vector-bulk |     76.6548 |     ms |
|                                       100th percentile latency |   custom-vector-bulk |     80.2939 |     ms |
|                                   50th percentile service time |   custom-vector-bulk |     64.4296 |     ms |
|                                   90th percentile service time |   custom-vector-bulk |     76.6548 |     ms |
|                                  100th percentile service time |   custom-vector-bulk |     80.2939 |     ms |
|                                                     error rate |   custom-vector-bulk |           0 |      % |
|                                                 Min Throughput | force-merge-segments |         0.1 |  ops/s |
|                                                Mean Throughput | force-merge-segments |         0.1 |  ops/s |
|                                              Median Throughput | force-merge-segments |         0.1 |  ops/s |
|                                                 Max Throughput | force-merge-segments |         0.1 |  ops/s |
|                                       100th percentile latency | force-merge-segments |     10028.1 |     ms |
|                                  100th percentile service time | force-merge-segments |     10028.1 |     ms |
|                                                     error rate | force-merge-segments |           0 |      % |
|                                                 Min Throughput |       warmup-indices |       87.95 |  ops/s |
|                                                Mean Throughput |       warmup-indices |       87.95 |  ops/s |
|                                              Median Throughput |       warmup-indices |       87.95 |  ops/s |
|                                                 Max Throughput |       warmup-indices |       87.95 |  ops/s |
|                                       100th percentile latency |       warmup-indices |     11.1267 |     ms |
|                                  100th percentile service time |       warmup-indices |     11.1267 |     ms |
|                                                     error rate |       warmup-indices |           0 |      % |
|                                                 Min Throughput |         prod-queries |      152.24 |  ops/s |
|                                                Mean Throughput |         prod-queries |      155.48 |  ops/s |
|                                              Median Throughput |         prod-queries |      156.19 |  ops/s |
|                                                 Max Throughput |         prod-queries |      156.38 |  ops/s |
|                                        50th percentile latency |         prod-queries |     4.46727 |     ms |
|                                        90th percentile latency |         prod-queries |     4.61414 |     ms |
|                                        99th percentile latency |         prod-queries |     4.81258 |     ms |
|                                      99.9th percentile latency |         prod-queries |     8.04509 |     ms |
|                                       100th percentile latency |         prod-queries |     12.5293 |     ms |
|                                   50th percentile service time |         prod-queries |     4.46727 |     ms |
|                                   90th percentile service time |         prod-queries |     4.61414 |     ms |
|                                   99th percentile service time |         prod-queries |     4.81258 |     ms |
|                                 99.9th percentile service time |         prod-queries |     8.04509 |     ms |
|                                  100th percentile service time |         prod-queries |     12.5293 |     ms |
|                                                     error rate |         prod-queries |           0 |      % |
|                                                  Mean recall@k |         prod-queries |           1 |        |
|                                                  Mean recall@1 |         prod-queries |           1 |        |

2. Test Case 2:- With Mode OnDisk 

> |---------------------------------------------------------------:|---------------------:|------------:|-------:|
|                     Cumulative indexing time of primary shards |                      |      0.0067 |    min |
|             Min cumulative indexing time across primary shards |                      |     0.00015 |    min |
|          Median cumulative indexing time across primary shards |                      |  0.00125833 |    min |
|             Max cumulative indexing time across primary shards |                      |  0.00148333 |    min |
|            Cumulative indexing throttle time of primary shards |                      |           0 |    min |
|    Min cumulative indexing throttle time across primary shards |                      |           0 |    min |
| Median cumulative indexing throttle time across primary shards |                      |           0 |    min |
|    Max cumulative indexing throttle time across primary shards |                      |           0 |    min |
|                        Cumulative merge time of primary shards |                      |  0.00113333 |    min |
|                       Cumulative merge count of primary shards |                      |           5 |        |
|                Min cumulative merge time across primary shards |                      |           0 |    min |
|             Median cumulative merge time across primary shards |                      | 0.000216667 |    min |
|                Max cumulative merge time across primary shards |                      | 0.000266667 |    min |
|               Cumulative merge throttle time of primary shards |                      |           0 |    min |
|       Min cumulative merge throttle time across primary shards |                      |           0 |    min |
|    Median cumulative merge throttle time across primary shards |                      |           0 |    min |
|       Max cumulative merge throttle time across primary shards |                      |           0 |    min |
|                      Cumulative refresh time of primary shards |                      |       0.003 |    min |
|                     Cumulative refresh count of primary shards |                      |          63 |        |
|              Min cumulative refresh time across primary shards |                      |      0.0003 |    min |
|           Median cumulative refresh time across primary shards |                      | 0.000516667 |    min |
|              Max cumulative refresh time across primary shards |                      |     0.00065 |    min |
|                        Cumulative flush time of primary shards |                      | 6.66667e-05 |    min |
|                       Cumulative flush count of primary shards |                      |           1 |        |
|                Min cumulative flush time across primary shards |                      |           0 |    min |
|             Median cumulative flush time across primary shards |                      |           0 |    min |
|                Max cumulative flush time across primary shards |                      | 6.66667e-05 |    min |
|                                        Total Young Gen GC time |                      |           0 |      s |
|                                       Total Young Gen GC count |                      |           0 |        |
|                                          Total Old Gen GC time |                      |           0 |      s |
|                                         Total Old Gen GC count |                      |           0 |        |
|                                                     Store size |                      |   0.0286957 |     GB |
|                                                  Translog size |                      | 1.57394e-06 |     GB |
|                                         Heap used for segments |                      |           0 |     MB |
|                                       Heap used for doc values |                      |           0 |     MB |
|                                            Heap used for terms |                      |           0 |     MB |
|                                            Heap used for norms |                      |           0 |     MB |
|                                           Heap used for points |                      |           0 |     MB |
|                                    Heap used for stored fields |                      |           0 |     MB |
|                                                  Segment count |                      |           6 |        |
|                                                 Min Throughput |   custom-vector-bulk |     5090.97 | docs/s |
|                                                Mean Throughput |   custom-vector-bulk |     5090.97 | docs/s |
|                                              Median Throughput |   custom-vector-bulk |     5090.97 | docs/s |
|                                                 Max Throughput |   custom-vector-bulk |     5090.97 | docs/s |
|                                        50th percentile latency |   custom-vector-bulk |     65.5015 |     ms |
|                                        90th percentile latency |   custom-vector-bulk |     77.3799 |     ms |
|                                       100th percentile latency |   custom-vector-bulk |     82.8606 |     ms |
|                                   50th percentile service time |   custom-vector-bulk |     65.5015 |     ms |
|                                   90th percentile service time |   custom-vector-bulk |     77.3799 |     ms |
|                                  100th percentile service time |   custom-vector-bulk |     82.8606 |     ms |
|                                                     error rate |   custom-vector-bulk |           0 |      % |
|                                                 Min Throughput | force-merge-segments |         0.1 |  ops/s |
|                                                Mean Throughput | force-merge-segments |         0.1 |  ops/s |
|                                              Median Throughput | force-merge-segments |         0.1 |  ops/s |
|                                                 Max Throughput | force-merge-segments |         0.1 |  ops/s |
|                                       100th percentile latency | force-merge-segments |     10048.3 |     ms |
|                                  100th percentile service time | force-merge-segments |     10048.3 |     ms |
|                                                     error rate | force-merge-segments |           0 |      % |
|                                                 Min Throughput |       warmup-indices |       72.71 |  ops/s |
|                                                Mean Throughput |       warmup-indices |       72.71 |  ops/s |
|                                              Median Throughput |       warmup-indices |       72.71 |  ops/s |
|                                                 Max Throughput |       warmup-indices |       72.71 |  ops/s |
|                                       100th percentile latency |       warmup-indices |     13.4643 |     ms |
|                                  100th percentile service time |       warmup-indices |     13.4643 |     ms |
|                                                     error rate |       warmup-indices |           0 |      % |
|                                                 Min Throughput |         prod-queries |      147.89 |  ops/s |
|                                                Mean Throughput |         prod-queries |      151.83 |  ops/s |
|                                              Median Throughput |         prod-queries |      152.57 |  ops/s |
|                                                 Max Throughput |         prod-queries |      153.73 |  ops/s |
|                                        50th percentile latency |         prod-queries |     4.40308 |     ms |
|                                        90th percentile latency |         prod-queries |     4.57319 |     ms |
|                                        99th percentile latency |         prod-queries |      5.0824 |     ms |
|                                      99.9th percentile latency |         prod-queries |     8.60256 |     ms |
|                                       100th percentile latency |         prod-queries |     12.3462 |     ms |
|                                   50th percentile service time |         prod-queries |     4.40308 |     ms |
|                                   90th percentile service time |         prod-queries |     4.57319 |     ms |
|                                   99th percentile service time |         prod-queries |      5.0824 |     ms |
|                                 99.9th percentile service time |         prod-queries |     8.60256 |     ms |
|                                  100th percentile service time |         prod-queries |     12.3462 |     ms |
|                                                     error rate |         prod-queries |           0 |      % |
|                                                  Mean recall@k |         prod-queries |           1 |        |
|                                                  Mean recall@1 |         prod-queries |           1 |        |

Both works as expected 
here is the link 

[Describe how this change was tested]

### Backport to Branches:
- [ ] 6
- [ ] 7
- [ ] 1
- [ ] 2
- [ ] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
