### PR TITLE
Add vectorsearch README update regarding recall accuracy

### DIFF
--- a/vectorsearch/README.md
+++ b/vectorsearch/README.md
@@ -36,6 +36,9 @@ opensearch-benchmark execute-test \
     --pipeline benchmark-only \
     --kill-running-processes
 ```
+### Best Recall Results
+
+For accurate recall results, we recommend users to keep `search_clients` equal to or less than the number of CPU cores on the load generation host that is running the benchmark.
 
 ## Current Procedures
 


### PR DESCRIPTION
### Description
Currently, users are mislead by the `recall` value when using more `search_clients` than the number of CPU cores on the load generation host running the benchmark. We have already incorporated a short term fix for this https://github.com/opensearch-project/opensearch-benchmark/pull/626 but would like to update the README too.

### Issues Resolved
#347 

### Backport to Branches:
- [ ] 6
- [ ] 7
- [x] 1
- [x] 2
- [x] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
