### PR TITLE
Update nested workloads to use cohere-nested corpus

### DIFF
--- a/vectorsearch/params/nested/nested-faiss.json
+++ b/vectorsearch/params/nested/nested-faiss.json
@@ -2,14 +2,14 @@
     "target_index_name": "target_index",
     "target_field_name": "nested_field.target_field",
     "target_index_body": "indices/nested/nested-faiss-index.json",
-    "target_index_dimension": 128,
+    "target_index_dimension": 768,
     "target_index_bulk_size": 100,
     "target_index_bulk_index_data_set_format": "hdf5",
-    "target_index_bulk_index_data_set_path": "/tmp/data-nested.hdf5",
+    "target_index_bulk_index_data_set_corpus": "cohere-nested",
     "target_index_bulk_indexing_clients": 10,
     
     "target_index_max_num_segments": 1,
-    "target_index_space_type": "l2",
+    "target_index_space_type": "innerproduct",
     
     "query_k": 5,
     "query_body": {
@@ -18,6 +18,6 @@
     },
 
     "query_data_set_format": "hdf5",
-    "query_data_set_path":"/tmp/data-nested.hdf5",
+    "query_data_set_corpus":"cohere-nested",
     "query_count": 10000
   }

--- a/vectorsearch/params/nested/nested-lucene.json
+++ b/vectorsearch/params/nested/nested-lucene.json
@@ -2,14 +2,14 @@
     "target_index_name": "target_index",
     "target_field_name": "nested_field.target_field",
     "target_index_body": "indices/nested/nested-lucene-index.json",
-    "target_index_dimension": 128,
+    "target_index_dimension": 768,
     "target_index_bulk_size": 100,
     "target_index_bulk_index_data_set_format": "hdf5",
-    "target_index_bulk_index_data_set_path": "/tmp/data-nested.hdf5",
+    "target_index_bulk_index_data_set_corpus": "cohere-nested",
     "target_index_bulk_indexing_clients": 10,
     
     "target_index_max_num_segments": 1,
-    "target_index_space_type": "l2",
+    "target_index_space_type": "innerproduct",
     
     "query_k": 5,
     "query_body": {
@@ -18,6 +18,6 @@
     },
 
     "query_data_set_format": "hdf5",
-    "query_data_set_path":"/tmp/data-nested.hdf5",
+    "query_data_set_corpus":"cohere-nested",
     "query_count": 10000
   }

--- a/vectorsearch/params/nested/nested-nmslib.json
+++ b/vectorsearch/params/nested/nested-nmslib.json
@@ -2,14 +2,14 @@
     "target_index_name": "target_index",
     "target_field_name": "nested_field.target_field",
     "target_index_body": "indices/nested/nested-nmslib-index.json",
-    "target_index_dimension": 128,
+    "target_index_dimension": 768,
     "target_index_bulk_size": 100,
     "target_index_bulk_index_data_set_format": "hdf5",
-    "target_index_bulk_index_data_set_path": "/tmp/data-nested.hdf5",
+    "target_index_bulk_index_data_set_corpus": "cohere-nested",
     "target_index_bulk_indexing_clients": 10,
     
     "target_index_max_num_segments": 1,
-    "target_index_space_type": "l2",
+    "target_index_space_type": "innerproduct",
     
     "query_k": 5,
     "query_body": {
@@ -18,6 +18,6 @@
     },
 
     "query_data_set_format": "hdf5",
-    "query_data_set_path":"/tmp/data-nested.hdf5",
+    "query_data_set_corpus":"cohere-nested",
     "query_count": 10000
   }


### PR DESCRIPTION
### Description
k-NN team is trying to add nested benchmark to their nightly benchmark runs. The nightlies should use the [cohere-nested](https://github.com/opensearch-project/opensearch-benchmark-workloads/blob/main/vectorsearch/workload.json#L66) corpus dataset instead of the dataset at `/tmp/data-nested.hdf5`. This PR changes the `vectorsearch/params/nested` workload parameter files to use the updated corpus.

### Issues Resolved
[List any issues this PR will resolve]

### Testing
- [x] New functionality includes testing
Successful faiss run locally with the corpus.

### Backport to Branches:
- [ ] 6
- [ ] 7
- [ ] 1
- [x] 2
- [x] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
