### PR TITLE
Add new maintainer Michael Oviedo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @IanHoang @gkamat @beaioun @cgchinmay @rishabh6788 @VijayanB
+* @IanHoang @gkamat @beaioun @cgchinmay @rishabh6788 @VijayanB @OVI3D0

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,4 +12,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Chinmay Gadgil          | [cgchinmay](https://github.com/cgchinmay)             | Amazon      | chinmay5j@gmail.com               |
 | Rishabh Singh           | [rishabh6788](https://github.com/rishabh6788)         | Amazon      | rishabhksingh@gmail.com           |
 | Vijayan Balasubramanian | [VijayanB](https://github.com/VijayanB)               | Amazon      | vijayan.balasubramanian@gmail.com |
-
+| Michael Oviedo          | [OVI3D0](https://github.com/OVI3D0)                   | Amazon      | michaeloviedo2000@gmail.com       |


### PR DESCRIPTION
### Description
@OVI3D0 has contributed numerous changes to the OpenSearch Benchmark ecosystem. Some notable contributions he's made include implementing of the aggregation feature that debuted in OSB 1.10.0, enabling OSB to run multiple test iterations, and simplifying the user experience in OSB workloads.

To see more on his contributions, see the following links:
**OpenSearch Benchmark Repo:**
PRs: https://github.com/opensearch-project/opensearch-benchmark/pulls?q=is%3Apr+author%3AOVI3D0
Issues: https://github.com/opensearch-project/opensearch-benchmark/issues/created_by/OVI3D0

**OpenSearch Benchmark Workloads Repo:** 
PRs: https://github.com/opensearch-project/opensearch-benchmark-workloads/pulls?q=is%3Apr+author%3AOVI3D0
Issues: https://github.com/opensearch-project/opensearch-benchmark-workloads/issues/created_by/OVI3D0

OSB maintainers have voted and agreed to add Michael as a maintainer. 
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
