### PR TITLE
Rename Default Operations to Match-All

### DIFF
--- a/big5/operations/default.json
+++ b/big5/operations/default.json
@@ -5,7 +5,7 @@
       "ingest-percentage": {{ingest_percentage | default(100)}}
     },
     {
-      "name": "default",
+      "name": "match-all",
       "operation-type": "search",
       "index": "{{index_name | default('big5')}}",
       "body": {

--- a/big5/test_procedures/common/big5-schedule.json
+++ b/big5/test_procedures/common/big5-schedule.json
@@ -1,5 +1,5 @@
 {
-  "operation": "default",
+  "operation": "match-all",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},
   "target-throughput": {{ target_throughput | default(2) | tojson }},

--- a/big5/test_procedures/common/test-schedule.json
+++ b/big5/test_procedures/common/test-schedule.json
@@ -1,5 +1,5 @@
 {
-  "operation": "default",
+  "operation": "match-all",
   "warmup-iterations": 500,
   "iterations": 100,
   "target-throughput": 20

--- a/geonames/operations/default.json
+++ b/geonames/operations/default.json
@@ -15,7 +15,7 @@
       "recency": {{recency | default(0)}}
     },
     {
-      "name": "default",
+      "name": "match-all",
       "operation-type": "search",
       "body": {
         "query": {

--- a/geonames/test_procedures/default.json
+++ b/geonames/test_procedures/default.json
@@ -21,7 +21,7 @@
           "clients": {{ node_stats_search_clients or search_clients | default(1) }}
         },
         {
-          "operation": "default",
+          "operation": "match-all",
           "warmup-iterations": {{ default_warmup_iterations or warmup_iterations | default(500) | tojson }},
           "iterations": {{ default_iterations or iterations | default(1000) | tojson }},
           "target-throughput": {{ default_target_throughput or target_throughput | default(50) | tojson }},

--- a/geonames/test_procedures/default.json
+++ b/geonames/test_procedures/default.json
@@ -22,8 +22,8 @@
         },
         {
           "operation": "match-all",
-          "warmup-iterations": {{ default_warmup_iterations or warmup_iterations | default(500) | tojson }},
-          "iterations": {{ default_iterations or iterations | default(1000) | tojson }},
+          "warmup-iterations": {{ match_all_warmup_iterations or warmup_iterations | default(500) | tojson }},
+          "iterations": {{ match_all_iterations or iterations | default(1000) | tojson }},
           "target-throughput": {{ default_target_throughput or target_throughput | default(50) | tojson }},
           "clients": {{ default_search_clients or search_clients | default(1) }}
         },

--- a/http_logs/operations/default.json
+++ b/http_logs/operations/default.json
@@ -49,7 +49,7 @@
       "corpora": "http_logs"
     },
     {
-      "name": "default",
+      "name": "match-all",
       "operation-type": "search",
       "index": "logs-*",
       "body": {

--- a/http_logs/test_procedures/default.json
+++ b/http_logs/test_procedures/default.json
@@ -8,8 +8,8 @@
         {% endwith %}
         {
           "operation": "match-all",
-          "warmup-iterations": {{ default_warmup_iterations or warmup_iterations | default(500) | tojson }},
-          "iterations": {{ default_iterations or iterations | default(100) | tojson }},
+          "warmup-iterations": {{ match_all_warmup_iterations or warmup_iterations | default(500) | tojson }},
+          "iterations": {{ match_all_iterations or iterations | default(100) | tojson }},
           "target-throughput": {{ default_target_throughput or target_throughput | default(8) | tojson }},
           "clients": {{ default_search_clients or search_clients | default(1) }}
         },
@@ -175,8 +175,8 @@
         {% endwith %}
         {
           "operation": "match-all",
-          "warmup-iterations": {{ default_warmup_iterations or warmup_iterations | default(500) | tojson }},
-          "iterations": {{ default_iterations or iterations | default(100) | tojson }},
+          "warmup-iterations": {{ match_all_warmup_iterations or warmup_iterations | default(500) | tojson }},
+          "iterations": {{ match_all_iterations or iterations | default(100) | tojson }},
           "target-throughput": {{ default_target_throughput or target_throughput | default(8) | tojson }},
           "clients": {{ default_search_clients or search_clients | default(1) }}
         },

--- a/http_logs/test_procedures/default.json
+++ b/http_logs/test_procedures/default.json
@@ -7,7 +7,7 @@
         {{ benchmark.collect(parts="../../common_operations/workload_setup.json") }},
         {% endwith %}
         {
-          "operation": "default",
+          "operation": "match-all",
           "warmup-iterations": {{ default_warmup_iterations or warmup_iterations | default(500) | tojson }},
           "iterations": {{ default_iterations or iterations | default(100) | tojson }},
           "target-throughput": {{ default_target_throughput or target_throughput | default(8) | tojson }},
@@ -174,7 +174,7 @@
         {{ benchmark.collect(parts="../../common_operations/workload_setup.json") }},
         {% endwith %}
         {
-          "operation": "default",
+          "operation": "match-all",
           "warmup-iterations": {{ default_warmup_iterations or warmup_iterations | default(500) | tojson }},
           "iterations": {{ default_iterations or iterations | default(100) | tojson }},
           "target-throughput": {{ default_target_throughput or target_throughput | default(8) | tojson }},
@@ -463,7 +463,7 @@
         {{ benchmark.collect(parts="../../common_operations/force_merge.json") }},
         {
           "name": "match-all",
-          "operation": "default",
+          "operation": "match-all",
           "warmup-iterations": {{ match_all_warmup_iterations or warmup_iterations | default(500) | tojson }},
           "iterations": {{ match_all_iterations or iterations | default(100) | tojson }},
           "target-throughput": {{ match_all_target_throughput or target_throughput | default(8) | tojson }},
@@ -471,7 +471,7 @@
         },
         {
           "name": "match-all-baseline-search-pipeline",
-          "operation": "default",
+          "operation": "match-all",
           "request-params": {
             "search-pipeline": "http-log-baseline-search-pipeline"
           },
@@ -482,7 +482,7 @@
         },
         {
           "name": "match-all-status-filter-search-pipeline",
-          "operation": "default",
+          "operation": "match-all",
           "request-params": {
             "search-pipeline": "http-log-status-filter-search-pipeline"
           },
@@ -493,7 +493,7 @@
         },
         {
           "name": "match-all-rename-field-search-pipeline",
-          "operation": "default",
+          "operation": "match-all",
           "request-params": {
             "search-pipeline": "http-log-rename-field-search-pipeline"
           },
@@ -504,7 +504,7 @@
         },
         {
           "name": "match-all-rename-100-field-search-pipeline",
-          "operation": "default",
+          "operation": "match-all",
           "request-params": {
             "search-pipeline": "http-log-rename-100-field-search-pipeline"
           },
@@ -515,7 +515,7 @@
         },
         {
           "name": "match-all-dummy-scripting-search-pipeline",
-          "operation": "default",
+          "operation": "match-all",
           "request-params": {
             "search-pipeline": "http-log-dummy-scripting-search-pipeline"
           },
@@ -526,7 +526,7 @@
         },
         {
           "name": "match-all-100-dummy-scripting-search-pipeline",
-          "operation": "default",
+          "operation": "match-all",
           "request-params": {
             "search-pipeline": "http-log-100-dummy-scripting-search-pipeline"
           },
@@ -537,7 +537,7 @@
         },
         {
           "name": "match-all-all-processors-search-pipeline",
-          "operation": "default",
+          "operation": "match-all",
           "request-params": {
             "search-pipeline": "http-log-all-processors-search-pipeline"
           },

--- a/nyc_taxis/operations/default.json
+++ b/nyc_taxis/operations/default.json
@@ -26,7 +26,7 @@
       "include-in-reporting": false
     },
     {
-      "name": "default",
+      "name": "match-all",
       "operation-type": "search",
       "body": {
         "query": {

--- a/nyc_taxis/test_procedures/default.json
+++ b/nyc_taxis/test_procedures/default.json
@@ -27,8 +27,8 @@
         {{ benchmark.collect(parts="../../common_operations/force_merge.json") }},
         {
           "operation": "match-all",
-          "warmup-iterations": {{ default_warmup_iterations or warmup_iterations | default(50) | tojson }},
-          "iterations": {{ default_iterations or iterations | default(100) | tojson }},
+          "warmup-iterations": {{ match_all_warmup_iterations or warmup_iterations | default(50) | tojson }},
+          "iterations": {{ match_all_iterations or iterations | default(100) | tojson }},
           "target-throughput": {{ default_target_throughput or target_throughput | default(3) | tojson }},
           "clients": {{ default_search_clients or search_clients | default(1) }}
         },

--- a/nyc_taxis/test_procedures/default.json
+++ b/nyc_taxis/test_procedures/default.json
@@ -26,7 +26,7 @@
         },
         {{ benchmark.collect(parts="../../common_operations/force_merge.json") }},
         {
-          "operation": "default",
+          "operation": "match-all",
           "warmup-iterations": {{ default_warmup_iterations or warmup_iterations | default(50) | tojson }},
           "iterations": {{ default_iterations or iterations | default(100) | tojson }},
           "target-throughput": {{ default_target_throughput or target_throughput | default(3) | tojson }},

--- a/nyc_taxis/test_procedures/searchable-snapshot.json
+++ b/nyc_taxis/test_procedures/searchable-snapshot.json
@@ -75,7 +75,7 @@
           "operation": "restore-snapshot"
         },
         {
-          "operation": "default",
+          "operation": "match-all",
           "warmup-iterations": 50,
           "iterations": 100
           {%- if not target_throughput %}

--- a/pmc/operations/default.json
+++ b/pmc/operations/default.json
@@ -15,7 +15,7 @@
       "recency": {{recency | default(0)}}
     },
     {
-      "name": "default",
+      "name": "match-all",
       "operation-type": "search",
       "#COMMENT": "Large responses cause overhead on the client when decompressing the response. Disable to avoid the overhead",
       "response-compression-enabled": false,

--- a/pmc/test_procedures/default.json
+++ b/pmc/test_procedures/default.json
@@ -30,7 +30,7 @@
         },
         {{ benchmark.collect(parts="../../common_operations/force_merge.json") }},
         {
-          "operation": "default",
+          "operation": "match-all",
           "warmup-iterations": {{ default_warmup_iterations or warmup_iterations | default(500) | tojson }},
           "iterations": {{ default_iterations or iterations | default(200) | tojson }},
           "target-throughput": {{ default_target_throughput or target_throughput | default(20) | tojson }},

--- a/pmc/test_procedures/default.json
+++ b/pmc/test_procedures/default.json
@@ -31,8 +31,8 @@
         {{ benchmark.collect(parts="../../common_operations/force_merge.json") }},
         {
           "operation": "match-all",
-          "warmup-iterations": {{ default_warmup_iterations or warmup_iterations | default(500) | tojson }},
-          "iterations": {{ default_iterations or iterations | default(200) | tojson }},
+          "warmup-iterations": {{ match_all_warmup_iterations or warmup_iterations | default(500) | tojson }},
+          "iterations": {{ match_all_iterations or iterations | default(200) | tojson }},
           "target-throughput": {{ default_target_throughput or target_throughput | default(20) | tojson }},
           "clients": {{ default_search_clients or search_clients | default(1) }}
         },

--- a/pmc/test_procedures/indexing-querying.json
+++ b/pmc/test_procedures/indexing-querying.json
@@ -89,7 +89,7 @@
             "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
           },
           {
-            "operation": "default",
+            "operation": "match-all",
             "warmup-iterations": 500,
             "iterations": 200,
             "target-throughput": {{ default_target_throughput or target_throughput | default(20) | tojson }},

--- a/treccovid_semantic_search/operations/default.json
+++ b/treccovid_semantic_search/operations/default.json
@@ -40,7 +40,7 @@
       "include-in-reporting": false
     },
     {
-      "name": "default",
+      "name": "match-all",
       "operation-type": "search",
       "body": {
         "query": {

--- a/treccovid_semantic_search/test_procedures/default.json
+++ b/treccovid_semantic_search/test_procedures/default.json
@@ -69,7 +69,7 @@
         },
         {{ benchmark.collect(parts="../../common_operations/force_merge.json") }},
         {
-          "operation": "default",
+          "operation": "match-all",
           "warmup-iterations": {{warmup_iterations | default(500) | tojson}},
           "iterations": {{iterations | default(500) | tojson }},
           "target-throughput": {{ target_throughput | default(100) | tojson}},


### PR DESCRIPTION
### Description
I've renamed all `default` operations to `match-all`. 

### Issues Resolved
#160 

### Testing
- [ ] New functionality includes testing

[Describe how this change was tested]

### Backport to Branches:
- [x] 6
- [x] 7
- [x] 1
- [x] 2
- [x] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
