### PR TITLE
Update hybrid-search test procedure to include a complex operation

### DIFF
--- a/neural_search/test_procedures/hybrid_search.json
+++ b/neural_search/test_procedures/hybrid_search.json
@@ -43,6 +43,13 @@
       "clients": {{ search_clients | default(1)}}
     },
     {
+      "operation": "hybrid-search-complex-with-search-pipeline",
+      "warmup-iterations": {{warmup_iterations | default(100) | tojson}},
+      "iterations": {{iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(0) | tojson}},
+      "clients": {{ search_clients | default(1)}}
+    },
+    {
       "operation": "hybrid-search-with-temporary-pipeline",
       "warmup-iterations": {{warmup_iterations | default(100) | tojson}},
       "iterations": {{iterations | default(100) | tojson }},


### PR DESCRIPTION
### Description
Currently the hybrid-search test procedure in neural search workload only perform search with simple query, we want to extend the procedure to include a complex query search

### Issues Resolved
N/A

### Testing
- [] New functionality includes testing

[Describe how this change was tested]
Run benchmark on local, it passed

### Backport to Branches:
- [ ] 6
- [ ] 7
- [ ] 1
- [X] 2
- [X] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
