### PR TITLE
add configurables to noaa workload

### DIFF
--- a/noaa/test_procedures/default.json
+++ b/noaa/test_procedures/default.json
@@ -60,115 +60,59 @@
         },
         {
           "operation": "range_field_big_range",
-          "warmup-iterations": 100,
-          "iterations": 500
-          {%- if not target_throughput %}
-          ,"target-throughput": 6
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ range_field_big_range_warmup_iterations or warmup_iterations | default(100) | tojson }},
+          "iterations": {{ range_field_big_range_iterations or iterations | default(500) | tojson }},
+          "target-throughput": {{ range_field_big_range_target_throughput or target_throughput | default(6) | tojson }},
+          "clients": {{ range_field_big_range_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "range_field_small_range",
-          "warmup-iterations": 100,
-          "iterations": 500
-          {%- if not target_throughput %}
-          ,"target-throughput": 10
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ range_field_small_range_warmup_iterations or warmup_iterations | default(100) | tojson }},
+          "iterations": {{ range_field_small_range_iterations or iterations | default(500) | tojson }},
+          "target-throughput": {{ range_field_small_range_target_throughput or target_throughput | default(10) | tojson }},
+          "clients": {{ range_field_small_range_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "range_field_conjunction_big_range_small_term_query",
-          "warmup-iterations": 100,
-          "iterations": 500
-          {%- if not target_throughput %}
-          ,"target-throughput": 10
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ range_field_conjunction_big_range_small_term_query_warmup_iterations or warmup_iterations | default(100) | tojson }},
+          "iterations": {{ range_field_conjunction_big_range_small_term_query_iterations or iterations | default(500) | tojson }},
+          "target-throughput": {{ range_field_conjunction_big_range_small_term_query_target_throughput or target_throughput | default(10) | tojson }},
+          "clients": {{ range_field_conjunction_big_range_small_term_query_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "range_field_conjunction_small_range_small_term_query",
-          "warmup-iterations": 100,
-          "iterations": 500
-          {%- if not target_throughput %}
-          ,"target-throughput": 10
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ range_field_conjunction_small_range_small_term_query_warmup_iterations or warmup_iterations | default(100) | tojson }},
+          "iterations": {{ range_field_conjunction_small_range_small_term_query_iterations or iterations | default(500) | tojson }},
+          "target-throughput": {{ range_field_conjunction_small_range_small_term_query_target_throughput or target_throughput | default(10) | tojson }},
+          "clients": {{ range_field_conjunction_small_range_small_term_query_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "range_field_conjunction_small_range_big_term_query",
-          "warmup-iterations": 100,
-          "iterations": 500
-          {%- if not target_throughput %}
-          ,"target-throughput": 4
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ range_field_conjunction_small_range_big_term_query_warmup_iterations or warmup_iterations | default(100) | tojson }},
+          "iterations": {{ range_field_conjunction_small_range_big_term_query_iterations or iterations | default(500) | tojson }},
+          "target-throughput": {{ range_field_conjunction_small_range_big_term_query_target_throughput or target_throughput | default(4) | tojson }},
+          "clients": {{ range_field_conjunction_small_range_big_term_query_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "range_field_conjunction_big_range_big_term_query",
-          "warmup-iterations": 100,
-          "iterations": 500
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ range_field_conjunction_big_range_big_term_query_warmup_iterations or warmup_iterations | default(100) | tojson }},
+          "iterations": {{ range_field_conjunction_big_range_big_term_query_iterations or iterations | default(500) | tojson }},
+          "target-throughput": {{ range_field_conjunction_big_range_big_term_query_target_throughput or target_throughput | default(1) | tojson }},
+          "clients": {{ range_field_conjunction_big_range_big_term_query_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "range_field_disjunction_small_range_small_term_query",
-          "warmup-iterations": 100,
-          "iterations": 500
-          {%- if not target_throughput %}
-          ,"target-throughput": 10
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ range_field_disjunction_small_range_small_term_query_warmup_iterations or warmup_iterations | default(100) | tojson }},
+          "iterations": {{ range_field_disjunction_small_range_small_term_query_iterations or iterations | default(500) | tojson }},
+          "target-throughput": {{ range_field_disjunction_small_range_small_term_query_target_throughput or target_throughput | default(10) | tojson }},
+          "clients": {{ range_field_disjunction_small_range_small_term_query_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "range_field_disjunction_big_range_small_term_query",
-          "warmup-iterations": 100,
-          "iterations": 500
-          {%- if not target_throughput %}
-          ,"target-throughput": 6
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ range_field_disjunction_big_range_small_term_query_warmup_iterations or warmup_iterations | default(100) | tojson }},
+          "iterations": {{ range_field_disjunction_big_range_small_term_query_iterations or iterations | default(500) | tojson }},
+          "target-throughput": {{ range_field_disjunction_big_range_small_term_query_target_throughput or target_throughput | default(6) | tojson }},
+          "clients": {{ range_field_disjunction_big_range_small_term_query_search_clients or search_clients | default(1) }}
         }
       ]
     },
