### PR TITLE
Adding search load for hybrid query with sort

### DIFF
--- a/noaa_semantic_search/README.md
+++ b/noaa_semantic_search/README.md
@@ -110,6 +110,11 @@ Procedure name `create-and-index`.
 The Hybrid Query Aggregations No Index procedure is used to run set of multiple search queries with hybrid query and identical bool query, both with aggregations. We do not create index and do not ingest any documents in this procedure, the assumption is that index already exists.
 Procedure name `hybrid-query-aggs-no-index`.
 
+### Hybrid Query Sorting
+
+This procedure is used to run set of multiple hybrid queries with sort and search after parameters. We do not create index and do not ingest any documents in this procedure, the assumption is that index already exists.
+Procedure name `hybrid-search-sorting`.
+
 ### Profiling
 
 The Profiling of Hybrid Query with Aggregations procedure is used to run small set of hybrid queries with aggregations to collect runtime metrics thaty can be used for analysis like profiling or debug. It does not create index or ingestg documents.

--- a/noaa_semantic_search/operations/hybrid_search_sorting.json
+++ b/noaa_semantic_search/operations/hybrid_search_sorting.json
@@ -1,0 +1,342 @@
+  {
+    "name": "bool-3-subqueries-no-sort",
+    "operation-type": "search",
+    "body": {
+      "size": 100,
+      "query": {
+        "bool": {
+            "should": [
+                {
+                    "term": {
+                        "station.country_code": "JA"
+                    }
+                },
+                {
+                    "range": {
+                        "TRANGE": {
+                            "gte": 0,
+                            "lte": 30
+                        }
+                    }
+                },
+                {
+                  "range": {
+                      "date": {
+                          "gte": "2016-06-04",
+                          "format":"yyyy-MM-dd"
+                      }
+                  }
+                }
+            ]
+        }
+      }
+    }
+  },
+  {
+    "name": "bool-3-subqueries-sort-by-score-search-after",
+    "operation-type": "search",
+    "body": {
+      "size": 100,
+      "query": {
+        "bool": {
+            "should": [
+                {
+                    "term": {
+                        "station.country_code": "JA"
+                    }
+                },
+                {
+                    "range": {
+                        "TRANGE": {
+                            "gte": 0,
+                            "lte": 30
+                        }
+                    }
+                },
+                {
+                  "range": {
+                      "date": {
+                          "gte": "2016-06-04",
+                          "format":"yyyy-MM-dd"
+                      }
+                  }
+                }
+            ]
+         }
+       },
+       "sort": [
+           {
+               "_score": {
+                   "order": "asc"
+               }
+           }
+       ],
+       "search_after": [
+           5
+       ]
+    }
+  },  
+  {
+    "name": "bool-3-subqueries-sort-by-two-fields",
+    "operation-type": "search",
+    "body": {
+      "size": 100,
+      "query": {
+        "bool": {
+            "should": [
+                {
+                    "term": {
+                        "station.country_code": "JA"
+                    }
+                },
+                {
+                    "range": {
+                        "TRANGE": {
+                            "gte": 0,
+                            "lte": 30
+                        }
+                    }
+                },
+                {
+                  "range": {
+                      "date": {
+                          "gte": "2016-06-04",
+                          "format":"yyyy-MM-dd"
+                      }
+                  }
+                }
+            ]
+        }
+      },
+      "sort": [
+          {
+              "PRCP": "desc"
+          },
+          {
+              "date": "asc"
+          }
+      ]
+    }
+  },
+  {
+    "name": "bool-3-subqueries-sort-by-two-fields-search-after",
+    "operation-type": "search",
+    "body": {
+      "size": 100,
+      "query": {
+        "bool": {
+            "should": [
+                {
+                    "term": {
+                        "station.country_code": "JA"
+                    }
+                },
+                {
+                    "range": {
+                        "TRANGE": {
+                            "gte": 0,
+                            "lte": 30
+                        }
+                    }
+                },
+                {
+                  "range": {
+                      "date": {
+                          "gte": "2016-06-04",
+                          "format":"yyyy-MM-dd"
+                      }
+                  }
+                }
+            ]
+        }
+      },
+      "sort": [
+          {
+              "PRCP": "desc"
+          },
+          {
+              "date": "asc"
+          }
+      ],
+      "search_after": [
+          5, 2
+      ]
+    }
+  },    
+  {
+    "name": "hybrid-query-3-subqueries-no-sort",
+    "operation-type": "search",
+    "request-params": {
+        "search_pipeline": "nlp-min-max-arithmetic-search-pipeline"
+    },
+    "body": {
+      "size": 100,
+      "query": {
+        "hybrid": {
+          "queries": [
+              {
+                  "term": {
+                      "station.country_code": "JA"
+                  }
+              },
+              {
+                  "range": {
+                      "TRANGE": {
+                          "gte": 0,
+                          "lte": 30
+                      }
+                  }
+              },
+              {
+                "range": {
+                    "date": {
+                        "gte": "2016-06-04",
+                        "format":"yyyy-MM-dd"
+                    }
+                }
+              }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "name": "hybrid-query-3-subqueries-sort-by-score-search-after",
+    "operation-type": "search",
+    "request-params": {
+        "search_pipeline": "nlp-min-max-arithmetic-search-pipeline"
+    },
+    "body": {
+      "size": 100,
+      "query": {
+        "hybrid": {
+          "queries": [
+              {
+                  "term": {
+                      "station.country_code": "JA"
+                  }
+              },
+              {
+                  "range": {
+                      "TRANGE": {
+                          "gte": 0,
+                          "lte": 30
+                      }
+                  }
+              },
+              {
+                "range": {
+                    "date": {
+                        "gte": "2016-06-04",
+                        "format":"yyyy-MM-dd"
+                    }
+                }
+              }
+          ]
+        }
+      },
+      "sort": [
+          {
+              "_score": {
+                  "order": "asc"
+              }
+          }
+      ],
+      "search_after": [
+          5
+      ]
+    }
+  },
+  {
+    "name": "hybrid-query-3-subqueries-sort-by-two-fields",
+    "operation-type": "search",
+    "request-params": {
+        "search_pipeline": "nlp-min-max-arithmetic-search-pipeline"
+    },
+    "body": {
+      "size": 100,
+      "query": {
+        "hybrid": {
+          "queries": [
+              {
+                  "term": {
+                      "station.country_code": "JA"
+                  }
+              },
+              {
+                  "range": {
+                      "TRANGE": {
+                          "gte": 0,
+                          "lte": 30
+                      }
+                  }
+              },
+              {
+                "range": {
+                    "date": {
+                        "gte": "2016-06-04",
+                        "format":"yyyy-MM-dd"
+                    }
+                }
+              }
+          ]
+        }
+      },
+      "sort": [
+          {
+              "PRCP": "desc"
+          },
+          {
+              "date": "asc"
+          }
+      ]
+    }
+  },  
+  {
+    "name": "hybrid-query-3-subqueries-sort-by-two-fields-search-after",
+    "operation-type": "search",
+    "request-params": {
+        "search_pipeline": "nlp-min-max-arithmetic-search-pipeline"
+    },
+    "body": {
+      "size": 100,
+      "query": {
+        "hybrid": {
+          "queries": [
+              {
+                  "term": {
+                      "station.country_code": "JA"
+                  }
+              },
+              {
+                  "range": {
+                      "TRANGE": {
+                          "gte": 0,
+                          "lte": 30
+                      }
+                  }
+              },
+              {
+                "range": {
+                    "date": {
+                        "gte": "2016-06-04",
+                        "format":"yyyy-MM-dd"
+                    }
+                }
+              }
+          ]
+        }
+      },
+      "sort": [
+          {
+              "PRCP": "desc"
+          },
+          {
+              "date": "asc"
+          }
+      ],
+      "search_after": [
+          5, 2
+      ]
+    }
+  }

--- a/noaa_semantic_search/test_procedures/hybrid_search.json
+++ b/noaa_semantic_search/test_procedures/hybrid_search.json
@@ -49,4 +49,12 @@
       "schedule": [
         {{ benchmark.collect(parts="semantic-search-common/profiler-workflow.json") }}
       ]
+    },
+    {
+      "name": "hybrid-search-sorting",
+      "description": "Run search queries with sort and search_after.",
+      "default": false,
+      "schedule": [
+        {{ benchmark.collect(parts="semantic-search-common/search-with-sort.json") }}
+      ]
     }

--- a/noaa_semantic_search/test_procedures/semantic-search-common/search-with-sort.json
+++ b/noaa_semantic_search/test_procedures/semantic-search-common/search-with-sort.json
@@ -1,0 +1,67 @@
+{
+  "name": "set-concurent-segment-search-setting",
+  "operation": {
+    "operation-type": "put-settings",
+    "body": {
+      "transient": {
+          "search.concurrent_segment_search.enabled": "{{concurrent_segment_search_enabled | default('false')}}"
+      }
+    }
+  }
+},
+{
+  "operation": "bool-3-subqueries-no-sort",
+  "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "bool-3-subqueries-sort-by-score-search-after",
+  "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "bool-3-subqueries-sort-by-two-fields",
+  "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "bool-3-subqueries-sort-by-two-fields-search-after",
+  "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "hybrid-query-3-subqueries-no-sort",
+  "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "hybrid-query-3-subqueries-sort-by-score-search-after",
+  "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "hybrid-query-3-subqueries-sort-by-two-fields",
+  "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "hybrid-query-3-subqueries-sort-by-two-fields-search-after",
+  "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+}


### PR DESCRIPTION
### Description
Adding procedure for existing workload for semantic search https://github.com/opensearch-project/opensearch-benchmark-workloads/tree/main/noaa_semantic_search that were added under https://github.com/opensearch-project/opensearch-benchmark-workloads/issues/291. 

New procedure is focused on performing hybrid and bool search queries when `sort` and `search_after` options are set.   

This is needed for new sorting related features in hybrid query:
- https://github.com/opensearch-project/neural-search/issues/866
- https://github.com/opensearch-project/neural-search/issues/933

[Describe how this change was tested]
Stability of OSB tested with this PR: https://github.com/opensearch-project/opensearch-benchmark/pull/727

Run following two commands. 
First one creates index and ingests documents from NOAA dataset:
```
opensearch-benchmark execute-test --workload-path="/home/user/dev/opensearch/opensearch-benchmark-workloads/noaa_semantic_search/" --workload-params="/home/user/dev/opensearch/opensearch-benchmark-workloads/noaa_semantic_search/params/one_replica_no_concurrent_segment_search.json" --pipeline=benchmark-only --client-options=timeout:30 --target-host=localhost:9200 --kill-running-processes --test-procedure="create-and-index"
```
second command executes the new test procedure with all new search queries:
```
opensearch-benchmark execute-test --workload-path="/home/user/dev/opensearch/opensearch-benchmark-workloads-second/noaa_semantic_search/" --workload-params="/home/user/dev/opensearch/opensearch-benchmark-workloads/noaa_semantic_search/params/one_replica_no_concurrent_segment_search.json" --pipeline=benchmark-only --client-options=timeout:30 --target-host=localhost:9200 --kill-running-processes --test-procedure="hybrid-search-sorting"
```


### Backport to Branches:
- [x] 6
- [x] 7
- [x] 1
- [x] 2
- [x] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
