### PR TITLE
add configurable options to nested workload

### DIFF
--- a/nested/test_procedures/default.json
+++ b/nested/test_procedures/default.json
@@ -60,115 +60,52 @@
         },
         {
           "operation": "randomized-nested-queries",
-          "warmup-iterations": 500,
-          "iterations": 1000
-          {%- if not target_throughput %}
-          ,"target-throughput": 20
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 2
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ randomized_nested_queries_warmup_iterations or warmup_iterations | default(500) | tojson }},
+          "iterations": {{ randomized_nested_queries_iterations or iterations | default(1000) | tojson }},
+          "target-throughput": {{ randomized_nested_queries_target_throughput or target_throughput | default(20) | tojson }},
+          "clients": {{ randomized_nested_queries_search_clients or search_clients | default(2) }}
         },
         {
           "operation": "randomized-term-queries",
-          "warmup-iterations": 500,
-          "iterations": 200
-          {%- if not target_throughput %}
-          ,"target-throughput": 25
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 2
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ randomized_term_queries_warmup_iterations or warmup_iterations | default(500) | tojson }},
+          "iterations": {{ randomized_term_queries_iterations or iterations | default(200) | tojson }},
+          "target-throughput": {{ randomized_term_queries_target_throughput or target_throughput | default(25) | tojson }},
+          "clients": {{ randomized_term_queries_search_clients or search_clients | default(2) }}
         },
         {
           "operation": "randomized-sorted-term-queries",
-          "warmup-iterations": 500,
-          "iterations": 200
-          {%- if not target_throughput %}
-          ,"target-throughput": 16
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 2
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ randomized_sorted_term_queries_warmup_iterations or warmup_iterations | default(500) | tojson }},
+          "iterations": {{ randomized_sorted_term_queries_iterations or iterations | default(200) | tojson }},
+          "target-throughput": {{ randomized_sorted_term_queries_target_throughput or target_throughput | default(16) | tojson }},
+          "clients": {{ randomized_sorted_term_queries_search_clients or search_clients | default(2) }}
         },
         {
           "operation": "match-all",
-          "warmup-iterations": 500,
-          "iterations": 200
-          {%- if not target_throughput %}
-          ,"target-throughput": 5
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 2
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ match_all_warmup_iterations or warmup_iterations | default(500) | tojson }},
+          "iterations": {{ match_all_iterations or iterations | default(200) | tojson }},
+          "target-throughput": {{ match_all_target_throughput or target_throughput | default(5) | tojson }},
+          "clients": {{ match_all_search_clients or search_clients | default(2) }}
         },
         {
           "operation": "nested-date-histo",
-          "warmup-iterations": 100,
-          "iterations": 200
-          {%- if not target_throughput %}
-          ,"target-throughput": 1
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 2
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ nested_date_histo_warmup_iterations or warmup_iterations | default(100) | tojson }},
+          "iterations": {{ nested_date_histo_iterations or iterations | default(200) | tojson }},
+          "target-throughput": {{ nested_date_histo_target_throughput or target_throughput | default(1) | tojson }},
+          "clients": {{ nested_date_histo_search_clients or search_clients | default(2) }}
         },
         {
           "operation": "randomized-nested-queries-with-inner-hits_default",
-          "warmup-iterations": 500,
-          "iterations": 1000
-          {%- if not target_throughput %}
-          ,"target-throughput": 18
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 2
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ randomized_nested_queries_with_inner_hits_default_warmup_iterations or warmup_iterations | default(500) | tojson }},
+          "iterations": {{ randomized_nested_queries_with_inner_hits_default_iterations or iterations | default(1000) | tojson }},
+          "target-throughput": {{ randomized_nested_queries_with_inner_hits_default_target_throughput or target_throughput | default(18) | tojson }},
+          "clients": {{ randomized_nested_queries_with_inner_hits_default_search_clients or search_clients | default(2) }}
         },
         {
           "operation": "randomized-nested-queries-with-inner-hits_default_big_size",
-          "warmup-iterations": 500,
-          "iterations": 1000
-          {%- if not target_throughput %}
-          ,"target-throughput": 16
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if not search_clients %}
-          ,"clients": 2
-          {%- elif search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ randomized_nested_queries_with_inner_hits_default_big_size_warmup_iterations or warmup_iterations | default(500) | tojson }},
+          "iterations": {{ randomized_nested_queries_with_inner_hits_default_big_size_iterations or iterations | default(1000) | tojson }},
+          "target-throughput": {{ randomized_nested_queries_with_inner_hits_default_big_size_target_throughput or target_throughput | default(16) | tojson }},
+          "clients": {{ randomized_nested_queries_with_inner_hits_default_big_size_search_clients or search_clients | default(2) }}
         }
       ]
     },


### PR DESCRIPTION
### Description
Adds configurable throughput, client, warmup + iteration values to the nested workload

### Issues Resolved
#405 

### Testing
- [x] New functionality includes testing

Tested by cherry-picking changes to branches 1, 3 and 7, and running [integ tests](https://github.com/OVI3D0/opensearch-benchmark/actions/runs/11351287613/job/31571533485)

### Backport to Branches:
- [ ] 6
- [x] 7
- [x] 1
- [x] 2
- [x] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
