### PR TITLE
Modify big5 cardinality-agg-high from agent.name to event.id and use execution hint ordinals

### DIFF
--- a/big5/README.md
+++ b/big5/README.md
@@ -68,6 +68,7 @@ This workload allows the following parameters to be specified using `--workload-
 * `target_throughput` (default: 2): Target throughput for each query operation in requests per second, use 0 or "" for no throughput throttling.
 * `warmup_iterations` (default: 100): Number of warmup query iterations prior to actual measurements commencing.
 * `index_translog_durability` (default: "async"): Controls the transaction log flush behavior. "request" flushes after every operation to avoid data loss, while "async" batches changes for efficiency.
+* `cardinality_agg_high_field` (default: "event.id"): Use another field name for cardinality_agg_high test, previously "agent.name" was used.
 
 NOTE: If disabling `target_throughput`, know that `target_throughput:""` is snynonymous with `target_throughput:0`.
 

--- a/big5/operations/default.json
+++ b/big5/operations/default.json
@@ -872,7 +872,7 @@
         "aggs": {
           "agent": {
             "cardinality": {
-              "field": "event.id"
+             "field": "{{cardinality_agg_high_field | default('event.id')}}"
               {% if distribution_version.split('.') | map('int') | list  >= "2.19.1".split('.') | map('int') | list and distribution_version.split('.') | map('int') | list  < "6.0.0".split('.') | map('int') | list %}
               ,"execution_hint":"ordinals"
               {% endif %}

--- a/big5/operations/default.json
+++ b/big5/operations/default.json
@@ -873,7 +873,7 @@
           "agent": {
             "cardinality": {
               "field": "event.id"
-              {% if distribution_version.split('.') | map('int') | list  >= "2.19.1".split('.') | map('int') | list %}
+              {% if distribution_version.split('.') | map('int') | list  >= "2.19.1".split('.') | map('int') | list and distribution_version.split('.') | map('int') | list  < "6.0.0".split('.') | map('int') | list %}
               ,"execution_hint":"ordinals"
               {% endif %}
             }

--- a/big5/operations/default.json
+++ b/big5/operations/default.json
@@ -866,12 +866,16 @@
       "name": "cardinality-agg-high",
       "operation-type": "search",
       "index": "{{index_name | default('big5')}}",
+      "request-timeout": 1800,
       "body": {
         "size": 0,
         "aggs": {
           "agent": {
             "cardinality": {
-              "field": "agent.name"
+              "field": "event.id"
+              {% if distribution_version.split('.') | map('int') | list  >= "2.19.1".split('.') | map('int') | list %}
+              ,"execution_hint":"ordinals"
+              {% endif %}
             }
           }
         }


### PR DESCRIPTION
### Description

* as part of follow up to https://github.com/opensearch-project/OpenSearch/pull/17312
* event.id has almost 7x count as agent.name, so it serves as better benchmark for high cardinality
* for more details see #576



### Issues Resolved
Resolves #576 

### Testing
- [x] New functionality includes testing

Tested using r5.xl host with EBS Gp3 16000 IOPS, 500Gb and 1000 throughput.

Note: I had to pass in `--workload-param "distribution_version:3.0.0"` to osb, I thought it would get it from the cluster itself: https://github.com/opensearch-project/opensearch-benchmark/pull/752

**Results**:  p90 baseline agent.name `477,093ms` -> event.id `1,652,790ms` -> event.id with hint `591,289ms` (-75%, withouthint/hint = `0.357`)


#### Baseline (agent.name)

```
[ec2-user@ip-172-31-61-197 DataDir]$ opensearch-benchmark execute-test --pipeline=benchmark-only --workload=big5 --target-hosts=localhost:9200 --kill-running-processes --include-tasks "cardinality-agg-high"

   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/

[INFO] [Test Execution ID]: d6a2c893-3a3b-4215-941c-9ccf83090585
[INFO] Executing test with workload [big5], test_procedure [big5] and provision_config_instance ['external'] with version [3.0.0-SNAPSHOT].

Running cardinality-agg-high                                                   [100% done]

