### PR TITLE
add configurable params for leftover operations in geonames

### DIFF
--- a/geonames/test_procedures/default.json
+++ b/geonames/test_procedures/default.json
@@ -449,59 +449,31 @@
         },
         {
           "operation": "significant_text_selective",
-          "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 2
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
-          },
+          "warmup-iterations": {{ significant_text_selective_warmup_iterations or warmup_iterations | default(200) | tojson }},
+          "iterations": {{ significant_text_selective_iterations or iterations | default(100) | tojson }},
+          "target-throughput": {{ significant_text_selective_target_throughput or target_throughput | default(2) | tojson }},
+          "clients": {{ significant_text_selective_search_clients or search_clients | default(1) }}
+        },
         {
           "operation": "significant_text_sampled_selective",
-          "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 20
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ significant_text_sampled_selective_warmup_iterations or warmup_iterations | default(200) | tojson }},
+          "iterations": {{ significant_text_sampled_selective_iterations or iterations | default(100) | tojson }},
+          "target-throughput": {{ significant_text_sampled_selective_target_throughput or target_throughput | default(20) | tojson }},
+          "clients": {{ significant_text_sampled_selective_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "significant_text_unselective",
-          "warmup-iterations": 50,
-          "iterations": 20
-          {%- if not target_throughput %}
-          ,"target-throughput": 0.04
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ significant_text_unselective_warmup_iterations or warmup_iterations | default(50) | tojson }},
+          "iterations": {{ significant_text_unselective_iterations or iterations | default(20) | tojson }},
+          "target-throughput": {{ significant_text_unselective_target_throughput or target_throughput | default(0.04) | tojson }},
+          "clients": {{ significant_text_unselective_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "significant_text_sampled_unselective",
-          "warmup-iterations": 200,
-          "iterations": 100
-          {%- if not target_throughput %}
-          ,"target-throughput": 6
-          {%- elif target_throughput is string and target_throughput.lower() == 'none' %}
-          {%- else %}
-          ,"target-throughput": {{ target_throughput | tojson }}
-          {%- endif %}
-          {%- if search_clients is defined and search_clients %}
-          ,"clients": {{ search_clients | tojson}}
-          {%- endif %}
+          "warmup-iterations": {{ significant_text_sampled_unselective_warmup_iterations or warmup_iterations | default(200) | tojson }},
+          "iterations": {{ significant_text_sampled_unselective_iterations or iterations | default(100) | tojson }},
+          "target-throughput": {{ significant_text_sampled_unselective_target_throughput or target_throughput | default(6) | tojson }},
+          "clients": {{ significant_text_sampled_unselective_search_clients or search_clients | default(1) }}
         }
       ]
     }


### PR DESCRIPTION
### Description
Had a few leftover operations from #397 

### Issues Resolved
#397 

### Testing
- [ ] New functionality includes testing

[Describe how this change was tested]

### Backport to Branches:
- [ ] 6
- [ ] 7
- [ ] 1
- [ ] 2
- [ ] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
