### PR TITLE
Update dataset download url

### DIFF
--- a/neural_search/workload.json
+++ b/neural_search/workload.json
@@ -24,7 +24,7 @@
     },
     {
       "name": "abo",
-      "base-url": "https://github.com/weijia-aws/neural-search/releases/download/abo",
+      "base-url": "https://dbyiw3u3rf9yr.cloudfront.net/corpora/neural_search",
       "documents": [
         {
           "source-file": "documents.json.bz2",

--- a/neural_search/workload_queries.json
+++ b/neural_search/workload_queries.json
@@ -8,7 +8,7 @@
   },
   {
     "name": "abo",
-    "base-url": "https://github.com/weijia-aws/neural-search/releases/download/abo",
+    "base-url": "https://dbyiw3u3rf9yr.cloudfront.net/corpora/neural_search",
     "source-file": "abo_queries.json.bz2",
     "compressed-bytes": 6335918,
     "uncompressed-bytes": 9109124


### PR DESCRIPTION
### Description
This PR updates the ABO dataset download url from personal to public 

### Issues Resolved
N/A

### Testing
- [N/A] New functionality includes testing

[Describe how this change was tested]

### Backport to Branches:
- [ ] 6
- [ ] 7
- [ ] 1
- [x] 2
- [x] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