------------------------------------------------------
    _______             __   _____
   / ____(_)___  ____ _/ /  / ___/_________  ________
  / /_  / / __ \/ __ `/ /   \__ \/ ___/ __ \/ ___/ _ \
 / __/ / / / / / /_/ / /   ___/ / /__/ /_/ / /  /  __/
/_/   /_/_/ /_/\__,_/_/   /____/\___/\____/_/   \___/
------------------------------------------------------

|                                                         Metric |                 Task |       Value |   Unit |
|---------------------------------------------------------------:|---------------------:|------------:|-------:|
|                     Cumulative indexing time of primary shards |                      |           0 |    min |
|             Min cumulative indexing time across primary shards |                      |           0 |    min |
|          Median cumulative indexing time across primary shards |                      |           0 |    min |
|             Max cumulative indexing time across primary shards |                      |           0 |    min |
|            Cumulative indexing throttle time of primary shards |                      |           0 |    min |
|    Min cumulative indexing throttle time across primary shards |                      |           0 |    min |
| Median cumulative indexing throttle time across primary shards |                      |           0 |    min |
|    Max cumulative indexing throttle time across primary shards |                      |           0 |    min |
|                        Cumulative merge time of primary shards |                      |           0 |    min |
|                       Cumulative merge count of primary shards |                      |           0 |        |
|                Min cumulative merge time across primary shards |                      |           0 |    min |
|             Median cumulative merge time across primary shards |                      |           0 |    min |
|                Max cumulative merge time across primary shards |                      |           0 |    min |
|               Cumulative merge throttle time of primary shards |                      |           0 |    min |
|       Min cumulative merge throttle time across primary shards |                      |           0 |    min |
|    Median cumulative merge throttle time across primary shards |                      |           0 |    min |
|       Max cumulative merge throttle time across primary shards |                      |           0 |    min |
|                      Cumulative refresh time of primary shards |                      |           0 |    min |
|                     Cumulative refresh count of primary shards |                      |           2 |        |
|              Min cumulative refresh time across primary shards |                      |           0 |    min |
|           Median cumulative refresh time across primary shards |                      |           0 |    min |
|              Max cumulative refresh time across primary shards |                      |           0 |    min |
|                        Cumulative flush time of primary shards |                      |           0 |    min |
|                       Cumulative flush count of primary shards |                      |           1 |        |
|                Min cumulative flush time across primary shards |                      |           0 |    min |
|             Median cumulative flush time across primary shards |                      |           0 |    min |
|                Max cumulative flush time across primary shards |                      |           0 |    min |
|                                        Total Young Gen GC time |                      |       0.016 |      s |
|                                       Total Young Gen GC count |                      |           1 |        |
|                                          Total Old Gen GC time |                      |           0 |      s |
|                                         Total Old Gen GC count |                      |           0 |        |
|                                                     Store size |                      |     25.6365 |     GB |
|                                                  Translog size |                      | 5.12227e-08 |     GB |
|                                         Heap used for segments |                      |           0 |     MB |
|                                       Heap used for doc values |                      |           0 |     MB |
|                                            Heap used for terms |                      |           0 |     MB |
|                                            Heap used for norms |                      |           0 |     MB |
|                                           Heap used for points |                      |           0 |     MB |
|                                    Heap used for stored fields |                      |           0 |     MB |
|                                                  Segment count |                      |          15 |        |
|                                                 Min Throughput | cardinality-agg-high |        0.47 |  ops/s |
|                                                Mean Throughput | cardinality-agg-high |        0.47 |  ops/s |
|                                              Median Throughput | cardinality-agg-high |        0.47 |  ops/s |
|                                                 Max Throughput | cardinality-agg-high |        0.47 |  ops/s |
|                                        50th percentile latency | cardinality-agg-high |      411698 |     ms |
|                                        90th percentile latency | cardinality-agg-high |      477093 |     ms |
|                                        99th percentile latency | cardinality-agg-high |      491782 |     ms |
|                                       100th percentile latency | cardinality-agg-high |      493385 |     ms |
|                                   50th percentile service time | cardinality-agg-high |     2134.97 |     ms |
|                                   90th percentile service time | cardinality-agg-high |     2187.75 |     ms |
|                                   99th percentile service time | cardinality-agg-high |     2246.78 |     ms |
|                                  100th percentile service time | cardinality-agg-high |     2277.26 |     ms |
|                                                     error rate | cardinality-agg-high |           0 |      % |


---------------------------------
[INFO] SUCCESS (took 652 seconds)
---------------------------------
```


##### Switch to event.id

