### PR TITLE
add missing curly brace to geonames test procedure

### DIFF
--- a/geonames/test_procedures/default.json
+++ b/geonames/test_procedures/default.json
@@ -275,6 +275,7 @@
         {% with index_name="geonames" %}
         {{ benchmark.collect(parts="../../common_operations/check_cluster_health.json") }},
         {% endwith %}
+        {
           "operation": {
               "name": "polling-ingest",
               "operation-type": "produce-stream-message",


### PR DESCRIPTION
### Description
In the new [polling ingestion](https://github.com/opensearch-project/opensearch-benchmark-workloads/pull/578) test procedure for geonames, there was a missing curly brace before the `polling-ingest` operation, causing this error when trying to run a test with the geonames workload:
```
[ERROR] Cannot execute-test. Error in test execution orchestrator (Could not load '/Users/mikeovi/workplace/opensearch-benchmark-workloads/geonames/workload.json': Expecting ',' delimiter: line 1017 column 22 (char 24832). Lines containing the error:

    }
},
        
          "operation": {
---------------------^ Error is here
              "name": "polling-ingest",
              "operation-type": "produce-stream-message",

The complete workload has been written to '/var/folders/h1/0qdq0c3s42b41x332lqslsg80000gq/T/tmpe1rr9x0u.json' for diagnosis. 

Suggestion: Verify that [geonames] workload has correctly formatted JSON files and Jinja Templates. For Jinja2 errors, consider using a live Jinja2 parser. See common workload formatting errors:
    ---------------------------------------------------------------------------------------------------------------------------
    [Common workload formatting errors:] 

    - Jinja2 expression missing parameters (e.g. got {{search_clients}} but needs {{search_clients | default(8)}})

    - Jinja2 expression missing "tojson" parameter when needed(e.g. got {{index_settings | default({})}} but needs {{index_settings | default({}) | tojson}})

    - JSON file might not be correctly formatted after rendering Jinja2 (e.g. additional brackets (}, ]) or missing commas (,))
    ---------------------------------------------------------------------------------------------------------------------------
    )
```

This PR just adds the missing curly brace and fixes the error.

### Issues Resolved
None

### Testing
- [x] New functionality includes testing

Ran the geonames workload with no syntax errors

### Backport to Branches:
- [ ] 6
- [ ] 7
- [ ] 1
- [ ] 2
- [x] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
