### PR TITLE
 Add cardinality-agg-high-2 query with event.id, and revert cardinality-agg-high to use agent.name field

### DIFF
--- a/big5/README.md
+++ b/big5/README.md
@@ -68,7 +68,6 @@ This workload allows the following parameters to be specified using `--workload-
 * `target_throughput` (default: 2): Target throughput for each query operation in requests per second, use 0 or "" for no throughput throttling.
 * `warmup_iterations` (default: 100): Number of warmup query iterations prior to actual measurements commencing.
 * `index_translog_durability` (default: "async"): Controls the transaction log flush behavior. "request" flushes after every operation to avoid data loss, while "async" batches changes for efficiency.
-* `cardinality_agg_high_field` (default: "event.id"): Use another field name for cardinality_agg_high test, previously "agent.name" was used.
 
 NOTE: If disabling `target_throughput`, know that `target_throughput:""` is snynonymous with `target_throughput:0`.
 

--- a/big5/operations/default.json
+++ b/big5/operations/default.json
@@ -886,16 +886,32 @@
       "name": "cardinality-agg-high",
       "operation-type": "search",
       "index": "{{index_name | default('big5')}}",
+      "body": {
+        "size": 0,
+        "aggs": {
+          "agent": {
+            "cardinality": {
+             "field": "agent.name"
+              {% if distribution_version.split('.') | map('int') | list  >= "2.19.1".split('.') | map('int') | list and distribution_version.split('.') | map('int') | list  < "6.0.0".split('.') | map('int') | list %
+              }, "execution_hint": "ordinals"
+              {% endif %}
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "cardinality-agg-high-2",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
       "request-timeout": 1800,
       "body": {
         "size": 0,
         "aggs": {
           "agent": {
             "cardinality": {
-             "field": "{{cardinality_agg_high_field | default('event.id')}}"
-              {% if distribution_version.split('.') | map('int') | list  >= "2.19.1".split('.') | map('int') | list and distribution_version.split('.') | map('int') | list  < "6.0.0".split('.') | map('int') | list %}
-              ,"execution_hint":"ordinals"
-              {% endif %}
+             "field": "event.id",
+             "execution_hint":"ordinals"
             }
           }
         }

--- a/big5/test_procedures/common/big5-schedule.json
+++ b/big5/test_procedures/common/big5-schedule.json
@@ -288,3 +288,13 @@
   "target-throughput": {{ target_throughput | default(2) | tojson }},
   "clients": {{ search_clients | default(1) }}
 }
+{% if distribution_version.split('.') | map('int') | list  >= "2.19.1".split('.') | map('int') | list and distribution_version.split('.') | map('int') | list  < "6.0.0".split('.') | map('int') | list %}
+,{
+  "operation": "cardinality-agg-high-2",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+}
+{% endif %}
+


### PR DESCRIPTION
### Description

* previous PR(#579) is causing long benchmark runs for old version
* this way we can keep the historical data
* new query only runs on 2.19.1+ versions



### Issues Resolved
None

### Testing
- [x] New functionality includes testing

```
[ec2-user@ip-172-31-61-197 ~]$ opensearch-benchmark execute-test --pipeline=benchmark-only --workload=big5 --target-hosts=localhost:9200 --kill-running-processes --include-tasks "cardinality-agg-high-2,cardinality-agg-high,query-string-on-message,cardinality-agg-low,range-auto-date-histo,range-auto-date-histo-with-metrics" --workload-param "warmup_iterations:3,test_iterations:10,distribution_version:3.1.0"

   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/

[INFO] [Test Execution ID]: aef13ea5-9003-457a-b5ae-57ad48becacf
[WARNING] Local changes in [/home/ec2-user/.osb/benchmarks/workloads/default] prevent workloads update from remote. Please commit your changes.
[WARNING] Local changes in [/home/ec2-user/.osb/benchmarks/workloads/default] prevent workloads update from remote. Please commit your changes.
[WARNING] Local changes in [/home/ec2-user/.osb/benchmarks/workloads/default] prevent workloads update from remote. Please commit your changes.
[INFO] Executing test with workload [big5], test_procedure [big5] and provision_config_instance ['external'] with version [3.1.0-SNAPSHOT].

Running query-string-on-message                                                [100% done]
Running range-auto-date-histo                                                  [100% done]
Running range-auto-date-histo-with-metrics                                     [100% done]
Running cardinality-agg-low                                                    [100% done]
Running cardinality-agg-high                                                   [100% done]
Running cardinality-agg-high-2                                                 [100% done]