```
[ec2-user@ip-172-31-61-197 ~]$ opensearch-benchmark execute-test --pipeline=benchmark-only --workload=big5 --target-hosts=localhost:9200 --kill-running-processes --include-tasks "cardinality-agg-high" --workload-param "warmup_iterations:10,test_iterations:20"

   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/

[INFO] [Test Execution ID]: f0b2d54d-be57-4bd0-8c15-6f517fbbec33
[WARNING] Local changes in [/home/ec2-user/.osb/benchmarks/workloads/default] prevent workloads update from remote. Please commit your changes.
[WARNING] Local changes in [/home/ec2-user/.osb/benchmarks/workloads/default] prevent workloads update from remote. Please commit your changes.
[WARNING] Local changes in [/home/ec2-user/.osb/benchmarks/workloads/default] prevent workloads update from remote. Please commit your changes.
[INFO] Executing test with workload [big5], test_procedure [big5] and provision_config_instance ['external'] with version [3.0.0-SNAPSHOT].

Running cardinality-agg-high                                                   [100% done]

------------------------------------------------------
    _______             __   _____
   / ____(_)___  ____ _/ /  / ___/_________  ________
  / /_  / / __ \/ __ `/ /   \__ \/ ___/ __ \/ ___/ _ \
 / __/ / / / / / /_/ / /   ___/ / /__/ /_/ / /  /  __/
/_/   /_/_/ /_/\__,_/_/   /____/\___/\____/_/   \___/
------------------------------------------------------

|                                                         Metric |                 Task |       Value |   Unit |
|---------------------------------------------------------------:|---------------------:|------------:|-------:|
|                     Cumulative indexing time of primary shards |                      |           0 |    min |
|             Min cumulative indexing time across primary shards |                      |           0 |    min |
|          Median cumulative indexing time across primary shards |                      |           0 |    min |
|             Max cumulative indexing time across primary shards |                      |           0 |    min |
|            Cumulative indexing throttle time of primary shards |                      |           0 |    min |
|    Min cumulative indexing throttle time across primary shards |                      |           0 |    min |
| Median cumulative indexing throttle time across primary shards |                      |           0 |    min |
|    Max cumulative indexing throttle time across primary shards |                      |           0 |    min |
|                        Cumulative merge time of primary shards |                      |           0 |    min |
|                       Cumulative merge count of primary shards |                      |           0 |        |
|                Min cumulative merge time across primary shards |                      |           0 |    min |
|             Median cumulative merge time across primary shards |                      |           0 |    min |
|                Max cumulative merge time across primary shards |                      |           0 |    min |
|               Cumulative merge throttle time of primary shards |                      |           0 |    min |
|       Min cumulative merge throttle time across primary shards |                      |           0 |    min |
|    Median cumulative merge throttle time across primary shards |                      |           0 |    min |
|       Max cumulative merge throttle time across primary shards |                      |           0 |    min |
|                      Cumulative refresh time of primary shards |                      |           0 |    min |
|                     Cumulative refresh count of primary shards |                      |           2 |        |
|              Min cumulative refresh time across primary shards |                      |           0 |    min |
|           Median cumulative refresh time across primary shards |                      |           0 |    min |
|              Max cumulative refresh time across primary shards |                      |           0 |    min |
|                        Cumulative flush time of primary shards |                      |           0 |    min |
|                       Cumulative flush count of primary shards |                      |           1 |        |
|                Min cumulative flush time across primary shards |                      |           0 |    min |
|             Median cumulative flush time across primary shards |                      |           0 |    min |
|                Max cumulative flush time across primary shards |                      |           0 |    min |
|                                        Total Young Gen GC time |                      |       0.052 |      s |
|                                       Total Young Gen GC count |                      |          16 |        |
|                                          Total Old Gen GC time |                      |           0 |      s |
|                                         Total Old Gen GC count |                      |           0 |        |
|                                                     Store size |                      |     25.6365 |     GB |
|                                                  Translog size |                      | 5.12227e-08 |     GB |
|                                         Heap used for segments |                      |           0 |     MB |
|                                       Heap used for doc values |                      |           0 |     MB |
|                                            Heap used for terms |                      |           0 |     MB |
|                                            Heap used for norms |                      |           0 |     MB |
|                                           Heap used for points |                      |           0 |     MB |
|                                    Heap used for stored fields |                      |           0 |     MB |
|                                                  Segment count |                      |          15 |        |
|                                                 Min Throughput | cardinality-agg-high |        0.02 |  ops/s |
|                                                Mean Throughput | cardinality-agg-high |        0.02 |  ops/s |
|                                              Median Throughput | cardinality-agg-high |        0.02 |  ops/s |
|                                                 Max Throughput | cardinality-agg-high |        0.02 |  ops/s |
|                                        50th percentile latency | cardinality-agg-high | 1.20627e+06 |     ms |
|                                        90th percentile latency | cardinality-agg-high | 1.65279e+06 |     ms |
|                                       100th percentile latency | cardinality-agg-high | 1.76424e+06 |     ms |
|                                   50th percentile service time | cardinality-agg-high |     58816.9 |     ms |
|                                   90th percentile service time | cardinality-agg-high |     59961.9 |     ms |
|                                  100th percentile service time | cardinality-agg-high |     63845.7 |     ms |
|                                                     error rate | cardinality-agg-high |           0 |      % |


