### PR TITLE
add configurable iterations + warmup iterations to the pmc workload

### DIFF
--- a/pmc/test_procedures/default.json
+++ b/pmc/test_procedures/default.json
@@ -70,43 +70,43 @@
         },
         {
           "operation": "default",
-          "warmup-iterations": 500,
-          "iterations": 200,
+          "warmup-iterations": {{ default_warmup_iterations or warmup_iterations | default(500) | tojson }},
+          "iterations": {{ default_iterations or iterations | default(200) | tojson }},
           "target-throughput": {{ default_target_throughput or target_throughput | default(20) | tojson }},
           "clients": {{ default_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "term",
-          "warmup-iterations": 500,
-          "iterations": 200,
+          "warmup-iterations": {{ term_warmup_iterations or warmup_iterations | default(500) | tojson }},
+          "iterations": {{ term_iterations or iterations | default(200) | tojson }},
           "target-throughput": {{ term_target_throughput or target_throughput | default(20) | tojson }},
           "clients": {{ term_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "phrase",
-          "warmup-iterations": 500,
-          "iterations": 200,
+          "warmup-iterations": {{ phrase_warmup_iterations or warmup_iterations | default(500) | tojson }},
+          "iterations": {{ phrase_iterations or iterations | default(200) | tojson }},
           "target-throughput": {{ phrase_target_throughput or target_throughput | default(20) | tojson }},
           "clients": {{ phrase_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "articles_monthly_agg_uncached",
-          "warmup-iterations": 500,
-          "iterations": 200,
+          "warmup-iterations": {{ articles_monthly_agg_uncached_warmup_iterations or warmup_iterations | default(500) | tojson }},
+          "iterations": {{ articles_monthly_agg_uncached_iterations or iterations | default(200) | tojson }},
           "target-throughput": {{ articles_monthly_agg_uncached_target_throughput or target_throughput | default(20) | tojson }},
           "clients": {{ articles_monthly_agg_uncached_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "articles_monthly_agg_cached",
-          "warmup-iterations": 500,
-          "iterations": 200,
+          "warmup-iterations": {{ articles_monthly_agg_cached_warmup_iterations or warmup_iterations | default(500) | tojson }},
+          "iterations": {{ articles_monthly_agg_cached_iterations or iterations | default(200) | tojson }},
           "target-throughput": {{ articles_monthly_agg_cached_target_throughput or target_throughput | default(20) | tojson }},
           "clients": {{ articles_monthly_agg_cached_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "scroll",
-          "warmup-iterations": 50,
-          "iterations": 100,
+          "warmup-iterations": {{ scroll_warmup_iterations or warmup_iterations | default(50) | tojson }},
+          "iterations": {{ scroll_iterations or iterations | default(100) | tojson }},
           "target-throughput": {{ scroll_target_throughput or target_throughput | default(0.5) | tojson }},
           "clients": {{ scroll_search_clients or search_clients | default(1) }}
         }


### PR DESCRIPTION
### Description
Adds configurable iterations + warmup iterations to the pmc workload

### Issues Resolved
#402 

### Testing
- [x] New functionality includes testing

Tested by cherry-picking changes to branches 1, 3, and 7 and running [integ tests](https://github.com/OVI3D0/opensearch-benchmark/actions/runs/11279153009/job/31375572184)

### Backport to Branches:
- [ ] 6
- [x] 7
- [x] 1
- [x] 2
- [x] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
