### PR TITLE
Edited parameters for noaa_semantic_search workload

### DIFF
--- a/noaa_semantic_search/README.md
+++ b/noaa_semantic_search/README.md
@@ -42,7 +42,7 @@ This workload allows the following parameters to be specified using `--workload-
 * `cluster_health` (default: "green"): The minimum required cluster health.
 * `target_throughput` (default: default values for each operation): Number of requests per second, `none` for no limit.
 * `search_clients`: Number of clients that issues search requests.
-* `concurrent_segment_search_enabled` (default: "false"): Setting enables or disables consurrent segment search feature for the cluster. Setting is avaliable starting from version 2.12.
+* `concurrent_segment_search_enabled` (default: version dependent, "false" for 2.x or "true" for 3.x): Setting enables or disables consurrent segment search feature for the cluster. Setting is avaliable starting from version 2.12.
 
 ### Running a benchmark
 
@@ -119,6 +119,12 @@ Procedure name `hybrid-search-sorting`.
 
 The Profiling of Hybrid Query with Aggregations procedure is used to run small set of hybrid queries with aggregations to collect runtime metrics thaty can be used for analysis like profiling or debug. It does not create index or ingestg documents.
 Procedure name `search-profiling`.
+
+### Complex Hybrid Queries
+
+The Complex Hybrid Queries procedure is used to run set of multiple search queries with complext hybrid query with multiple sub-queries, aggregations and sort. As part of this precedure
+we create an index and ingest documents, then run search queries.
+Procedure name `hybrid-search-create-index-and-complex-queries`.
 
 #### Sample Output
 

--- a/noaa_semantic_search/params/one_replica_no_concurrent_segment_search.json
+++ b/noaa_semantic_search/params/one_replica_no_concurrent_segment_search.json
@@ -3,5 +3,6 @@
      "number_of_shards" :6,
      "max_num_segments" :8,
      "concurrent_segment_search_enabled": "false",
-     "search_clients" : 8
+     "search_clients" : 8,
+     "target_throughput": 0
 }

--- a/noaa_semantic_search/params/target_througput_no_concurrent_segment_search.json
+++ b/noaa_semantic_search/params/target_througput_no_concurrent_segment_search.json
@@ -2,7 +2,7 @@
      "number_of_replicas": 1,
      "number_of_shards" :6,
      "max_num_segments" :8,
-     "concurrent_segment_search_enabled": "true",
+     "concurrent_segment_search_enabled": "false",
      "search_clients" : 8,
-     "target_throughput": 0
+     "target_throughput": 25
 }

--- a/noaa_semantic_search/params/target_througput_with_concurrent_segment_search copy.json
+++ b/noaa_semantic_search/params/target_througput_with_concurrent_segment_search copy.json
@@ -4,5 +4,5 @@
      "max_num_segments" :8,
      "concurrent_segment_search_enabled": "true",
      "search_clients" : 8,
-     "target_throughput": 0
+     "target_throughput": 25
 }

--- a/noaa_semantic_search/test_procedures/hybrid_search.json
+++ b/noaa_semantic_search/test_procedures/hybrid_search.json
@@ -57,4 +57,14 @@
       "schedule": [
         {{ benchmark.collect(parts="semantic-search-common/search-with-sort.json") }}
       ]
+    },
+    {
+      "name": "hybrid-search-create-index-and-complex-queries",
+      "description": "Run hybrid search queries with multiple sub-queries, aggregations and sort.",
+      "default": false,
+      "schedule": [
+        {{ benchmark.collect(parts="semantic-search-common/create-index-ingest-docs.json") }},
+        {{ benchmark.collect(parts="semantic-search-common/check-status-add-resources-no-index.json") }},
+        {{ benchmark.collect(parts="semantic-search-common/hybrid-search-complex-queries.json") }}
+      ]
     }

--- a/noaa_semantic_search/test_procedures/semantic-search-common/check-status-add-resources-no-index.json
+++ b/noaa_semantic_search/test_procedures/semantic-search-common/check-status-add-resources-no-index.json
@@ -10,6 +10,7 @@
       "retry-until-success": true
     }
   },
+{%- if concurrent_segment_search_enabled is defined %}  
   {
     "name": "set-concurent-segment-search-setting",
     "operation": {
@@ -21,6 +22,7 @@
       }
     }
   },
+{%- endif %}  
   {
     "name": "refresh-after-index",
     "operation": "refresh"

--- a/noaa_semantic_search/test_procedures/semantic-search-common/hybrid-search-complex-queries.json
+++ b/noaa_semantic_search/test_procedures/semantic-search-common/hybrid-search-complex-queries.json
@@ -1,0 +1,70 @@
+    {
+        "operation": "hybrid-query-only-range",
+        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
+        "iterations": {{ test_iterations | default(100) | tojson }},
+        "target-throughput": {{ target_throughput | default(2) | tojson }},
+        "clients": {{ search_clients | default(1) }}
+    },
+    {
+        "operation": "hybrid-query-only-range-large-subset",
+        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
+        "iterations": {{ test_iterations | default(100) | tojson }},
+        "target-throughput": {{ target_throughput | default(2) | tojson }},
+        "clients": {{ search_clients | default(1) }}
+    },
+    {
+        "operation": "hybrid-query-only-term-range-date",
+        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
+        "iterations": {{ test_iterations | default(100) | tojson }},
+        "target-throughput": {{ target_throughput | default(2) | tojson }},
+        "clients": {{ search_clients | default(1) }}
+    },
+    {
+        "operation": "aggs-query-min-avg-sum-hybrid",
+        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
+        "iterations": {{ test_iterations | default(100) | tojson }},
+        "target-throughput": {{ target_throughput | default(2) | tojson }},
+        "clients": {{ search_clients | default(1) }}
+    },        
+    {
+        "operation": "aggs-query-term-min-hybrid",
+        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
+        "iterations": {{ test_iterations | default(100) | tojson }},
+        "target-throughput": {{ target_throughput | default(2) | tojson }},
+        "clients": {{ search_clients | default(1) }}
+    },
+    {
+        "operation": "aggs-query-date-histo-geohash-grid-hybrid",
+        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
+        "iterations": {{ test_iterations | default(100) | tojson }},
+        "target-throughput": {{ target_throughput | default(2) | tojson }},
+        "clients": {{ search_clients | default(1) }}
+    },
+    {
+        "operation": "aggs-query-range-numeric-significant-terms-hybrid",
+        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
+        "iterations": {{ test_iterations | default(100) | tojson }},
+        "target-throughput": {{ target_throughput | default(2) | tojson }},
+        "clients": {{ search_clients | default(1) }}
+    },
+    {
+        "operation": "hybrid-query-3-subqueries-sort-by-score-search-after",
+        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
+        "iterations": {{ test_iterations | default(100) | tojson }},
+        "target-throughput": {{ target_throughput | default(2) | tojson }},
+        "clients": {{ search_clients | default(1) }}
+    },
+    {
+        "operation": "hybrid-query-3-subqueries-sort-by-two-fields",
+        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
+        "iterations": {{ test_iterations | default(100) | tojson }},
+        "target-throughput": {{ target_throughput | default(2) | tojson }},
+        "clients": {{ search_clients | default(1) }}
+    },
+    {
+        "operation": "hybrid-query-3-subqueries-sort-by-two-fields-search-after",
+        "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},
+        "iterations": {{ test_iterations | default(100) | tojson }},
+        "target-throughput": {{ target_throughput | default(2) | tojson }},
+        "clients": {{ search_clients | default(1) }}
+    }            

--- a/noaa_semantic_search/test_procedures/semantic-search-common/profiler-workflow.json
+++ b/noaa_semantic_search/test_procedures/semantic-search-common/profiler-workflow.json
@@ -1,3 +1,4 @@
+{%- if concurrent_segment_search_enabled is defined %}
 {
   "name": "set-concurent-segment-search-setting",
   "operation": {
@@ -9,6 +10,7 @@
     }
   }
 },
+{%- endif %}
 {
   "operation": "hybrid-query-only-range-medium-subset",
   "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},

--- a/noaa_semantic_search/test_procedures/semantic-search-common/search-with-sort.json
+++ b/noaa_semantic_search/test_procedures/semantic-search-common/search-with-sort.json
@@ -1,3 +1,4 @@
+{%- if concurrent_segment_search_enabled is defined %}
 {
   "name": "set-concurent-segment-search-setting",
   "operation": {
@@ -9,6 +10,7 @@
     }
   }
 },
+{%- endif %}
 {
   "operation": "bool-3-subqueries-no-sort",
   "warmup-iterations": {{ warmup_iterations | default(25) | tojson }},


### PR DESCRIPTION
### Description
Changed some parameters for noaa_semantic_search workload to reflect recent findings and features in hybrid query:

- change default value for concurrent_segment_search to be version dependent. previous default value "disabled" does not reflect new default behavior in 3.0 and above, where CSS is enabled by default. With this change in 2.x versions by default CSS will be disabled, and is 3.x is will be enabled
- set benchmark mode for throughput as default mode for existing param files
- added new set of parameters with fixed target throughput 25qps
- added new test procedure `hybrid-search-create-index-and-complex-queries`, it has most complex hybrid queries: 3 sub-queries, aggregations, sort

Having those parameters and consolidated test procedure with all complex queries should help in tracking performance with nightly test runs.
 
### Issues Resolved


### Testing
- [ ] New functionality includes testing

Run manually on 3.0-alpha OpenSearch remote cluster, using command:
```
opensearch-benchmark execute-test --workload-path="/home/user/dev/opensearch/opensearch-benchmark-workloads-third/noaa_semantic_search/" --workload-params="/home/user/dev/opensearch/opensearch-benchmark-workloads-third/noaa_semantic_search/params/one_replica_with_concurrent_segment_search.json" --pipeline=benchmark-only --client-options=timeout:30 --target-host=myhost.elb.us-east-1.amazonaws.com:80 --kill-running-processes --test-procedure="hybrid-search-create-index-and-complex-queries"
```
I got following output:
```

   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/