----------------------------------
[INFO] SUCCESS (took 1795 seconds)
----------------------------------

```

##### event.id with execution_hint=ordinals

```

[ec2-user@ip-172-31-61-197 ~]$ opensearch-benchmark execute-test --pipeline=benchmark-only --workload=big5 --target-hosts=localhost:9200 --kill-running-processes --include-tasks "cardinality-agg-high" --workload-param "distribution_version:3.0.0"

   ____                  _____                      __       ____                  __                         __
/ __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
/ / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
/_/

[INFO] [Test Execution ID]: 517abcd0-16f9-4b95-a005-c58405ebef4d
[WARNING] Local changes in [/home/ec2-user/.osb/benchmarks/workloads/default] prevent workloads update from remote. Please commit your changes.
[WARNING] Local changes in [/home/ec2-user/.osb/benchmarks/workloads/default] prevent workloads update from remote. Please commit your changes.
[WARNING] Local changes in [/home/ec2-user/.osb/benchmarks/workloads/default] prevent workloads update from remote. Please commit your changes.
[INFO] Executing test with workload [big5], test_procedure [big5] and provision_config_instance ['external'] with version [3.0.0-SNAPSHOT].

Running cardinality-agg-high                                                   [100% done]

------------------------------------------------------
    _______             __   _____
/ ____(_)___  ____ _/ /  / ___/_________  ________
/ /_  / / __ \/ __ `/ /   \__ \/ ___/ __ \/ ___/ _ \
/ __/ / / / / / /_/ / /   ___/ / /__/ /_/ / /  /  __/
/_/   /_/_/ /_/\__,_/_/   /____/\___/\____/_/   \___/
------------------------------------------------------

|                                                         Metric |                 Task |       Value |   Unit |
|---------------------------------------------------------------:|---------------------:|------------:|-------:|
|                     Cumulative indexing time of primary shards |                      |           0 |    min |
|             Min cumulative indexing time across primary shards |                      |           0 |    min |
|          Median cumulative indexing time across primary shards |                      |           0 |    min |
|             Max cumulative indexing time across primary shards |                      |           0 |    min |
|            Cumulative indexing throttle time of primary shards |                      |           0 |    min |
|    Min cumulative indexing throttle time across primary shards |                      |           0 |    min |
| Median cumulative indexing throttle time across primary shards |                      |           0 |    min |
|    Max cumulative indexing throttle time across primary shards |                      |           0 |    min |
|                        Cumulative merge time of primary shards |                      |           0 |    min |
|                       Cumulative merge count of primary shards |                      |           0 |        |
|                Min cumulative merge time across primary shards |                      |           0 |    min |
|             Median cumulative merge time across primary shards |                      |           0 |    min |
|                Max cumulative merge time across primary shards |                      |           0 |    min |
|               Cumulative merge throttle time of primary shards |                      |           0 |    min |
|       Min cumulative merge throttle time across primary shards |                      |           0 |    min |
|    Median cumulative merge throttle time across primary shards |                      |           0 |    min |
|       Max cumulative merge throttle time across primary shards |                      |           0 |    min |
|                      Cumulative refresh time of primary shards |                      |           0 |    min |
|                     Cumulative refresh count of primary shards |                      |           2 |        |
|              Min cumulative refresh time across primary shards |                      |           0 |    min |
|           Median cumulative refresh time across primary shards |                      |           0 |    min |
|              Max cumulative refresh time across primary shards |                      |           0 |    min |
|                        Cumulative flush time of primary shards |                      |           0 |    min |
|                       Cumulative flush count of primary shards |                      |           1 |        |
|                Min cumulative flush time across primary shards |                      |           0 |    min |
|             Median cumulative flush time across primary shards |                      |           0 |    min |
|                Max cumulative flush time across primary shards |                      |           0 |    min |
|                                        Total Young Gen GC time |                      |           0 |      s |
|                                       Total Young Gen GC count |                      |           0 |        |
|                                          Total Old Gen GC time |                      |           0 |      s |
|                                         Total Old Gen GC count |                      |           0 |        |
|                                                     Store size |                      |     25.6365 |     GB |
|                                                  Translog size |                      | 5.12227e-08 |     GB |
|                                         Heap used for segments |                      |           0 |     MB |
|                                       Heap used for doc values |                      |           0 |     MB |
|                                            Heap used for terms |                      |           0 |     MB |
|                                            Heap used for norms |                      |           0 |     MB |
|                                           Heap used for points |                      |           0 |     MB |
|                                    Heap used for stored fields |                      |           0 |     MB |
|                                                  Segment count |                      |          15 |        |
|                                                 Min Throughput | cardinality-agg-high |        0.38 |  ops/s |
|                                                Mean Throughput | cardinality-agg-high |        0.38 |  ops/s |
|                                              Median Throughput | cardinality-agg-high |        0.38 |  ops/s |
|                                                 Max Throughput | cardinality-agg-high |        0.39 |  ops/s |
|                                        50th percentile latency | cardinality-agg-high |      427883 |     ms |
|                                        90th percentile latency | cardinality-agg-high |      591289 |     ms |
|                                        99th percentile latency | cardinality-agg-high |      623632 |     ms |
|                                       100th percentile latency | cardinality-agg-high |      627217 |     ms |
|                                   50th percentile service time | cardinality-agg-high |     2617.87 |     ms |
|                                   90th percentile service time | cardinality-agg-high |     2657.37 |     ms |
|                                   99th percentile service time | cardinality-agg-high |     2706.87 |     ms |
|                                  100th percentile service time | cardinality-agg-high |     2718.74 |     ms |
|                                                     error rate | cardinality-agg-high |           0 |      % |


---------------------------------
[INFO] SUCCESS (took 789 seconds)
---------------------------------

```

