### PR TITLE
Fix: Issue with parametrizing restore-snapshot operation

### DIFF
--- a/nyc_taxis/operations/snapshot.json
+++ b/nyc_taxis/operations/snapshot.json
@@ -35,7 +35,7 @@
     {
       "name": "restore-snapshot",
       "operation-type": "restore-snapshot",
-      "repository": "test-repository",
+      "repository": "{{ snapshot_repository_name | default('test-repository') }}",
       "snapshot": "{{ snapshot_name | default('test-snapshot') }}",
       "body": {
         "indices": ["nyc_taxis"],


### PR DESCRIPTION
### Issues Resolved
[List any issues this PR will resolve]
Parametrizing restore-snapshot operation.
Tested against OpenSearch v2.18 using
`opensearch-benchmark execute-test --workload=nyc_taxis --test-procedure=searchable-snapshot`