------------------------------------------------------
    _______             __   _____
   / ____(_)___  ____ _/ /  / ___/_________  ________
  / /_  / / __ \/ __ `/ /   \__ \/ ___/ __ \/ ___/ _ \
 / __/ / / / / / /_/ / /   ___/ / /__/ /_/ / /  /  __/
/_/   /_/_/ /_/\__,_/_/   /____/\___/\____/_/   \___/
------------------------------------------------------

|                                                         Metric |                               Task |       Value |   Unit |
|---------------------------------------------------------------:|-----------------------------------:|------------:|-------:|
|                     Cumulative indexing time of primary shards |                                    |           0 |    min |
|             Min cumulative indexing time across primary shards |                                    |           0 |    min |
|          Median cumulative indexing time across primary shards |                                    |           0 |    min |
|             Max cumulative indexing time across primary shards |                                    |           0 |    min |
|            Cumulative indexing throttle time of primary shards |                                    |           0 |    min |
|    Min cumulative indexing throttle time across primary shards |                                    |           0 |    min |
| Median cumulative indexing throttle time across primary shards |                                    |           0 |    min |
|    Max cumulative indexing throttle time across primary shards |                                    |           0 |    min |
|                        Cumulative merge time of primary shards |                                    |           0 |    min |
|                       Cumulative merge count of primary shards |                                    |           0 |        |
|                Min cumulative merge time across primary shards |                                    |           0 |    min |
|             Median cumulative merge time across primary shards |                                    |           0 |    min |
|                Max cumulative merge time across primary shards |                                    |           0 |    min |
|               Cumulative merge throttle time of primary shards |                                    |           0 |    min |
|       Min cumulative merge throttle time across primary shards |                                    |           0 |    min |
|    Median cumulative merge throttle time across primary shards |                                    |           0 |    min |
|       Max cumulative merge throttle time across primary shards |                                    |           0 |    min |
|                      Cumulative refresh time of primary shards |                                    |           0 |    min |
|                     Cumulative refresh count of primary shards |                                    |           2 |        |
|              Min cumulative refresh time across primary shards |                                    |           0 |    min |
|           Median cumulative refresh time across primary shards |                                    |           0 |    min |
|              Max cumulative refresh time across primary shards |                                    |           0 |    min |
|                        Cumulative flush time of primary shards |                                    |           0 |    min |
|                       Cumulative flush count of primary shards |                                    |           1 |        |
|                Min cumulative flush time across primary shards |                                    |           0 |    min |
|             Median cumulative flush time across primary shards |                                    |           0 |    min |
|                Max cumulative flush time across primary shards |                                    |           0 |    min |
|                                        Total Young Gen GC time |                                    |       0.934 |      s |
|                                       Total Young Gen GC count |                                    |          13 |        |
|                                          Total Old Gen GC time |                                    |           0 |      s |
|                                         Total Old Gen GC count |                                    |           0 |        |
|                                                     Store size |                                    |     25.6365 |     GB |
|                                                  Translog size |                                    | 5.12227e-08 |     GB |
|                                         Heap used for segments |                                    |           0 |     MB |
|                                       Heap used for doc values |                                    |           0 |     MB |
|                                            Heap used for terms |                                    |           0 |     MB |
|                                            Heap used for norms |                                    |           0 |     MB |
|                                           Heap used for points |                                    |           0 |     MB |
|                                    Heap used for stored fields |                                    |           0 |     MB |
|                                                  Segment count |                                    |          15 |        |
|                                                 Min Throughput |            query-string-on-message |        1.72 |  ops/s |
|                                                Mean Throughput |            query-string-on-message |        1.79 |  ops/s |
|                                              Median Throughput |            query-string-on-message |         1.8 |  ops/s |
|                                                 Max Throughput |            query-string-on-message |        1.85 |  ops/s |
|                                        50th percentile latency |            query-string-on-message |     162.063 |     ms |
|                                        90th percentile latency |            query-string-on-message |     165.837 |     ms |
|                                       100th percentile latency |            query-string-on-message |     175.033 |     ms |
|                                   50th percentile service time |            query-string-on-message |     161.145 |     ms |
|                                   90th percentile service time |            query-string-on-message |     164.881 |     ms |
|                                  100th percentile service time |            query-string-on-message |     173.579 |     ms |
|                                                     error rate |            query-string-on-message |           0 |      % |
|                                                 Min Throughput |              range-auto-date-histo |        0.36 |  ops/s |
|                                                Mean Throughput |              range-auto-date-histo |         0.4 |  ops/s |
|                                              Median Throughput |              range-auto-date-histo |        0.41 |  ops/s |
|                                                 Max Throughput |              range-auto-date-histo |        0.43 |  ops/s |
|                                        50th percentile latency |              range-auto-date-histo |     15718.3 |     ms |
|                                        90th percentile latency |              range-auto-date-histo |     21449.8 |     ms |
|                                       100th percentile latency |              range-auto-date-histo |     22885.9 |     ms |
|                                   50th percentile service time |              range-auto-date-histo |     2102.44 |     ms |
|                                   90th percentile service time |              range-auto-date-histo |      2144.2 |     ms |
|                                  100th percentile service time |              range-auto-date-histo |     2179.74 |     ms |
|                                                     error rate |              range-auto-date-histo |           0 |      % |
|                                                 Min Throughput | range-auto-date-histo-with-metrics |         0.1 |  ops/s |
|                                                Mean Throughput | range-auto-date-histo-with-metrics |         0.1 |  ops/s |
|                                              Median Throughput | range-auto-date-histo-with-metrics |         0.1 |  ops/s |
|                                                 Max Throughput | range-auto-date-histo-with-metrics |        0.11 |  ops/s |
|                                        50th percentile latency | range-auto-date-histo-with-metrics |     78974.8 |     ms |
|                                        90th percentile latency | range-auto-date-histo-with-metrics |      112206 |     ms |
|                                       100th percentile latency | range-auto-date-histo-with-metrics |      121161 |     ms |
|                                   50th percentile service time | range-auto-date-histo-with-metrics |     10138.2 |     ms |
|                                   50th percentile service time |                cardinality-agg-low |     10.0443 |     ms |
|                                   90th percentile service time |                cardinality-agg-low |     10.7903 |     ms |
|                                  100th percentile service time |                cardinality-agg-low |     11.7723 |     ms |
|                                                     error rate |                cardinality-agg-low |           0 |      % |
|                                                 Min Throughput |               cardinality-agg-high |        0.71 |  ops/s |
|                                                Mean Throughput |               cardinality-agg-high |        0.72 |  ops/s |
|                                              Median Throughput |               cardinality-agg-high |        0.72 |  ops/s |
|                                                 Max Throughput |               cardinality-agg-high |        0.74 |  ops/s |
|                                        50th percentile latency |               cardinality-agg-high |     7908.95 |     ms |
|                                        90th percentile latency |               cardinality-agg-high |     10782.3 |     ms |
|                                       100th percentile latency |               cardinality-agg-high |     11555.2 |     ms |
|                                   50th percentile service time |               cardinality-agg-high |     1320.12 |     ms |
|                                   90th percentile service time |               cardinality-agg-high |     1364.53 |     ms |
|                                  100th percentile service time |               cardinality-agg-high |      1419.3 |     ms |
|                                                     error rate |               cardinality-agg-high |           0 |      % |
|                                                 Min Throughput |             cardinality-agg-high-2 |        0.58 |  ops/s |
|                                                Mean Throughput |             cardinality-agg-high-2 |         0.6 |  ops/s |
|                                              Median Throughput |             cardinality-agg-high-2 |        0.61 |  ops/s |
|                                                 Max Throughput |             cardinality-agg-high-2 |        0.62 |  ops/s |
|                                        50th percentile latency |             cardinality-agg-high-2 |     9950.66 |     ms |
|                                        90th percentile latency |             cardinality-agg-high-2 |     13872.1 |     ms |
|                                       100th percentile latency |             cardinality-agg-high-2 |     14815.2 |     ms |
|                                   50th percentile service time |             cardinality-agg-high-2 |     1575.87 |     ms |
|                                   90th percentile service time |             cardinality-agg-high-2 |     1598.15 |     ms |
|                                  100th percentile service time |             cardinality-agg-high-2 |      1650.7 |     ms |
|                                                     error rate |             cardinality-agg-high-2 |           0 |      % |


---------------------------------
[INFO] SUCCESS (took 237 seconds)
---------------------------------

```

### Backport to Branches:
- [ ] 6
- [ ] 7
- [ ] 1
- [ ] 2
- [ ] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
