### PR TITLE
Update big5 to support pre-OpenSearch versions (ES 6.8, 7.10, etc.)

### DIFF
--- a/big5/index.json
+++ b/big5/index.json
@@ -26,10 +26,10 @@
     ]
   },
   "mappings": {
-    "_data_stream_timestamp": {
-      "enabled": true
-    },
     {% if distribution_version.split('.') | map('int') | list  < "6.0.0".split('.') | map('int') | list %}
+      "_data_stream_timestamp": {
+	"enabled": true
+      },
       "dynamic_templates": [
 	{
 	  "match_ip": {
@@ -60,182 +60,188 @@
 	}
       ],
     {% endif %}
-    "date_detection": false,
-    "properties": {
-      "@timestamp": {
-        "type": "date"
-      },
-      "agent": {
-        "type": "object",
-        "properties": {
-          "ephemeral_id": {
-            "type": "keyword",
-            "ignore_above": 1024
-          },
-          "id": {
-            "type": "keyword",
-            "ignore_above": 1024
-          },
-          "name": {
-            "type": "keyword",
-            "ignore_above": 1024
-          },
-          "type": {
-            "type": "keyword",
-            "ignore_above": 1024
-          },
-          "version": {
-            "type": "keyword",
-            "ignore_above": 1024
-          }
-        }
-      },
-      "aws": {
-        "type": "object",
-        "properties": {
-          "cloudwatch": {
-            "type": "object",
-            "properties": {
-              "ingestion_time": {
-                "type": "keyword",
-                "ignore_above": 1024
-              },
-              "log_group": {
-                "type": "keyword",
-                "ignore_above": 1024
-              },
-              "log_stream": {
-                "type": "keyword",
-                "ignore_above": 1024
-              }
-            }
-          }
-        }
-      },
-      "cloud": {
-        "type": "object",
-        "properties": {
-          "region": {
-            "type": "keyword",
-            "ignore_above": 1024
-          }
-        }
-      },
-      "data_stream": {
-        "properties": {
-          "dataset": {
-	    {% if constant_keyword_available is defined  %}
-	      "type": "constant_keyword",
-	      "value": "benchmarks"
-	    {% else %}
-	      "type": "keyword"
-	    {% endif %}
-          },
-          "namespace": {
-	    {% if constant_keyword_available is defined  %}
-	      "type": "constant_keyword",
-	      "value": "day1"
-	    {% else %}
-	      "type": "keyword"
-	    {% endif %}
-          },
-          "type": {
-	    {% if constant_keyword_available is defined  %}
-	      "type": "constant_keyword",
-	      "value": "logs"
-	    {% else %}
-	      "type": "keyword"
-	    {% endif %}
-          }
-        }
-      },
-      "ecs": {
-        "type": "object",
-        "properties": {
-          "version": {
-            "type": "keyword",
-            "ignore_above": 1024
-          }
-        }
-      },
-      "event": {
-        "type": "object",
-        "properties": {
-          "dataset": {
-            "type": "keyword",
-            "ignore_above": 1024
-          },
-          "id": {
-            "type": "keyword",
-            "ignore_above": 1024
-          },
-          "ingested": {
-            "type": "date"
-          }
-        }
-      },
-      "host": {
-        "type": "object"
-      },
-      "input": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "keyword",
-            "ignore_above": 1024
-          }
-        }
-      },
-      "log": {
-        "type": "object",
-        "properties": {
-          "file": {
-            "type": "object",
-            "properties": {
-              "path": {
-                "type": "keyword",
-                "ignore_above": 1024
-              }
-            }
-          }
-        }
-      },
-      "message": {
-        "type": "{{ match_only_text }}"
-      },
-      "meta": {
-        "type": "object",
-        "properties": {
-          "file": {
-            "type": "keyword",
-            "ignore_above": 1024
-          }
-        }
-      },
-      "metrics": {
-        "type": "object",
-        "properties": {
-          "size": {
-            "type": "long"
-          },
-          "tmin": {
-            "type": "long"
-          }
-        }
-      },
-      "process": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "keyword",
-            "ignore_above": 1024
-          }
-        }
-      },
-      "tags": {
-        "type": "keyword",
-        "ignore_above": 1024
+    {% if distribution_version.split('.') | map('int') | list  >= "6.0.0".split('.') | map('int') | list and distribution_version.split('.') | map('int') | list  < "7.0.0".split('.') | map('int') | list %}
+      "_doc": {
+    {% endif %}
+	"date_detection": false,
+	"properties": {
+	  "@timestamp": {
+	    "type": "date"
+	  },
+	  "agent": {
+	    "type": "object",
+	    "properties": {
+	      "ephemeral_id": {
+		"type": "keyword",
+		"ignore_above": 1024
+	      },
+	      "id": {
+		"type": "keyword",
+		"ignore_above": 1024
+	      },
+	      "name": {
+		"type": "keyword",
+		"ignore_above": 1024
+	      },
+	      "type": {
+		"type": "keyword",
+		"ignore_above": 1024
+	      },
+	      "version": {
+		"type": "keyword",
+		"ignore_above": 1024
+	      }
+	    }
+	  },
+	  "aws": {
+	    "type": "object",
+	    "properties": {
+	      "cloudwatch": {
+		"type": "object",
+		"properties": {
+		  "ingestion_time": {
+		    "type": "keyword",
+		    "ignore_above": 1024
+		  },
+		  "log_group": {
+		    "type": "keyword",
+		    "ignore_above": 1024
+		  },
+		  "log_stream": {
+		    "type": "keyword",
+		    "ignore_above": 1024
+		  }
+		}
+	      }
+	    }
+	  },
+	  "cloud": {
+	    "type": "object",
+	    "properties": {
+	      "region": {
+		"type": "keyword",
+		"ignore_above": 1024
+	      }
+	    }
+	  },
+	  "data_stream": {
+	    "properties": {
+	      "dataset": {
+		{% if constant_keyword_available is defined  %}
+		  "type": "constant_keyword",
+		  "value": "benchmarks"
+		{% else %}
+		  "type": "keyword"
+		{% endif %}
+	      },
+	      "namespace": {
+		{% if constant_keyword_available is defined  %}
+		  "type": "constant_keyword",
+		  "value": "day1"
+		{% else %}
+		  "type": "keyword"
+		{% endif %}
+	      },
+	      "type": {
+		{% if constant_keyword_available is defined  %}
+		  "type": "constant_keyword",
+		  "value": "logs"
+		{% else %}
+		  "type": "keyword"
+		{% endif %}
+	      }
+	    }
+	  },
+	  "ecs": {
+	    "type": "object",
+	    "properties": {
+	      "version": {
+		"type": "keyword",
+		"ignore_above": 1024
+	      }
+	    }
+	  },
+	  "event": {
+	    "type": "object",
+	    "properties": {
+	      "dataset": {
+		"type": "keyword",
+		"ignore_above": 1024
+	      },
+	      "id": {
+		"type": "keyword",
+		"ignore_above": 1024
+	      },
+	      "ingested": {
+		"type": "date"
+	      }
+	    }
+	  },
+	  "host": {
+	    "type": "object"
+	  },
+	  "input": {
+	    "type": "object",
+	    "properties": {
+	      "type": {
+		"type": "keyword",
+		"ignore_above": 1024
+	      }
+	    }
+	  },
+	  "log": {
+	    "type": "object",
+	    "properties": {
+	      "file": {
+		"type": "object",
+		"properties": {
+		  "path": {
+		    "type": "keyword",
+		    "ignore_above": 1024
+		  }
+		}
+	      }
+	    }
+	  },
+	  "message": {
+	    "type": "{{ match_only_text }}"
+	  },
+	  "meta": {
+	    "type": "object",
+	    "properties": {
+	      "file": {
+		"type": "keyword",
+		"ignore_above": 1024
+	      }
+	    }
+	  },
+	  "metrics": {
+	    "type": "object",
+	    "properties": {
+	      "size": {
+		"type": "long"
+	      },
+	      "tmin": {
+		"type": "long"
+	      }
+	    }
+	  },
+	  "process": {
+	    "type": "object",
+	    "properties": {
+	      "name": {
+		"type": "keyword",
+		"ignore_above": 1024
+	      }
+	    }
+	  },
+	  "tags": {
+	    "type": "keyword",
+	    "ignore_above": 1024
+	  }
+	}
+    {% if distribution_version.split('.') | map('int') | list  >= "6.0.0".split('.') | map('int') | list and distribution_version.split('.') | map('int') | list  < "7.0.0".split('.') | map('int') | list %}
       }
-    }
+    {% endif %}
   }
 }