@@ -282,307 +226,136 @@
         },
         {
           "operation": "max_temp",
-          "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 4
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ max_temp_warmup_iterations or warmup_iterations | default(10) | tojson }},
+          "iterations": {{ max_temp_iterations or iterations | default(100) | tojson }},
+          "target-throughput": {{ max_temp_target_throughput or target_throughput | default(4) | tojson }},
+          "clients": {{ max_temp_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "last_max_temp_top_hits",
-          "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 4
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ last_max_temp_top_hits_warmup_iterations or warmup_iterations | default(10) | tojson }},
+          "iterations": {{ last_max_temp_top_hits_iterations or iterations | default(100) | tojson }},
+          "target-throughput": {{ last_max_temp_top_hits_target_throughput or target_throughput | default(4) | tojson }},
+          "clients": {{ last_max_temp_top_hits_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "last_max_temp_top_metrics",
-          "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 4
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ last_max_temp_top_metrics_warmup_iterations or warmup_iterations | default(10) | tojson }},
+          "iterations": {{ last_max_temp_top_metrics_iterations or iterations | default(100) | tojson }},
+          "target-throughput": {{ last_max_temp_top_metrics_target_throughput or target_throughput | default(4) | tojson }},
+          "clients": {{ last_max_temp_top_metrics_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "max_temp_per_station_10",
-          "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ max_temp_per_station_10_warmup_iterations or warmup_iterations | default(10) | tojson }},
+          "iterations": {{ max_temp_per_station_10_iterations or iterations | default(100) | tojson }},
+          "target-throughput": {{ max_temp_per_station_10_target_throughput or target_throughput | default(2) | tojson }},
+          "clients": {{ max_temp_per_station_10_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "last_max_temp_per_station_top_hits_10",
-          "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ last_max_temp_per_station_top_hits_10_warmup_iterations or warmup_iterations | default(10) | tojson }},
+          "iterations": {{ last_max_temp_per_station_top_hits_10_iterations or iterations | default(100) | tojson }},
+          "target-throughput": {{ last_max_temp_per_station_top_hits_10_target_throughput or target_throughput | default(2) | tojson }},
+          "clients": {{ last_max_temp_per_station_top_hits_10_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "last_max_temp_per_station_top_metrics_10",
-          "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ last_max_temp_per_station_top_metrics_10_warmup_iterations or warmup_iterations | default(10) | tojson }},
+          "iterations": {{ last_max_temp_per_station_top_metrics_10_iterations or iterations | default(100) | tojson }},
+          "target-throughput": {{ last_max_temp_per_station_top_metrics_10_target_throughput or target_throughput | default(2) | tojson }},
+          "clients": {{ last_max_temp_per_station_top_metrics_10_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "last_min_and_max_temp_per_station_top_metrics_10",
-          "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ last_min_and_max_temp_per_station_top_metrics_10_warmup_iterations or warmup_iterations | default(10) | tojson }},
+          "iterations": {{ last_min_and_max_temp_per_station_top_metrics_10_iterations or iterations | default(100) | tojson }},
+          "target-throughput": {{ last_min_and_max_temp_per_station_top_metrics_10_target_throughput or target_throughput | default(2) | tojson }},
+          "clients": {{ last_min_and_max_temp_per_station_top_metrics_10_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "last_five_max_temp_per_station_top_metrics_10",
-          "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ last_five_max_temp_per_station_top_metrics_10_warmup_iterations or warmup_iterations | default(10) | tojson }},
+          "iterations": {{ last_five_max_temp_per_station_top_metrics_10_iterations or iterations | default(100) | tojson }},
+          "target-throughput": {{ last_five_max_temp_per_station_top_metrics_10_target_throughput or target_throughput | default(2) | tojson }},
+          "clients": {{ last_five_max_temp_per_station_top_metrics_10_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "max_temp_per_station_10_depth_first",
-          "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ max_temp_per_station_10_depth_first_warmup_iterations or warmup_iterations | default(10) | tojson }},
+          "iterations": {{ max_temp_per_station_10_depth_first_iterations or iterations | default(100) | tojson }},
+          "target-throughput": {{ max_temp_per_station_10_depth_first_target_throughput or target_throughput | default(2) | tojson }},
+          "clients": {{ max_temp_per_station_10_depth_first_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "last_max_temp_per_station_top_hits_10_depth_first",
-          "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ last_max_temp_per_station_top_hits_10_depth_first_warmup_iterations or warmup_iterations | default(10) | tojson }},
+          "iterations": {{ last_max_temp_per_station_top_hits_10_depth_first_iterations or iterations | default(100) | tojson }},
+          "target-throughput": {{ last_max_temp_per_station_top_hits_10_depth_first_target_throughput or target_throughput | default(1) | tojson }},
+          "clients": {{ last_max_temp_per_station_top_hits_10_depth_first_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "last_max_temp_per_station_top_metrics_10_depth_first",
-          "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ last_max_temp_per_station_top_metrics_10_depth_first_warmup_iterations or warmup_iterations | default(10) | tojson }},
+          "iterations": {{ last_max_temp_per_station_top_metrics_10_depth_first_iterations or iterations | default(100) | tojson }},
+          "target-throughput": {{ last_max_temp_per_station_top_metrics_10_depth_first_target_throughput or target_throughput | default(1) | tojson }},
+          "clients": {{ last_max_temp_per_station_top_metrics_10_depth_first_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "last_max_temp_per_station_top_metrics_10_sort_by",
-          "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ last_max_temp_per_station_top_metrics_10_sort_by_warmup_iterations or warmup_iterations | default(10) | tojson }},
+          "iterations": {{ last_max_temp_per_station_top_metrics_10_sort_by_iterations or iterations | default(100) | tojson }},
+          "target-throughput": {{ last_max_temp_per_station_top_metrics_10_sort_by_target_throughput or target_throughput | default(1) | tojson }},
+          "clients": {{ last_max_temp_per_station_top_metrics_10_sort_by_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "max_temp_per_station_5000",
-          "warmup-iterations": 10,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ max_temp_per_station_5000_warmup_iterations or warmup_iterations | default(10) | tojson }},
+          "iterations": {{ max_temp_per_station_5000_iterations or iterations | default(100) | tojson }},
+          "target-throughput": {{ max_temp_per_station_5000_target_throughput or target_throughput | default(1) | tojson }},
+          "clients": {{ max_temp_per_station_5000_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "last_max_temp_per_station_top_hits_5000",
-          "warmup-iterations": 10,
-          "iterations": 50
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ last_max_temp_per_station_top_hits_5000_warmup_iterations or warmup_iterations | default(10) | tojson }},
+          "iterations": {{ last_max_temp_per_station_top_hits_5000_iterations or iterations | default(50) | tojson }},
+          "target-throughput": {{ last_max_temp_per_station_top_hits_5000_target_throughput or target_throughput | default(1) | tojson }},
+          "clients": {{ last_max_temp_per_station_top_hits_5000_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "last_max_temp_per_station_top_hits_5000_via_source",
-          "warmup-iterations": 10,
-          "iterations": 50
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ last_max_temp_per_station_top_hits_5000_via_source_warmup_iterations or warmup_iterations | default(10) | tojson }},
+          "iterations": {{ last_max_temp_per_station_top_hits_5000_via_source_iterations or iterations | default(50) | tojson }},
+          "target-throughput": {{ last_max_temp_per_station_top_hits_5000_via_source_target_throughput or target_throughput | default(1) | tojson }},
+          "clients": {{ last_max_temp_per_station_top_hits_5000_via_source_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "last_max_temp_per_station_top_metrics_5000",
-          "warmup-iterations": 10,
-          "iterations": 50
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ last_max_temp_per_station_top_metrics_5000_warmup_iterations or warmup_iterations | default(10) | tojson }},
+          "iterations": {{ last_max_temp_per_station_top_metrics_5000_iterations or iterations | default(50) | tojson }},
+          "target-throughput": {{ last_max_temp_per_station_top_metrics_5000_target_throughput or target_throughput | default(1) | tojson }},
+          "clients": {{ last_max_temp_per_station_top_metrics_5000_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "last_min_and_max_temp_per_station_top_metrics_5000",
-          "warmup-iterations": 10,
-          "iterations": 50
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ last_min_and_max_temp_per_station_top_metrics_5000_warmup_iterations or warmup_iterations | default(10) | tojson }},
+          "iterations": {{ last_min_and_max_temp_per_station_top_metrics_5000_iterations or iterations | default(50) | tojson }},
+          "target-throughput": {{ last_min_and_max_temp_per_station_top_metrics_5000_target_throughput or target_throughput | default(1) | tojson }},
+          "clients": {{ last_min_and_max_temp_per_station_top_metrics_5000_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "last_five_max_temp_per_station_top_metrics_5000",
-          "warmup-iterations": 10,
-          "iterations": 50
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ last_five_max_temp_per_station_top_metrics_5000_warmup_iterations or warmup_iterations | default(10) | tojson }},
+          "iterations": {{ last_five_max_temp_per_station_top_metrics_5000_iterations or iterations | default(50) | tojson }},
+          "target-throughput": {{ last_five_max_temp_per_station_top_metrics_5000_target_throughput or target_throughput | default(1) | tojson }},
+          "clients": {{ last_five_max_temp_per_station_top_metrics_5000_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "last_country_code_per_station_top_metrics_5000",
-          "warmup-iterations": 10,
-          "iterations": 50
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 1
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ last_country_code_per_station_top_metrics_5000_warmup_iterations or warmup_iterations | default(10) | tojson }},
+          "iterations": {{ last_country_code_per_station_top_metrics_5000_iterations or iterations | default(50) | tojson }},
+          "target-throughput": {{ last_country_code_per_station_top_metrics_5000_target_throughput or target_throughput | default(1) | tojson }},
+          "clients": {{ last_country_code_per_station_top_metrics_5000_search_clients or search_clients | default(1) }}
         }
       ]
     },


### PR DESCRIPTION
### Description
Adds configurable throughput, client, warmup + iteration values to the noaa workload

### Issues Resolved
#404 

### Testing
- [x] New functionality includes testing

tested by cherry-picked to branches 1, 3 and 7 and running [integ tests](https://github.com/OVI3D0/opensearch-benchmark/actions/runs/11332259895/job/31514005625)

### Backport to Branches:
- [ ] 6
- [x] 7
- [x] 1
- [x] 2
- [x] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