#### Compare

```
[ec2-user@ip-172-31-61-197 ~]$ opensearch-benchmark compare --baseline f0b2d54d-be57-4bd0-8c15-6f517fbbec33 --contender  517abcd0-16f9-4b95-a005-c58405ebef4d --results-numbers-align decimal

   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/


Comparing baseline
  TestExecution ID: f0b2d54d-be57-4bd0-8c15-6f517fbbec33
  TestExecution timestamp: 2025-03-11 22:24:16
  TestProcedure: big5
  ProvisionConfigInstance: external

with contender
  TestExecution ID: 517abcd0-16f9-4b95-a005-c58405ebef4d
  TestExecution timestamp: 2025-03-12 01:01:13
  TestProcedure: big5
  ProvisionConfigInstance: external

------------------------------------------------------
    _______             __   _____
   / ____(_)___  ____ _/ /  / ___/_________  ________
  / /_  / / __ \/ __ `/ /   \__ \/ ___/ __ \/ ___/ _ \
 / __/ / / / / / /_/ / /   ___/ / /__/ /_/ / /  /  __/
/_/   /_/_/ /_/\__,_/_/   /____/\___/\____/_/   \___/
------------------------------------------------------

|                                                        Metric |                 Task |        Baseline |        Contender |              Diff |   Unit |
|--------------------------------------------------------------:|---------------------:|----------------:|-----------------:|------------------:|-------:|
|                    Cumulative indexing time of primary shards |                      |     0           |      0           |       0           |    min |
|             Min cumulative indexing time across primary shard |                      |     0           |      0           |       0           |    min |
|          Median cumulative indexing time across primary shard |                      |     0           |      0           |       0           |    min |
|             Max cumulative indexing time across primary shard |                      |     0           |      0           |       0           |    min |
|           Cumulative indexing throttle time of primary shards |                      |     0           |      0           |       0           |    min |
|    Min cumulative indexing throttle time across primary shard |                      |     0           |      0           |       0           |    min |
| Median cumulative indexing throttle time across primary shard |                      |     0           |      0           |       0           |    min |
|    Max cumulative indexing throttle time across primary shard |                      |     0           |      0           |       0           |    min |
|                       Cumulative merge time of primary shards |                      |     0           |      0           |       0           |    min |
|                      Cumulative merge count of primary shards |                      |     0           |      0           |       0           |        |
|                Min cumulative merge time across primary shard |                      |     0           |      0           |       0           |    min |
|             Median cumulative merge time across primary shard |                      |     0           |      0           |       0           |    min |
|                Max cumulative merge time across primary shard |                      |     0           |      0           |       0           |    min |
|              Cumulative merge throttle time of primary shards |                      |     0           |      0           |       0           |    min |
|       Min cumulative merge throttle time across primary shard |                      |     0           |      0           |       0           |    min |
|    Median cumulative merge throttle time across primary shard |                      |     0           |      0           |       0           |    min |
|       Max cumulative merge throttle time across primary shard |                      |     0           |      0           |       0           |    min |
|                     Cumulative refresh time of primary shards |                      |     0           |      0           |       0           |    min |
|                    Cumulative refresh count of primary shards |                      |     2           |      2           |       0           |        |
|              Min cumulative refresh time across primary shard |                      |     0           |      0           |       0           |    min |
|           Median cumulative refresh time across primary shard |                      |     0           |      0           |       0           |    min |
|              Max cumulative refresh time across primary shard |                      |     0           |      0           |       0           |    min |
|                       Cumulative flush time of primary shards |                      |     0           |      0           |       0           |    min |
|                      Cumulative flush count of primary shards |                      |     1           |      1           |       0           |        |
|                Min cumulative flush time across primary shard |                      |     0           |      0           |       0           |    min |
|             Median cumulative flush time across primary shard |                      |     0           |      0           |       0           |    min |
|                Max cumulative flush time across primary shard |                      |     0           |      0           |       0           |    min |
|                                       Total Young Gen GC time |                      |     0.052       |      0           |      -0.052       |      s |
|                                      Total Young Gen GC count |                      |    16           |      0           |     -16           |        |
|                                         Total Old Gen GC time |                      |     0           |      0           |       0           |      s |
|                                        Total Old Gen GC count |                      |     0           |      0           |       0           |        |
|                                                    Store size |                      |    25.6365      |     25.6365      |       0           |     GB |
|                                                 Translog size |                      |     5.12227e-08 |      5.12227e-08 |       0           |     GB |
|                                        Heap used for segments |                      |     0           |      0           |       0           |     MB |
|                                      Heap used for doc values |                      |     0           |      0           |       0           |     MB |
|                                           Heap used for terms |                      |     0           |      0           |       0           |     MB |
|                                           Heap used for norms |                      |     0           |      0           |       0           |     MB |
|                                          Heap used for points |                      |     0           |      0           |       0           |     MB |
|                                   Heap used for stored fields |                      |     0           |      0           |       0           |     MB |
|                                                 Segment count |                      |    15           |     15           |       0           |        |
|                                                Min Throughput | cardinality-agg-high |     0.0167275   |      0.379808    |       0.36308     |  ops/s |
|                                               Mean Throughput | cardinality-agg-high |     0.0168025   |      0.380615    |       0.36381     |  ops/s |
|                                             Median Throughput | cardinality-agg-high |     0.0168143   |      0.380062    |       0.36325     |  ops/s |
|                                                Max Throughput | cardinality-agg-high |     0.0168378   |      0.386057    |       0.36922     |  ops/s |
|                                       50th percentile latency | cardinality-agg-high |     1.20627e+06 | 427883           | -778383           |     ms |
|                                       90th percentile latency | cardinality-agg-high |     1.65279e+06 | 591289           |      -1.0615e+06  |     ms |
|                                      100th percentile latency | cardinality-agg-high |     1.76424e+06 | 627217           |      -1.13702e+06 |     ms |
|                                  50th percentile service time | cardinality-agg-high | 58816.9         |   2617.87        |  -56199           |     ms |
|                                  90th percentile service time | cardinality-agg-high | 59961.9         |   2657.37        |  -57304.5         |     ms |
|                                 100th percentile service time | cardinality-agg-high | 63845.7         |   2718.74        |  -61127           |     ms |
|                                                    error rate | cardinality-agg-high |     0           |      0           |       0           |      % |


-------------------------------
[INFO] SUCCESS (took 0 seconds)
-------------------------------

```


### Backport to Branches:
- [ ] 6
- [ ] 7
- [ ] 1
- [ ] 2
- [ ] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
