### PR TITLE
Add a restore snapshot operation to workloads

### DIFF
--- a/common_operations/restore_snapshot.json
+++ b/common_operations/restore_snapshot.json
@@ -1,0 +1,15 @@
+{
+    "operation": {
+      "name": "restore-snapshot",
+      "operation-type": "raw-request",
+      "method": "POST",
+      "path": "/_snapshot/{{ snapshot_repo }}/{{ snapshot_name }}/_restore",
+      "body": {
+        "indices": "{{ snapshot_indices | default('geonames') }}",
+        "include_global_state": false,
+        "rename_pattern": "(.+)",
+        "rename_replacement": "$1"
+      }
+    }
+  }
+  

--- a/common_operations/restore_snapshot.json
+++ b/common_operations/restore_snapshot.json
@@ -1,15 +1,14 @@
 {
-    "operation": {
-      "name": "restore-snapshot",
-      "operation-type": "raw-request",
-      "method": "POST",
-      "path": "/_snapshot/{{ snapshot_repo }}/{{ snapshot_name }}/_restore",
-      "body": {
-        "indices": "{{ snapshot_indices | default('geonames') }}",
-        "include_global_state": false,
-        "rename_pattern": "(.+)",
-        "rename_replacement": "$1"
-      }
+  "operation": {
+    "name": "restore-snapshot",
+    "operation-type": "raw-request",
+    "method": "POST",
+    "path": "/_snapshot/{{ snapshot_repo }}/{{ snapshot_name }}/_restore",
+    "body": {
+      "indices": "{{ snapshot_indices | default('_all') }}",
+      "include_global_state": false,
+      "rename_pattern": "(.+)",
+      "rename_replacement": "$1"
     }
   }
-  
+}

--- a/common_operations/workload_setup.json
+++ b/common_operations/workload_setup.json
@@ -1,5 +1,11 @@
-{{ benchmark.collect(parts="delete_index.json") }},
-{{ benchmark.collect(parts="create_index.json") }},
-{{ benchmark.collect(parts="check_cluster_health.json") }},
-{{ benchmark.collect(parts="index_append.json") }},
-{{ benchmark.collect(parts="force_merge.json") }}
+{% if use_snapshot %}
+  {% with snapshot_repo=snapshot_repo, snapshot_name=snapshot_name, snapshot_indices=snapshot_indices %}
+    {{ benchmark.collect(parts="restore_snapshot.json") }}
+  {% endwith %}
+{% else %}
+  {{ benchmark.collect(parts="delete_index.json") }},
+  {{ benchmark.collect(parts="create_index.json") }},
+  {{ benchmark.collect(parts="check_cluster_health.json") }},
+  {{ benchmark.collect(parts="index_append.json") }},
+  {{ benchmark.collect(parts="force_merge.json") }}
+{% endif %}

--- a/geonames/test_procedures/default.json
+++ b/geonames/test_procedures/default.json
@@ -3,7 +3,7 @@
       "description": "Indexes the whole document corpus using OpenSearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Benchmark will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only. After that a couple of queries are run.",
       "default": true,
       "schedule": [
-        {% with default_index_settings={}, index_name="geonames" %}
+        {% with index_name="geonames" %}
         {{ benchmark.collect(parts="../../common_operations/workload_setup.json") }},
         {% endwith %}
         {
@@ -275,6 +275,7 @@
         {% with index_name="geonames" %}
         {{ benchmark.collect(parts="../../common_operations/check_cluster_health.json") }},
         {% endwith %}
+        {
           "operation": {
               "name": "polling-ingest",
               "operation-type": "produce-stream-message",


### PR DESCRIPTION
### Description
Adds the ability to run a benchmark on a restored snapshot for more stable comparisons. This should reduce the deviation between results, and is skipped unless user provides the following params:

use_snapshot
snapshot_repo
snapshot_name
snapshot_indices

Below is an example command
```
opensearch-benchmark execute-test \                                                                                          
  --workload=geonames \
  --target-hosts=<opensearch cluster> \
  --pipeline=benchmark-only \
  --workload-params='{              
    "use_snapshot": true,
    "snapshot_repo": "s3_backup_repo",
    "snapshot_name": "geonames_snapshot",
    "snapshot_indices": "geonames"
  }' \
--kill-running-processes
```

### Issues Resolved
#155 

### Testing
- [x] New functionality includes testing

Tested by running benchmarks both with and without a restored snapshot. Results shown below

### Backport to Branches:
- [ ] 6
- [ ] 7
- [ ] 1
- [ ] 2
- [ ] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
