### PR TITLE
[Backport 7] insert index_name in common operations/cluster health operations in workload schedules

### DIFF
--- a/big5/test_procedures/common/big5-schedule.json
+++ b/big5/test_procedures/common/big5-schedule.json
@@ -1,4 +1,3 @@
-{{ benchmark.collect(parts="../../../common_operations/workload_setup.json") }},
 {
   "operation": "default",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},

--- a/big5/test_procedures/default.json
+++ b/big5/test_procedures/default.json
@@ -2,6 +2,9 @@
   "name": "big5",
   "default": true,
   "schedule": [
+    {% with default_index_settings={}, index_name="big5" %}
+    {{ benchmark.collect(parts="../../common_operations/workload_setup.json") }},
+    {% endwith %}
     {{ benchmark.collect(parts="common/big5-schedule.json") }}
   ]
 },
@@ -9,6 +12,9 @@
   "name": "test",
   "default": false,
   "schedule": [
+    {% with default_index_settings={}, index_name="big5" %}
+    {{ benchmark.collect(parts="../../common_operations/workload_setup.json") }},
+    {% endwith %}
     {{ benchmark.collect(parts="common/test-schedule.json") }}
   ]
 }

--- a/eventdata/test_procedures/default.json
+++ b/eventdata/test_procedures/default.json
@@ -1,9 +1,11 @@
-    {
+{
       "name": "append-no-conflicts",
       "description": "Indexes the whole document corpus using OpenSearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Benchmark will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only.",
       "default": true,
       "schedule": [
-        {{ benchmark.collect(parts="../../common_operations/workload_setup.json") }}
+        {% with default_index_settings={}, index_name="eventdata" %}
+          {{ benchmark.collect(parts="../../common_operations/workload_setup.json") }}
+        {% endwith %}
       ]
     },
     {
@@ -11,7 +13,9 @@
       "description": "Indexes the whole document corpus using OpenSearch default settings and run transforms to pivot data by terms, date and geo tiles.",
       "default": false,
       "schedule": [
-        {{ benchmark.collect(parts="../../common_operations/workload_setup.json") }},
+        {% with default_index_settings={}, index_name="eventdata" %}
+          {{ benchmark.collect(parts="../../common_operations/workload_setup.json") }},
+        {% endwith %}
         {
           "name": "delete-transform-group-by-terms",
           "operation": {

--- a/geonames/test_procedures/default.json
+++ b/geonames/test_procedures/default.json
@@ -3,7 +3,7 @@
       "description": "Indexes the whole document corpus using OpenSearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Benchmark will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only. After that a couple of queries are run.",
       "default": true,
       "schedule": [
-        {% with default_index_settings={} %}
+        {% with default_index_settings={}, index_name="geonames" %}
         {{ benchmark.collect(parts="../../common_operations/workload_setup.json") }},
         {% endwith %}
         {
@@ -188,7 +188,7 @@
       "name": "append-no-conflicts-index-only",
       "description": "Indexes the whole document corpus using OpenSearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Benchmark will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only.",
       "schedule": [
-        {% with default_index_settings={} %}
+        {% with default_index_settings={}, index_name="geonames" %}
         {{ benchmark.collect(parts="../../common_operations/workload_setup.json") }}
         {% endwith %}
       ]
@@ -200,7 +200,7 @@
         {% with default_index_settings={
           "index.sort.field": ["country_code.raw", "admin1_code.raw"],
           "index.sort.order": ["asc", "asc"]
-        } %}
+        }, index_name="geonames" %}
         {{ benchmark.collect(parts="../../common_operations/workload_setup.json") }}
         {% endwith %}
       ]
@@ -213,7 +213,7 @@
           "index.refresh_interval": "30s",
           "index.number_of_shards": number_of_shards | default(6),
           "index.translog.flush_threshold_size": "4g"
-        } %}
+        }, index_name="geonames" %}
         {{ benchmark.collect(parts="../../common_operations/workload_setup.json") }}
         {% endwith %}
       ]