[INFO] [Test Execution ID]: 2eb6924b-d670-444d-b0f1-e434c7885feb
[INFO] Executing test with workload [noaa_semantic_search], test_procedure [hybrid-search-create-index-and-complex-queries] and provision_config_instance ['external'] with version [3.1.0].

[WARNING] merges_total_time is 463458 ms indicating that the cluster is not in a defined clean state. Recorded index time metrics may be misleading.
[WARNING] merges_total_throttled_time is 221931 ms indicating that the cluster is not in a defined clean state. Recorded index time metrics may be misleading.
[WARNING] indexing_total_time is 1582712 ms indicating that the cluster is not in a defined clean state. Recorded index time metrics may be misleading.
[WARNING] refresh_total_time is 105413 ms indicating that the cluster is not in a defined clean state. Recorded index time metrics may be misleading.
[WARNING] flush_total_time is 55583 ms indicating that the cluster is not in a defined clean state. Recorded index time metrics may be misleading.
Running delete-index                                                           [100% done]
Running create-index                                                           [100% done]
Running check-cluster-health-before-index-creation                             [100% done]
Running index                                                                  [100% done]
Running refresh-after-index-created                                            [100% done]
Running check-cluster-health                                                   [100% done]
Running set-concurent-segment-search-setting                                   [100% done]
Running refresh-after-index                                                    [100% done]
Running force-merge                                                            [100% done]
Running refresh-after-force-merge                                              [100% done]
Running wait-until-merges-finish                                               [100% done]
Running create-normalization-processor-no-weights-search-pipeline              [100% done]
Running hybrid-query-only-range                                                [100% done]
Running hybrid-query-only-range-large-subset                                   [100% done]
Running hybrid-query-only-term-range-date                                      [100% done]
Running aggs-query-min-avg-sum-hybrid                                          [100% done]
Running aggs-query-term-min-hybrid                                             [100% done]
Running aggs-query-date-histo-geohash-grid-hybrid                              [100% done]
Running aggs-query-range-numeric-significant-terms-hybrid                      [100% done]
Running hybrid-query-3-subqueries-sort-by-score-search-after                   [100% done]
Running hybrid-query-3-subqueries-sort-by-two-fields                           [100% done]
Running hybrid-query-3-subqueries-sort-by-two-fields-search-after              [100% done]

