### PR TITLE
Add configurable parameters to geonames operations

### DIFF
--- a/geonames/test_procedures/default.json
+++ b/geonames/test_procedures/default.json
@@ -449,27 +449,31 @@
         },
         {
           "operation": "significant_text_selective",
-          "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 2
+          "warmup-iterations": {{ significant_text_selective_warmup_iterations or warmup_iterations | default(200) | tojson }},
+          "iterations": {{ significant_text_selective_iterations or iterations | default(100) | tojson }},
+          "target-throughput": {{ significant_text_selective_target_throughput or target_throughput | default(2) | tojson }},
+          "clients": {{ significant_text_selective_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "significant_text_sampled_selective",
-          "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 20
+          "warmup-iterations": {{ significant_text_sampled_selective_warmup_iterations or warmup_iterations | default(200) | tojson }},
+          "iterations": {{ significant_text_sampled_selective_iterations or iterations | default(100) | tojson }},
+          "target-throughput": {{ significant_text_sampled_selective_target_throughput or target_throughput | default(20) | tojson }},
+          "clients": {{ significant_text_sampled_selective_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "significant_text_unselective",
-          "warmup-iterations": 50,
-          "iterations": 20,
-          "target-throughput": 0.04
+          "warmup-iterations": {{ significant_text_unselective_warmup_iterations or warmup_iterations | default(50) | tojson }},
+          "iterations": {{ significant_text_unselective_iterations or iterations | default(20) | tojson }},
+          "target-throughput": {{ significant_text_unselective_target_throughput or target_throughput | default(0.04) | tojson }},
+          "clients": {{ significant_text_unselective_search_clients or search_clients | default(1) }}
         },
         {
           "operation": "significant_text_sampled_unselective",
-          "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 6
+          "warmup-iterations": {{ significant_text_sampled_unselective_warmup_iterations or warmup_iterations | default(200) | tojson }},
+          "iterations": {{ significant_text_sampled_unselective_iterations or iterations | default(100) | tojson }},
+          "target-throughput": {{ significant_text_sampled_unselective_target_throughput or target_throughput | default(6) | tojson }},
+          "clients": {{ significant_text_sampled_unselective_search_clients or search_clients | default(1) }}
         }
       ]
     }

--- a/geonames/test_procedures/default.json
+++ b/geonames/test_procedures/default.json
@@ -451,29 +451,25 @@
           "operation": "significant_text_selective",
           "warmup-iterations": {{ significant_text_selective_warmup_iterations or warmup_iterations | default(200) | tojson }},
           "iterations": {{ significant_text_selective_iterations or iterations | default(100) | tojson }},
-          "target-throughput": {{ significant_text_selective_target_throughput or target_throughput | default(2) | tojson }},
-          "clients": {{ significant_text_selective_search_clients or search_clients | default(1) }}
+          "target-throughput": {{ significant_text_selective_target_throughput or target_throughput | default(2) | tojson }}
         },
         {
           "operation": "significant_text_sampled_selective",
           "warmup-iterations": {{ significant_text_sampled_selective_warmup_iterations or warmup_iterations | default(200) | tojson }},
           "iterations": {{ significant_text_sampled_selective_iterations or iterations | default(100) | tojson }},
-          "target-throughput": {{ significant_text_sampled_selective_target_throughput or target_throughput | default(20) | tojson }},
-          "clients": {{ significant_text_sampled_selective_search_clients or search_clients | default(1) }}
+          "target-throughput": {{ significant_text_sampled_selective_target_throughput or target_throughput | default(20) | tojson }}
         },
         {
           "operation": "significant_text_unselective",
           "warmup-iterations": {{ significant_text_unselective_warmup_iterations or warmup_iterations | default(50) | tojson }},
           "iterations": {{ significant_text_unselective_iterations or iterations | default(20) | tojson }},
-          "target-throughput": {{ significant_text_unselective_target_throughput or target_throughput | default(0.04) | tojson }},
-          "clients": {{ significant_text_unselective_search_clients or search_clients | default(1) }}
+          "target-throughput": {{ significant_text_unselective_target_throughput or target_throughput | default(0.04) | tojson }}
         },
         {
           "operation": "significant_text_sampled_unselective",
           "warmup-iterations": {{ significant_text_sampled_unselective_warmup_iterations or warmup_iterations | default(200) | tojson }},
           "iterations": {{ significant_text_sampled_unselective_iterations or iterations | default(100) | tojson }},
-          "target-throughput": {{ significant_text_sampled_unselective_target_throughput or target_throughput | default(6) | tojson }},
-          "clients": {{ significant_text_sampled_unselective_search_clients or search_clients | default(1) }}
+          "target-throughput": {{ significant_text_sampled_unselective_target_throughput or target_throughput | default(6) | tojson }}
         }
       ]
     }


### PR DESCRIPTION
### Description
A few operations in geonames were not updated with configurable parameters. This change updates those last few operations

### Issues Resolved
#397 

### Testing
- [ ] New functionality includes testing

[Describe how this change was tested]

### Backport to Branches:
- [ ] 6
- [x] 7
- [x] 1
- [x] 2
- [ ] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