--- a/big5/operations/default.json
+++ b/big5/operations/default.json
@@ -95,7 +95,11 @@
           "by_hour": {
             "date_histogram": {
               "field": "@timestamp",
-              "calendar_interval": "hour"
+              {% if distribution_version.split('.') | map('int') | list < "6.0.0".split('.') | map('int') | list or distribution_version.split('.') | map('int') | list >= "7.0.0".split('.') | map('int') | list %}
+                "calendar_interval": "hour"
+              {% else %}
+                "interval": "hour"
+              {% endif %}
             }
           }
         }
@@ -119,7 +123,11 @@
           "by_hour": {
             "date_histogram": {
               "field": "@timestamp",
-              "calendar_interval": "minute"
+              {% if distribution_version.split('.') | map('int') | list < "6.0.0".split('.') | map('int') | list or distribution_version.split('.') | map('int') | list >= "7.0.0".split('.') | map('int') | list %}
+                "calendar_interval": "minute"
+              {% else %}
+                "interval": "minute"
+              {% endif %}
             }
           }
         }
@@ -162,7 +170,11 @@
         "sort" : [
           {"@timestamp" : "desc"}
         ],
-        "search_after": ["2023-01-06T23:59:58.000Z"]
+	{% if distribution_version.split('.') | map('int') | list < "6.0.0".split('.') | map('int') | list or distribution_version.split('.') | map('int') | list >= "7.0.0".split('.') | map('int') | list %}
+          "search_after": ["2023-01-01T23:59:58.000Z"]
+	{% else %}
+          "search_after": [1673049598]
+	{% endif %}
       }
     },
     {
@@ -190,7 +202,11 @@
         "sort" : [
           {"@timestamp" : "asc"}
         ],
-        "search_after": ["2023-01-01T23:59:58.000Z"]
+	{% if distribution_version.split('.') | map('int') | list < "6.0.0".split('.') | map('int') | list or distribution_version.split('.') | map('int') | list >= "7.0.0".split('.') | map('int') | list %}
+          "search_after": ["2023-01-01T23:59:58.000Z"]
+	{% else %}
+          "search_after": [1673049598]
+	{% endif %}
       }
     },
     {
@@ -808,7 +824,11 @@
           "logs": {
             "composite": {
               "sources": [
-                { "date": { "date_histogram": { "field": "@timestamp", "calendar_interval": "day" } } }
+		{% if distribution_version.split('.') | map('int') | list < "6.0.0".split('.') | map('int') | list or distribution_version.split('.') | map('int') | list >= "7.0.0".split('.') | map('int') | list %}
+                  { "date": { "date_histogram": { "field": "@timestamp", "calendar_interval": "day" } } }
+		{% else %}
+                  { "date": { "date_histogram": { "field": "@timestamp", "interval": "day" } } }
+		{% endif %}
               ]
             }
           }

--- a/big5/workload.json
+++ b/big5/workload.json
@@ -15,6 +15,9 @@
   "corpora": [
     {
       "name": "big5",
+      {% if distribution_version.split('.') | map('int') | list >= "6.0.0".split('.') | map('int') | list and distribution_version.split('.') | map('int') | list < "7.0.0".split('.') | map('int') | list %}
+        "target-type": "_doc",
+      {% endif %}
       "base-url": "https://dbyiw3u3rf9yr.cloudfront.net/corpora/big5",
       "documents": [
 	{% if not corpus_size %}


### PR DESCRIPTION
### Description
Update _big5_ to support pre-OpenSearch versions (ES 6.8, 7.10, etc.)

### Issues Resolved
#531 

### Testing
Ran the workload against ES 6.8 and 7.10, and against OpenSearch 2.11.

### Backport to Branches:
- [ x] 6
- [ x] 7
- [ x] 1
- [ x] 2
- [ x] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