------------------------------------------------------
    _______             __   _____
   / ____(_)___  ____ _/ /  / ___/_________  ________
  / /_  / / __ \/ __ `/ /   \__ \/ ___/ __ \/ ___/ _ \
 / __/ / / / / / /_/ / /   ___/ / /__/ /_/ / /  /  __/
/_/   /_/_/ /_/\__,_/_/   /____/\___/\____/_/   \___/
|                                              Median Throughput |                                aggs-query-term-min-hybrid |       17.43 |  ops/s |
|                                                 Max Throughput |                                aggs-query-term-min-hybrid |       18.11 |  ops/s |
|                                        50th percentile latency |                                aggs-query-term-min-hybrid |     334.158 |     ms |
|                                        90th percentile latency |                                aggs-query-term-min-hybrid |     387.641 |     ms |
|                                        99th percentile latency |                                aggs-query-term-min-hybrid |         431 |     ms |
|                                       100th percentile latency |                                aggs-query-term-min-hybrid |      447.22 |     ms |
|                                   50th percentile service time |                                aggs-query-term-min-hybrid |     334.158 |     ms |
|                                   90th percentile service time |                                aggs-query-term-min-hybrid |     387.641 |     ms |
|                                   99th percentile service time |                                aggs-query-term-min-hybrid |         431 |     ms |
|                                  100th percentile service time |                                aggs-query-term-min-hybrid |      447.22 |     ms |
|                                                     error rate |                                aggs-query-term-min-hybrid |           0 |      % |
|                                                 Min Throughput |                 aggs-query-date-histo-geohash-grid-hybrid |       20.43 |  ops/s |
|                                                Mean Throughput |                 aggs-query-date-histo-geohash-grid-hybrid |        21.6 |  ops/s |
|                                              Median Throughput |                 aggs-query-date-histo-geohash-grid-hybrid |       21.71 |  ops/s |
|                                                 Max Throughput |                 aggs-query-date-histo-geohash-grid-hybrid |       22.33 |  ops/s |
|                                        50th percentile latency |                 aggs-query-date-histo-geohash-grid-hybrid |     304.521 |     ms |
|                                        90th percentile latency |                 aggs-query-date-histo-geohash-grid-hybrid |     342.951 |     ms |
|                                        99th percentile latency |                 aggs-query-date-histo-geohash-grid-hybrid |     381.312 |     ms |
|                                       100th percentile latency |                 aggs-query-date-histo-geohash-grid-hybrid |     393.479 |     ms |
|                                   50th percentile service time |                 aggs-query-date-histo-geohash-grid-hybrid |     304.521 |     ms |
|                                   90th percentile service time |                 aggs-query-date-histo-geohash-grid-hybrid |     342.951 |     ms |
|                                   99th percentile service time |                 aggs-query-date-histo-geohash-grid-hybrid |     381.312 |     ms |
|                                  100th percentile service time |                 aggs-query-date-histo-geohash-grid-hybrid |     393.479 |     ms |
|                                                     error rate |                 aggs-query-date-histo-geohash-grid-hybrid |           0 |      % |
|                                                 Min Throughput |         aggs-query-range-numeric-significant-terms-hybrid |        2.06 |  ops/s |
|                                                Mean Throughput |         aggs-query-range-numeric-significant-terms-hybrid |        2.11 |  ops/s |
|                                              Median Throughput |         aggs-query-range-numeric-significant-terms-hybrid |        2.12 |  ops/s |
|                                                 Max Throughput |         aggs-query-range-numeric-significant-terms-hybrid |        2.15 |  ops/s |
|                                        50th percentile latency |         aggs-query-range-numeric-significant-terms-hybrid |     3521.34 |     ms |
|                                        90th percentile latency |         aggs-query-range-numeric-significant-terms-hybrid |     5023.39 |     ms |
|                                        99th percentile latency |         aggs-query-range-numeric-significant-terms-hybrid |     6005.91 |     ms |
|                                       100th percentile latency |         aggs-query-range-numeric-significant-terms-hybrid |     6497.75 |     ms |
|                                   50th percentile service time |         aggs-query-range-numeric-significant-terms-hybrid |     3521.34 |     ms |
|                                   90th percentile service time |         aggs-query-range-numeric-significant-terms-hybrid |     5023.39 |     ms |
|                                   99th percentile service time |         aggs-query-range-numeric-significant-terms-hybrid |     6005.91 |     ms |
|                                  100th percentile service time |         aggs-query-range-numeric-significant-terms-hybrid |     6497.75 |     ms |
|                                                     error rate |         aggs-query-range-numeric-significant-terms-hybrid |           0 |      % |
|                                                 Min Throughput |         aggs-query-range-numeric-significant-terms-hybrid |        2.06 |  ops/s |
|                                                Mean Throughput |         aggs-query-range-numeric-significant-terms-hybrid |        2.11 |  ops/s |
|                                              Median Throughput |         aggs-query-range-numeric-significant-terms-hybrid |        2.12 |  ops/s |
|                                                 Max Throughput |         aggs-query-range-numeric-significant-terms-hybrid |        2.15 |  ops/s |
|                                        50th percentile latency |         aggs-query-range-numeric-significant-terms-hybrid |     3521.34 |     ms |
|                                        90th percentile latency |         aggs-query-range-numeric-significant-terms-hybrid |     5023.39 |     ms |
|                                        99th percentile latency |         aggs-query-range-numeric-significant-terms-hybrid |     6005.91 |     ms |
|                                       100th percentile latency |         aggs-query-range-numeric-significant-terms-hybrid |     6497.75 |     ms |
|                                   50th percentile service time |         aggs-query-range-numeric-significant-terms-hybrid |     3521.34 |     ms |
|                                   90th percentile service time |         aggs-query-range-numeric-significant-terms-hybrid |     5023.39 |     ms |
|                                   99th percentile service time |         aggs-query-range-numeric-significant-terms-hybrid |     6005.91 |     ms |
|                                  100th percentile service time |         aggs-query-range-numeric-significant-terms-hybrid |     6497.75 |     ms |
|                                                     error rate |         aggs-query-range-numeric-significant-terms-hybrid |           0 |      % |
|                                                 Min Throughput |      hybrid-query-3-subqueries-sort-by-score-search-after |        9.51 |  ops/s |
|                                                Mean Throughput |      hybrid-query-3-subqueries-sort-by-score-search-after |        9.64 |  ops/s |
|                                              Median Throughput |      hybrid-query-3-subqueries-sort-by-score-search-after |        9.64 |  ops/s |
|                                                 Max Throughput |      hybrid-query-3-subqueries-sort-by-score-search-after |        9.75 |  ops/s |
|                                        50th percentile latency |      hybrid-query-3-subqueries-sort-by-score-search-after |     784.484 |     ms |
|                                        90th percentile latency |      hybrid-query-3-subqueries-sort-by-score-search-after |     1001.59 |     ms |
|                                        99th percentile latency |      hybrid-query-3-subqueries-sort-by-score-search-after |     1236.56 |     ms |
|                                       100th percentile latency |      hybrid-query-3-subqueries-sort-by-score-search-after |      1272.6 |     ms |
|                                   50th percentile service time |      hybrid-query-3-subqueries-sort-by-score-search-after |     784.484 |     ms |
|                                   90th percentile service time |      hybrid-query-3-subqueries-sort-by-score-search-after |     1001.59 |     ms |
|                                   99th percentile service time |      hybrid-query-3-subqueries-sort-by-score-search-after |     1236.56 |     ms |
|                                  100th percentile service time |      hybrid-query-3-subqueries-sort-by-score-search-after |      1272.6 |     ms |
|                                                     error rate |      hybrid-query-3-subqueries-sort-by-score-search-after |           0 |      % |
|                                                 Min Throughput |              hybrid-query-3-subqueries-sort-by-two-fields |        5.11 |  ops/s |
|                                                Mean Throughput |              hybrid-query-3-subqueries-sort-by-two-fields |        5.36 |  ops/s |
|                                              Median Throughput |              hybrid-query-3-subqueries-sort-by-two-fields |        5.38 |  ops/s |
|                                                 Max Throughput |              hybrid-query-3-subqueries-sort-by-two-fields |        5.53 |  ops/s |
|                                        50th percentile latency |              hybrid-query-3-subqueries-sort-by-two-fields |     1254.75 |     ms |
|                                        90th percentile latency |              hybrid-query-3-subqueries-sort-by-two-fields |     1742.31 |     ms |
|                                        99th percentile latency |              hybrid-query-3-subqueries-sort-by-two-fields |     2204.01 |     ms |
|                                       100th percentile latency |              hybrid-query-3-subqueries-sort-by-two-fields |      2234.6 |     ms |
|                                   50th percentile service time |              hybrid-query-3-subqueries-sort-by-two-fields |     1254.75 |     ms |
|                                   90th percentile service time |              hybrid-query-3-subqueries-sort-by-two-fields |     1742.31 |     ms |
|                                   99th percentile service time |              hybrid-query-3-subqueries-sort-by-two-fields |     2204.01 |     ms |
|                                  100th percentile service time |              hybrid-query-3-subqueries-sort-by-two-fields |      2234.6 |     ms |
|                                                     error rate |              hybrid-query-3-subqueries-sort-by-two-fields |           0 |      % |
|                                                 Min Throughput | hybrid-query-3-subqueries-sort-by-two-fields-search-after |        5.45 |  ops/s |
|                                                Mean Throughput | hybrid-query-3-subqueries-sort-by-two-fields-search-after |        5.56 |  ops/s |
|                                              Median Throughput | hybrid-query-3-subqueries-sort-by-two-fields-search-after |        5.56 |  ops/s |
|                                                 Max Throughput | hybrid-query-3-subqueries-sort-by-two-fields-search-after |        5.64 |  ops/s |
|                                        50th percentile latency | hybrid-query-3-subqueries-sort-by-two-fields-search-after |     1444.79 |     ms |
|                                        90th percentile latency | hybrid-query-3-subqueries-sort-by-two-fields-search-after |     1834.21 |     ms |
|                                        99th percentile latency | hybrid-query-3-subqueries-sort-by-two-fields-search-after |     2366.18 |     ms |
|                                       100th percentile latency | hybrid-query-3-subqueries-sort-by-two-fields-search-after |     2460.64 |     ms |
|                                   50th percentile service time | hybrid-query-3-subqueries-sort-by-two-fields-search-after |     1444.79 |     ms |
|                                   90th percentile service time | hybrid-query-3-subqueries-sort-by-two-fields-search-after |     1834.21 |     ms |
|                                   99th percentile service time | hybrid-query-3-subqueries-sort-by-two-fields-search-after |     2366.18 |     ms |
|                                  100th percentile service time | hybrid-query-3-subqueries-sort-by-two-fields-search-after |     2460.64 |     ms |
|                                                     error rate | hybrid-query-3-subqueries-sort-by-two-fields-search-after |           0 |      % |


---------------------------------
[INFO] SUCCESS (took 891 seconds)
---------------------------------
```


### Backport to Branches:
- [ ] 6
- [ ] 7
- [ ] 1
- [ ] 2
- [ ] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