@@ -222,7 +222,7 @@
       "name": "significant-text",
       "description": "Indexes the whole document corpus using OpenSearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Benchmark will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only.",
       "schedule": [
-        {% with default_index_settings={} %}
+        {% with default_index_settings={}, index_name="geonames" %}
         {{ benchmark.collect(parts="../../common_operations/workload_setup.json") }},
         {% endwith %}
         {

--- a/geopoint/test_procedures/default.json
+++ b/geopoint/test_procedures/default.json
@@ -3,7 +3,9 @@
       "description": "Indexes the whole document corpus using OpenSearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Benchmark will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only. After that a couple of queries are run.",
       "default": true,
       "schedule": [
+        {% with default_index_settings={}, index_name="osmgeopoints" %}
         {{ benchmark.collect(parts="../../common_operations/workload_setup.json") }},
+        {% endwith %}
         {
           "operation": "polygon",
           "warmup-iterations": 200,
@@ -38,7 +40,9 @@
       "name": "append-no-conflicts-index-only",
       "description": "Indexes the whole document corpus using OpenSearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Benchmark will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only.",
       "schedule": [
+        {% with default_index_settings={}, index_name="osmgeopoints" %}
         {{ benchmark.collect(parts="../../common_operations/workload_setup.json") }}
+        {% endwith %}
       ]
     },
     {
@@ -49,7 +53,7 @@
           "index.refresh_interval": "30s",
           "index.number_of_shards": number_of_shards | default(6),
           "index.translog.flush_threshold_size": "4g"
-        } %}
+        }, index_name="osmgeopoints" %}
         {{ benchmark.collect(parts="../../common_operations/workload_setup.json") }}
         {% endwith %}
       ]

--- a/geopointshape/test_procedures/default.json
+++ b/geopointshape/test_procedures/default.json
@@ -3,7 +3,9 @@
       "description": "Indexes the whole document corpus using OpenSearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Benchmark will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only. After that a couple of queries are run.",
       "default": true,
       "schedule": [
+        {% with default_index_settings={}, index_name="osmgeoshapes" %}
         {{ benchmark.collect(parts="../../common_operations/workload_setup.json") }},
+        {% endwith %}
         {
           "operation": "polygon",
           "warmup-iterations": 200,
@@ -24,7 +26,9 @@
       "name": "append-no-conflicts-index-only",
       "description": "Indexes the whole document corpus using OpenSearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Benchmark will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only.",
       "schedule": [
+        {% with default_index_settings={}, index_name="osmgeoshapes" %}
         {{ benchmark.collect(parts="../../common_operations/workload_setup.json") }}
+        {% endwith %}
       ]
     },
     {
@@ -35,7 +39,7 @@
           "index.refresh_interval": "30s",
           "index.number_of_shards": number_of_shards | default(6),
           "index.translog.flush_threshold_size": "4g"
-        } %}
+        }, index_name="osmgeoshapes" %}
         {{ benchmark.collect(parts="../../common_operations/workload_setup.json") }}
         {% endwith %}
       ]

--- a/http_logs/test_procedures/default.json
+++ b/http_logs/test_procedures/default.json
@@ -3,7 +3,9 @@
       "description": "Indexes the whole document corpus using OpenSearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Benchmark will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only. After that a couple of queries are run.",
       "default": true,
       "schedule": [
+        {% with default_index_settings={}, index_name="logs-*" %}
         {{ benchmark.collect(parts="../../common_operations/workload_setup.json") }},
+        {% endwith %}
         {
           "operation": "default",
           "warmup-iterations": {{ default_warmup_iterations or warmup_iterations | default(500) | tojson }},
@@ -147,7 +149,9 @@
       "name": "append-no-conflicts-index-only",
       "description": "Indexes the whole document corpus using OpenSearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Benchmark will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only.",
       "schedule": [
+        {% with default_index_settings={}, index_name="logs-*" %}
         {{ benchmark.collect(parts="../../common_operations/workload_setup.json") }}
+        {% endwith %}
       ]
     },
     {
@@ -157,7 +161,7 @@
         {% with default_index_settings={
               "index.sort.field": "@timestamp",
               "index.sort.order": "desc"
-        } %}
+        }, index_name="logs-*" %}
         {{ benchmark.collect(parts="../../common_operations/workload_setup.json") }}
         {% endwith %}
       ]
@@ -168,7 +172,9 @@
       "schedule": [
         {{ benchmark.collect(parts="../../common_operations/delete_index.json") }},
         {{ benchmark.collect(parts="../../common_operations/create_index.json") }},
+        {% with default_index_settings={}, index_name="logs-*" %}
         {{ benchmark.collect(parts="../../common_operations/check_cluster_health.json") }},
+        {% endwith %}
         {
         "operation": "create-http-log-{{ingest_pipeline | default('baseline')}}-pipeline"
         },
@@ -193,7 +199,7 @@
           "index.number_of_shards": number_of_shards | default(1),
           "index.number_of_replicas": number_of_replicas | default(0),
           "index.store.type": store_type | default('fs')
-        } %}
+        }, index_name="logs-*" %}
         {{ benchmark.collect(parts="../../common_operations/create_index.json") }},
         {% endwith %}
         {{ benchmark.collect(parts="../../common_operations/check_cluster_health.json") }},
