### PR TITLE
Add warning to Workloads Lint Workflow

### DIFF
--- a/.github/workflows/workload-format-checker.yml
+++ b/.github/workflows/workload-format-checker.yml
@@ -33,6 +33,6 @@ jobs:
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             if [[ $file == *.json ]]; then
               echo "Checking $file"
-              j2lint "$GITHUB_WORKSPACE/$file" --extensions json --json
+              j2lint "$GITHUB_WORKSPACE/$file" --extensions json --json --warn S1 S2 S3 S4 S5 S6 S7
             fi
           done


### PR DESCRIPTION
### Description
Users should not be stopped unless there's a breaking change. This PR surpresses most lint issues as a warning. Keeps the incorrect syntax as an error. 

### Issues Resolved
#655 
#513

### Testing
- [ ] New functionality includes testing

[Describe how this change was tested]

### Backport to Branches:
- [x] 6
- [x] 7
- [x] 1
- [x] 2
- [x] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
