### PR TITLE
parameterize index.translog.durability in big5 workload

### DIFF
--- a/big5/README.md
+++ b/big5/README.md
@@ -67,6 +67,7 @@ This workload allows the following parameters to be specified using `--workload-
 * `test_iterations` (default: 200): Number of test iterations per query that will have their latency and throughput measured.
 * `target_throughput` (default: 2): Target throughput for each query operation in requests per second, use 0 or "" for no throughput throttling.
 * `warmup_iterations` (default: 100): Number of warmup query iterations prior to actual measurements commencing.
+* `index_translog_durability` (default: "async"): Controls the transaction log flush behavior. "request" flushes after every operation to avoid data loss, while "async" batches changes for efficiency.
 
 NOTE: If disabling `target_throughput`, know that `target_throughput:""` is snynonymous with `target_throughput:0`.
 

--- a/big5/index.json
+++ b/big5/index.json
@@ -20,7 +20,7 @@
     {% endif %}
     "index.codec": "best_compression",
     "index.translog.sync_interval": "30s",
-    "index.translog.durability": "async",
+    "index.translog.durability": {{index_translog_durability | default("async") | tojson}},
     "index.query.default_field": [
       "message"
     ]


### PR DESCRIPTION
Description
Parameterizes index.translog.durability in the big5 workload. Default is still async as the workload is intended to evaluate performance, and is not in itself a production use-case. The user can override this by passing in `--workload-params=index_translog_durability:"request"` for example.

Issues Resolved
https://github.com/opensearch-project/opensearch-benchmark-workloads/issues/515

Testing
 New functionality includes testing
Tested by running big5 with/without new parameter

### Backport to Branches:
- [ ] 6
- [x] 7
- [x] 1
- [x] 2
- [x] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