@@ -214,7 +220,9 @@
       "name": "append-no-conflicts-index-reindex-only",
       "description": "Indexes the whole document corpus using OpenSearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Benchmark will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only. After indexing, same data are reindexed.",
       "schedule": [
+        {% with default_index_settings={}, index_name="logs-*" %}
         {{ benchmark.collect(parts="../../common_operations/workload_setup.json") }},
+        {% endwith %}
         {
           "name": "reindex",
           "operation": {

--- a/nested/test_procedures/default.json
+++ b/nested/test_procedures/default.json
@@ -3,7 +3,9 @@
       "description": "Indexes the document corpus for an hour using OpenSearch default settings. After that randomized nested queries are run.",
       "default": true,
       "schedule": [
+        {% with default_index_settings={}, index_name="sonested" %}
         {{ benchmark.collect(parts="../../common_operations/workload_setup.json") }},
+        {% endwith %}
         {
           "operation": "randomized-nested-queries",
           "warmup-iterations": {{ randomized_nested_queries_warmup_iterations or warmup_iterations | default(500) | tojson }},
@@ -59,6 +61,8 @@
       "name": "index-only",
       "description": "Indexes the document corpus for an hour using OpenSearch default settings.",
       "schedule": [
+        {% with default_index_settings={}, index_name="sonested" %}
         {{ benchmark.collect(parts="../../common_operations/workload_setup.json") }}
+        {% endwith %}
       ]
     }

--- a/noaa/test_procedures/default.json
+++ b/noaa/test_procedures/default.json
@@ -5,7 +5,9 @@
       "schedule": [
         {{ benchmark.collect(parts="../../common_operations/delete_index.json") }},
         {{ benchmark.collect(parts="../../common_operations/create_index.json") }},
+        {% with default_index_settings={}, index_name="weather-data-2016" %}
         {{ benchmark.collect(parts="../../common_operations/check_cluster_health.json") }},
+        {% endwith %}
         {
           "operation": "index",
           "#COMMENT": "This is an incredibly short warmup time period but it is necessary to get also measurement samples. As this benchmark is rather about search than indexing this is ok.",
@@ -82,7 +84,9 @@
       "schedule": [
         {{ benchmark.collect(parts="../../common_operations/delete_index.json") }},
         {{ benchmark.collect(parts="../../common_operations/create_index.json") }},
+        {% with default_index_settings={}, index_name="weather-data-2016" %}
         {{ benchmark.collect(parts="../../common_operations/check_cluster_health.json") }},
+        {% endwith %}
         {
           "operation": "index",
           "#COMMENT": "This is an incredibly short warmup time period but it is necessary to get also measurement samples. As this benchmark is rather about search than indexing this is ok.",
@@ -104,7 +108,9 @@
       "schedule": [
         {{ benchmark.collect(parts="../../common_operations/delete_index.json") }},
         {{ benchmark.collect(parts="../../common_operations/create_index.json") }},
+        {% with default_index_settings={}, index_name="weather-data-2016" %}
         {{ benchmark.collect(parts="../../common_operations/check_cluster_health.json") }},
+        {% endwith %}
         {
           "operation": "index",
           "#COMMENT": "This is an incredibly short warmup time period but it is necessary to get also measurement samples. As this benchmark is rather about search than indexing this is ok.",
@@ -261,7 +267,9 @@
       "schedule": [
         {{ benchmark.collect(parts="../../common_operations/delete_index.json") }},
         {{ benchmark.collect(parts="../../common_operations/create_index.json") }},
+        {% with default_index_settings={}, index_name="weather-data-2016" %}
         {{ benchmark.collect(parts="../../common_operations/check_cluster_health.json") }},
+        {% endwith %}
         {
           "operation": "index",
           "#COMMENT": "This is an incredibly short warmup time period but it is necessary to get also measurement samples. As this benchmark is rather about search than indexing this is ok.",

--- a/nyc_taxis/test_procedures/default.json
+++ b/nyc_taxis/test_procedures/default.json
@@ -11,7 +11,9 @@
         } %}
         {{ benchmark.collect(parts="../../common_operations/create_index.json") }},
         {% endwith %}
+        {% with default_index_settings={}, index_name="nyc_taxis" %}
         {{ benchmark.collect(parts="../../common_operations/check_cluster_health.json") }},
+        {% endwith %}
         {
           "operation": "index",
           "warmup-time-period": 240,
@@ -72,7 +74,9 @@
         } %}
         {{ benchmark.collect(parts="../../common_operations/create_index.json") }},
         {% endwith %}
+        {% with default_index_settings={}, index_name="nyc_taxis" %}
         {{ benchmark.collect(parts="../../common_operations/check_cluster_health.json") }},
+        {% endwith %}
         {
           "operation": "index",
           "warmup-time-period": 240,
@@ -100,7 +104,9 @@
         } %}
         {{ benchmark.collect(parts="../../common_operations/create_index.json") }},
         {% endwith %}
+        {% with default_index_settings={}, index_name="nyc_taxis" %}
         {{ benchmark.collect(parts="../../common_operations/check_cluster_health.json") }},
+        {% endwith %}
         {
           "operation": "index",
           "warmup-time-period": 240,
@@ -125,7 +131,9 @@
         } %}
         {{ benchmark.collect(parts="../../common_operations/create_index.json") }},
         {% endwith %}
+        {% with default_index_settings={}, index_name="nyc_taxis" %}
         {{ benchmark.collect(parts="../../common_operations/check_cluster_health.json") }},
+        {% endwith %}
         {
           "operation": "update",
           "warmup-time-period": 1200,

--- a/percolator/test_procedures/default.json
+++ b/percolator/test_procedures/default.json
@@ -5,7 +5,9 @@
       "schedule": [
         {{ benchmark.collect(parts="../../common_operations/delete_index.json") }},
         {{ benchmark.collect(parts="../../common_operations/create_index.json") }},
+        {% with default_index_settings={}, index_name="queries" %}
         {{ benchmark.collect(parts="../../common_operations/check_cluster_health.json") }},
+        {% endwith %}
         {
           "operation": "index",
           "#COMMENT": "This is an incredibly short warmup time period but it is necessary to get also measurement samples. As this benchmark is rather about search than indexing this is ok.",

--- a/pmc/test_procedures/default.json
+++ b/pmc/test_procedures/default.json
@@ -15,7 +15,9 @@
         },
         {{ benchmark.collect(parts="../../common_operations/delete_index.json") }},
         {{ benchmark.collect(parts="../../common_operations/create_index.json") }},
+        {% with default_index_settings={}, index_name="pmc" %}
         {{ benchmark.collect(parts="../../common_operations/check_cluster_health.json") }},
+        {% endwith %}
         {
           "operation": "index-append",
           "warmup-time-period": 240,
@@ -77,7 +79,9 @@
       "schedule": [
         {{ benchmark.collect(parts="../../common_operations/delete_index.json") }},
         {{ benchmark.collect(parts="../../common_operations/create_index.json") }},
+        {% with default_index_settings={}, index_name="pmc" %}
         {{ benchmark.collect(parts="../../common_operations/check_cluster_health.json") }},
+        {% endwith %}
         {
           "operation": "index-append",
           "warmup-time-period": 240,
@@ -98,7 +102,7 @@
         {% with default_index_settings={
           "index.sort.field": "timestamp", 
           "index.sort.order": "desc"
-        } %}
+        }, index_name="pmc" %}
         {{ benchmark.collect(parts="../../common_operations/workload_setup.json") }}
         {% endwith %}
       ]
@@ -115,7 +119,9 @@
         } %}
         {{ benchmark.collect(parts="../../common_operations/create_index.json") }},
         {% endwith %}
+        {% with default_index_settings={}, index_name="pmc" %}
         {{ benchmark.collect(parts="../../common_operations/check_cluster_health.json") }},
+        {% endwith %}
         {
           "operation": "index-update",
           "warmup-time-period": 240,

--- a/so/test_procedures/default.json
+++ b/so/test_procedures/default.json
@@ -3,6 +3,8 @@
       "description": "Indexes the whole document corpus using OpenSearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Benchmark will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only.",
       "default": true,
       "schedule": [
+        {% with default_index_settings={}, index_name="so" %}
         {{ benchmark.collect(parts="../../common_operations/workload_setup.json") }}
+        {% endwith %}
       ]
     }

--- a/treccovid_semantic_search/test_procedures/default.json
+++ b/treccovid_semantic_search/test_procedures/default.json
@@ -54,7 +54,9 @@
         } %}
         {{ benchmark.collect(parts="../../common_operations/create_index.json") }},
         {% endwith %}
+        {% with default_index_settings={}, index_name="treccovid" %}
         {{ benchmark.collect(parts="../../common_operations/check_cluster_health.json") }},
+        {% endwith %}
         {
           "operation": "index-append",
           "warmup-time-period": 60,


### PR DESCRIPTION
### Description
Cherry-pick changes from #577 to branch 7. Conflict caused by missing test_procedures folder in geoshape workload on branch 7.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
