### PR TITLE
add new procedure polling-ingest-index-only to geonames

### DIFF
--- a/geonames/test_procedures/default.json
+++ b/geonames/test_procedures/default.json
@@ -254,4 +254,44 @@
           "clients": {{ significant_text_sampled_unselective_search_clients or search_clients | default(1) | tojson }}
         }
       ]
+    },
+    {
+      "name": "polling-ingest-index-only",
+      "description": "Ingest the documents from Streaming Service into OpenSearch using polling ingestion. The index is created with the default settings.",
+      "schedule": [
+        {{ benchmark.collect(parts="../../common_operations/delete_index.json") }},
+        {% with default_index_settings={
+          "ingestion_source": {
+            "type": ingestion_source_type | default("kafka"),
+            "pointer.init.reset": "latest",
+            "param": {
+              "topic": ingestion_topic | default(""),
+              "bootstrap_servers": ingestion_bootstrap_servers | default("")
+            }
+          }
+        } %}
+        {{ benchmark.collect(parts="../../common_operations/create_index.json") }},
+        {% endwith %}
+        {{ benchmark.collect(parts="../../common_operations/check_cluster_health.json") }},
+        {
+          "operation": {
+              "name": "polling-ingest",
+              "operation-type": "produce-stream-message",
+              "bulk-size": {{bulk_size | default(100)}},
+              "ingest-percentage": {{ingest_percentage | default(100)}},
+              "ingestion-source": {
+                "type": {{ingestion_source_type | default("kafka") | tojson}},
+                "param": {
+                   "topic": {{ingestion_topic | default("") | tojson}},
+                   "bootstrap-servers": {{ingestion_bootstrap_servers | default("") | tojson}}
+                }
+             }
+          }
+        },
+        {
+          "name": "refresh-after-index",
+          "operation": "refresh"
+        },
+        {{ benchmark.collect(parts="../../common_operations/force_merge.json") }}
+      ]
     }

--- a/geonames/test_procedures/default.json
+++ b/geonames/test_procedures/default.json
@@ -272,8 +272,9 @@
         } %}
         {{ benchmark.collect(parts="../../common_operations/create_index.json") }},
         {% endwith %}
+        {% with index_name="geonames" %}
         {{ benchmark.collect(parts="../../common_operations/check_cluster_health.json") }},
-        {
+        {% endwith %}
           "operation": {
               "name": "polling-ingest",
               "operation-type": "produce-stream-message",

--- a/geonames/test_procedures/default.json
+++ b/geonames/test_procedures/default.json
@@ -263,7 +263,7 @@
         {% with default_index_settings={
           "ingestion_source": {
             "type": ingestion_source_type | default("kafka"),
-            "pointer.init.reset": "latest",
+            "pointer.init.reset": ingestion_pointer_init_reset | default("latest"),
             "param": {
               "topic": ingestion_topic | default(""),
               "bootstrap_servers": ingestion_bootstrap_servers | default("")


### PR DESCRIPTION
### Description
This PR adds a new polling-ingest-index-only procedure to geonames to support running benchmarks for polling ingestion, which is implemented in https://github.com/opensearch-project/opensearch-benchmark/pull/784

### Issues Resolved
related to issue: https://github.com/opensearch-project/OpenSearch/issues/17086

### Testing
- [x] New functionality includes testing

Tested in [PR #784](https://github.com/opensearch-project/opensearch-benchmark/pull/784) 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
