### PR TITLE
Add J2 Workload Lint Checker to PRs

### DIFF
--- a/.github/workflows/workload-format-checker.yml
+++ b/.github/workflows/workload-format-checker.yml
@@ -1,0 +1,38 @@
+name: OSB Workloads Format Linter
+on: [pull_request]
+
+jobs:
+  jinja2-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          git clone https://github.com/aristanetworks/j2lint.git && cd j2lint
+          python3 -m pip install -e .
+          j2lint --version
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v39
+        with:
+          files: |
+            **.json
+
+      - name: Run J2lint on changed JSON files in a pull-request
+        if: github.event_name == 'pull_request'
+        run: |
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            if [[ $file == *.json ]]; then
+              echo "Checking $file"
+              j2lint "$GITHUB_WORKSPACE/$file" --extensions json --json
+            fi
+          done


### PR DESCRIPTION
### Description
All PRs should be lint-checked to ensure that there are no jinja2 violations being introduced. This should reduce the number of formatting errors. 

This is related to streamlining efforts for OSB 2.0.0

### Issues Resolved
#513 

### Testing
- [x] New functionality includes testing

Induced some errors in big5 workload and opened a PR. Workflow caught error as shown below. 
![image](https://github.com/user-attachments/assets/f6b4e6a6-21af-42b3-be0b-63385965cb22)


### Backport to Branches:
- [x] 6
- [x] 7
- [x] 1
- [x] 2
- [x] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
