### PR TITLE
Add ppl queries to big5 benchmark

### DIFF
--- a/big5/README.md
+++ b/big5/README.md
@@ -63,6 +63,30 @@ osb execute-test --workload=big5 --test-procedure=ppl
 
 This will execute all PPL operations including basic queries, sorting, aggregations, and range operations using the PPL syntax instead of the standard OpenSearch Query DSL.
 
+#### PPL Operations Troubleshooting
+
+If your cluster doesn't have the SQL plugin installed, all PPL operations will fail with the following error:
+
+```
+[ERROR] no handler found for uri [/_plugins/_ppl] and method [POST] ({'error': 'no handler found for uri [/_plugins/_ppl] and method [POST]'})
+```
+
+To resolve this issue, **install the OpenSearch SQL Plugin** on your cluster (required for PPL operations).
+
+#### Enabling Calcite for PPL Operations
+
+By default, Calcite is disabled. To enable it for PPL operations, use the following command:
+
+```bash
+curl -XPUT "http://localhost:9200/_cluster/settings" \
+-H "Content-Type: application/json" \
+-d'{
+  "persistent": {
+    "plugins.calcite.enabled": true
+  }
+}'
+```
+
 ### Parameters
 
 This workload allows the following parameters to be specified using `--workload-params`:
@@ -147,6 +171,12 @@ The document schema can be found in the `index.json` file.  An example document 
 
 ### Sample Run Output
 
+#### Default Test Procedure
+
+```bash
+osb execute-test --workload=big5
+```
+
 ```
    ____                  _____                      __       ____                  __                         __
   / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
@@ -203,6 +233,68 @@ Running range_field_conjunction_small_range_small_term_query                   [
 Running range_field_conjunction_small_range_big_term_query                     [100% done]
 Running range-auto-date-histo                                                  [100% done]
 Running range-auto-date-histo-with-metrics                                     [100% done]
+
+------------------------------------------------------
+```
+
+#### PPL Test Procedure
+
+```bash
+osb execute-test --workload=big5 --test-procedure=ppl
+```
+
+```
+[INFO] Executing test with workload [big5], test_procedure [ppl] and provision_config_instance ['external'] with version [3.0.0].
+
+Running delete-index                                                           [100% done]
+Running create-index                                                           [100% done]
+Running check-cluster-health                                                   [100% done]
+Running index-append                                                           [100% done]
+Running refresh-after-index                                                    [100% done]
+Running force-merge                                                            [100% done]
+Running refresh-after-force-merge                                              [100% done]
+Running wait-until-merges-finish                                               [100% done]
+Running ppl-default                                                            [100% done]
+Running ppl-term                                                               [100% done]
+Running ppl-range                                                              [100% done]
+Running ppl-asc-sort-timestamp-can-match-shortcut                              [100% done]
+Running ppl-asc-sort-timestamp-no-can-match-shortcut                           [100% done]
+Running ppl-asc-sort-timestamp                                                 [100% done]
+Running ppl-asc-sort-with-after-timestamp                                      [100% done]
+Running ppl-composite-date-histogram-daily                                     [100% done]
+Running ppl-composite-terms-keyword                                            [100% done]
+Running ppl-composite-terms                                                    [100% done]
+Running ppl-date-histogram-hourly-agg                                          [100% done]
+Running ppl-date-histogram-minute-agg                                          [100% done]
+Running ppl-desc-sort-timestamp-can-match-shortcut                             [100% done]
+Running ppl-desc-sort-timestamp-no-can-match-shortcut                          [100% done]
+Running ppl-desc-sort-timestamp                                                [100% done]
+Running ppl-desc-sort-with-after-timestamp                                     [100% done]
+Running ppl-keyword-in-range                                                   [100% done]
+Running ppl-keyword-terms-low-cardinality                                      [100% done]
+Running ppl-keyword-terms                                                      [100% done]
+Running ppl-multi-terms-keyword                                                [100% done]
+Running ppl-query-string-on-message                                            [100% done]
+Running ppl-query-string-on-message-filtered                                   [100% done]
+Running ppl-query-string-on-message-filtered-sorted-num                        [100% done]
+Running ppl-range-auto-date-histo                                              [100% done]
+Running ppl-range-auto-date-histo-with-metrics                                 [100% done]
+Running ppl-range-field-conjunction-big-range-big-term-query                   [100% done]
+Running ppl-range-field-conjunction-small-range-big-term-query                 [100% done]
+Running ppl-range-field-conjunction-small-range-small-term-query               [100% done]
+Running ppl-range-field-disjunction-big-range-small-term-query                 [100% done]
+Running ppl-range-numeric                                                      [100% done]
+Running ppl-range-with-asc-sort                                                [100% done]
+Running ppl-range-with-desc-sort                                               [100% done]
+Running ppl-scroll                                                             [100% done]
+Running ppl-sort-keyword-can-match-shortcut                                    [100% done]
+Running ppl-sort-keyword-no-can-match-shortcut                                 [100% done]
+Running ppl-sort-numeric-asc                                                   [100% done]
+Running ppl-sort-numeric-asc-with-match                                        [100% done]
+Running ppl-sort-numeric-desc                                                  [100% done]
+Running ppl-sort-numeric-desc-with-match                                       [100% done]
+Running ppl-terms-significant-1                                                [100% done]
+Running ppl-terms-significant-2                                                [100% done]
 
 ------------------------------------------------------
 ```

--- a/big5/README.md
+++ b/big5/README.md
@@ -36,7 +36,32 @@ Before using this repository, ensure you have the following installed:
 
 - [OpenSearch](https://opensearch.org) (v2.11 or later)
 - [OpenSearch Benchmark](https://opensearch.org/docs/latest/benchmark) (v1.2 or later)
+- [OpenSearch SQL Plugin](https://opensearch.org/docs/latest/search-plugins/sql/index/) (required for PPL operations)
 
+
+### PPL Operations Support
+
+This workload includes PPL (Piped Processing Language) operations that provide an alternative query interface to OpenSearch. PPL operations are available in the `operations/ppl.json` file and include:
+
+- **ppl-default**: Basic PPL query with head operation
+- **ppl-term**: Term filtering using PPL where clause
+- **ppl-range**: Range filtering with timestamp conditions
+- **ppl-*-sort-***: Various sorting operations (ascending/descending, with/without shortcuts)
+- **ppl-date-histogram-***: Date histogram aggregations (hourly/minute intervals)
+- **ppl-composite-***: Composite aggregations for terms and date histograms
+- **ppl-keyword-***: Keyword-based operations and aggregations
+- **ppl-query-string-***: Query string operations with filtering and sorting
+- **ppl-range-***: Range queries with various conditions and sorting
+- **ppl-sort-***: Sorting operations on different field types
+- **ppl-terms-***: Terms aggregations for statistical analysis
+
+To use PPL operations, run the workload with the `ppl` test procedure:
+
+```bash
+osb execute-test --workload=big5 --test-procedure=ppl
+```
+
+This will execute all PPL operations including basic queries, sorting, aggregations, and range operations using the PPL syntax instead of the standard OpenSearch Query DSL.
 
 ### Parameters
 

--- a/big5/operations/ppl.json
+++ b/big5/operations/ppl.json
@@ -1,0 +1,369 @@
+    {
+      "name": "ppl-default",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | head 10"
+      }
+    },
+    {
+      "name": "ppl-term",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `log.file.path` = '/var/log/messages/birdknight' | head 10"
+      }
+    },
+    {
+      "name": "ppl-range",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `@timestamp` >= '2023-01-01 00:00:00' and `@timestamp` < '2023-01-03 00:00:00' | head 10"
+      }
+    },
+    {
+      "name": "ppl-asc-sort-timestamp-can-match-shortcut",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} match(`process.name`, 'kernel') | sort + `@timestamp` | head 10"
+      }
+    },
+    {
+      "name": "ppl-asc-sort-timestamp-no-can-match-shortcut",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} match(`process.name`, 'kernel') | sort + `@timestamp` | head 10"
+      }
+    },
+    {
+      "name": "ppl-asc-sort-timestamp",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | sort + `@timestamp` | head 10"
+      }
+    },
+    {
+      "name": "ppl-asc-sort-with-after-timestamp",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | sort + `@timestamp` | head 10"
+      }
+    },
+    {
+      "name": "ppl-composite-date-histogram-daily",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `@timestamp` >= '2022-12-30 00:00:00' and `@timestamp` < '2023-01-07 12:00:00' | stats count() by span(`@timestamp`, 1d)"
+      }
+    },
+    {
+      "name": "ppl-composite-terms-keyword",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `@timestamp` >= '2023-01-02 00:00:00' and `@timestamp` < '2023-01-03 00:00:00' | stats count() by `process.name`, `cloud.region`, `aws.cloudwatch.log_stream` | sort - `process.name`, + `cloud.region`, + `aws.cloudwatch.log_stream`"
+      }
+    },
+    {
+      "name": "ppl-composite-terms",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `@timestamp` >= '2023-01-02 00:00:00' and `@timestamp` < '2023-01-03 00:00:00' | stats count() by `process.name`, `cloud.region` | sort - `process.name`, + `cloud.region`"
+      }
+    },
+    {
+      "name": "ppl-date-histogram-hourly-agg",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | stats count() by span(`@timestamp`, 1h)"
+      }
+    },
+    {
+      "name": "ppl-date-histogram-minute-agg",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `@timestamp` >= '2023-01-01 00:00:00' and `@timestamp` < '2023-01-03 00:00:00' | stats count() by span(`@timestamp`, 1m)"
+      }
+    },
+    {
+      "name": "ppl-desc-sort-timestamp-can-match-shortcut",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} match(`process.name`, 'kernel') | sort - `@timestamp` | head 10"
+      }
+    },
+    {
+      "name": "ppl-desc-sort-timestamp-no-can-match-shortcut",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} match(`process.name`, 'kernel') | sort - `@timestamp` | head 10"
+      }
+    },
+    {
+      "name": "ppl-desc-sort-timestamp",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | sort - `@timestamp` | head 10"
+      }
+    },
+    {
+      "name": "ppl-desc-sort-with-after-timestamp",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | sort - `@timestamp` | head 10"
+      }
+    },
+    {
+      "name": "ppl-keyword-in-range",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} match(`process.name`, 'kernel') | where `@timestamp` >= '2023-01-01 00:00:00' and `@timestamp` < '2023-01-03 00:00:00' | head 10"
+      }
+    },
+    {
+      "name": "ppl-keyword-terms-low-cardinality",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | stats count() as country by `aws.cloudwatch.log_stream` | sort - country | head 100"
+      }
+    },
+    {
+      "name": "ppl-keyword-terms",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | stats count() as station by `aws.cloudwatch.log_stream` | sort - station | head 500"
+      }
+    },
+    {
+      "name": "ppl-multi-terms-keyword",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `@timestamp` >= '2022-12-30 00:00:00' and `@timestamp` < '2023-01-01 03:00:00' | stats count() by `process.name`, `event.id`, `cloud.region` | sort - `count()`"
+      }
+    },
+    {
+      "name": "ppl-query-string-on-message-filtered-sorted-num",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} query_string(['message'], 'shield AND carp AND shark') | where `@timestamp` >= '2023-01-01 00:00:00' and `@timestamp` < '2023-01-03 00:00:00' | sort - `metrics.size` | head 10"
+      }
+    },
+    {
+      "name": "ppl-query-string-on-message-filtered",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} query_string(['message'], 'shield carp shark', default_operator='AND') | where `@timestamp` >= '2023-01-01 00:00:00' and `@timestamp` < '2023-01-03 00:00:00' | head 10"
+      }
+    },
+    {
+      "name": "ppl-query-string-on-message",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} query_string(['message'], 'shield AND carp AND shark') | head 10"
+      }
+    },
+    {
+      "name": "ppl-range-auto-date-histo-with-metrics",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | eval range_bucket = case(`metrics.size` < -10, 'range_1', `metrics.size` >= -10 and `metrics.size` < 10, 'range_2', `metrics.size` >= 10 and `metrics.size` < 100, 'range_3', `metrics.size` >= 100 and `metrics.size` < 1000, 'range_4', `metrics.size` >= 1000 and `metrics.size` < 2000, 'range_5', `metrics.size` >= 2000, 'range_6') | stats min(`metrics.tmin`) as tmin, avg(`metrics.size`) as tavg, max(`metrics.size`) as tmax by range_bucket, span(`@timestamp`, 1h) as auto_span | sort + range_bucket, + auto_span"
+      }
+    },
+    {
+      "name": "ppl-range-auto-date-histo",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | eval range_bucket = case(`metrics.size` < -10, 'range_1', `metrics.size` >= -10 and `metrics.size` < 10, 'range_2', `metrics.size` >= 10 and `metrics.size` < 100, 'range_3', `metrics.size` >= 100 and `metrics.size` < 1000, 'range_4', `metrics.size` >= 1000 and `metrics.size` < 2000, 'range_5', `metrics.size` >= 2000, 'range_6') | stats count() by range_bucket, span(`@timestamp`, 1h) as auto_span | sort + range_bucket, + auto_span"
+      }
+    },
+    {
+      "name": "ppl-range-field-conjunction-big-range-big-term-query",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `process.name` = 'systemd' and `metrics.size` >= 1 and `metrics.size` <= 1000 | head 10"
+      }
+    },
+    {
+      "name": "ppl-range-field-conjunction-small-range-big-term-query",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `metrics.size` >= 1 and `metrics.size` <= 42 | head 10"
+      }
+    },
+    {
+      "name": "ppl-range-field-conjunction-small-range-small-term-query",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `aws.cloudwatch.log_stream` = 'indigodagger' or (`metrics.size` >= 1 and `metrics.size` <= 30) | head 10"
+      }
+    },
+    {
+      "name": "ppl-range-field-disjunction-big-range-small-term-query",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `aws.cloudwatch.log_stream` = 'indigodagger' or (`metrics.size` >= 1 and `metrics.size` <= 1000) | head 10"
+      }
+    },
+    {
+      "name": "ppl-range-numeric",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `metrics.size` >= 1 and `metrics.size` <= 1000 | head 10"
+      }
+    },
+    {
+      "name": "ppl-range-with-asc-sort",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `@timestamp` >= '2023-01-01 00:00:00' and `@timestamp` <= '2023-01-13 00:00:00' | sort + `@timestamp` | head 10"
+      }
+    },
+    {
+      "name": "ppl-range-with-desc-sort",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `@timestamp` >= '2023-01-01 00:00:00' and `@timestamp` <= '2023-01-13 00:00:00' | sort - `@timestamp` | head 10"
+      }
+    },
+    {
+      "name": "ppl-scroll",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | head 10"
+      }
+    },
+    {
+      "name": "ppl-sort-keyword-can-match-shortcut",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} match(`process.name`, 'kernel') | sort + `@timestamp` | head 10"
+      }
+    },
+    {
+      "name": "ppl-sort-keyword-no-can-match-shortcut",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} match(`process.name`, 'kernel') | sort + `@timestamp` | head 10"
+      }
+    },
+    {
+      "name": "ppl-sort-numeric-asc-with-match",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} match(`log.file.path`, '/var/log/messages/solarshark') | sort + `metrics.size` | head 10"
+      }
+    },
+    {
+      "name": "ppl-sort-numeric-asc",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | sort + `metrics.size` | head 10"
+      }
+    },
+    {
+      "name": "ppl-sort-numeric-desc-with-match",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} match(`log.file.path`, '/var/log/messages/solarshark') | sort - `metrics.size` | head 10"
+      }
+    },
+    {
+      "name": "ppl-sort-numeric-desc",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | sort - `metrics.size` | head 10"
+      }
+    },
+    {
+      "name": "ppl-terms-significant-1",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `@timestamp` >= '2023-01-01 00:00:00' and `@timestamp` < '2023-01-03 00:00:00' | stats count() by `aws.cloudwatch.log_stream` | head 10"
+      }
+    },
+    {
+      "name": "ppl-terms-significant-2",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `@timestamp` >= '2023-01-01 00:00:00' and `@timestamp` < '2023-01-03 00:00:00' | stats count() by `process.name` | head 10"
+      }
+    }

--- a/big5/queries/ppl/asc_sort_timestamp.ppl
+++ b/big5/queries/ppl/asc_sort_timestamp.ppl
@@ -1,0 +1,3 @@
+source = big5
+| sort + `@timestamp`
+| head 10

--- a/big5/queries/ppl/asc_sort_timestamp_can_match_shortcut.ppl
+++ b/big5/queries/ppl/asc_sort_timestamp_can_match_shortcut.ppl
@@ -1,0 +1,3 @@
+source = big5 match(`process.name`, 'kernel')
+| sort + `@timestamp`
+| head 10

--- a/big5/queries/ppl/asc_sort_timestamp_no_can_match_shortcut.ppl
+++ b/big5/queries/ppl/asc_sort_timestamp_no_can_match_shortcut.ppl
@@ -1,0 +1,3 @@
+source = big5 match(`process.name`, 'kernel')
+| sort + `@timestamp`
+| head 10

--- a/big5/queries/ppl/asc_sort_with_after_timestamp.ppl
+++ b/big5/queries/ppl/asc_sort_with_after_timestamp.ppl
@@ -1,0 +1,3 @@
+source = big5
+| sort + `@timestamp`
+| head 10

--- a/big5/queries/ppl/composite_date_histogram_daily.ppl
+++ b/big5/queries/ppl/composite_date_histogram_daily.ppl
@@ -1,0 +1,3 @@
+source = big5
+| where `@timestamp` >= '2022-12-30 00:00:00' and `@timestamp` < '2023-01-07 12:00:00'
+| stats count() by span(`@timestamp`, 1d)

--- a/big5/queries/ppl/composite_terms.ppl
+++ b/big5/queries/ppl/composite_terms.ppl
@@ -1,0 +1,4 @@
+source = big5
+| where `@timestamp` >= '2023-01-02 00:00:00' and `@timestamp` < '2023-01-03 00:00:00'
+| stats count() by `process.name`, `cloud.region`
+| sort - `process.name`, + `cloud.region`

--- a/big5/queries/ppl/composite_terms_keyword.ppl
+++ b/big5/queries/ppl/composite_terms_keyword.ppl
@@ -1,0 +1,4 @@
+source = big5
+| where `@timestamp` >= '2023-01-02 00:00:00' and `@timestamp` < '2023-01-03 00:00:00'
+| stats count() by `process.name`, `cloud.region`, `aws.cloudwatch.log_stream`
+| sort - `process.name`, + `cloud.region`, + `aws.cloudwatch.log_stream`

--- a/big5/queries/ppl/date_histogram_hourly_agg.ppl
+++ b/big5/queries/ppl/date_histogram_hourly_agg.ppl
@@ -1,0 +1,2 @@
+source = big5
+| stats count() by span(`@timestamp`, 1h)

--- a/big5/queries/ppl/date_histogram_minute_agg.ppl
+++ b/big5/queries/ppl/date_histogram_minute_agg.ppl
@@ -1,0 +1,3 @@
+source = big5
+| where `@timestamp` >= '2023-01-01 00:00:00' and `@timestamp` < '2023-01-03 00:00:00'
+| stats count() by span(`@timestamp`, 1m)

--- a/big5/queries/ppl/default.ppl
+++ b/big5/queries/ppl/default.ppl
@@ -1,0 +1,2 @@
+source = big5
+| head 10

--- a/big5/queries/ppl/desc_sort_timestamp.ppl
+++ b/big5/queries/ppl/desc_sort_timestamp.ppl
@@ -1,0 +1,3 @@
+source = big5
+| sort - `@timestamp`
+| head 10

--- a/big5/queries/ppl/desc_sort_timestamp_can_match_shortcut.ppl
+++ b/big5/queries/ppl/desc_sort_timestamp_can_match_shortcut.ppl
@@ -1,0 +1,3 @@
+source = big5 match(`process.name`, 'kernel')
+| sort - `@timestamp`
+| head 10

--- a/big5/queries/ppl/desc_sort_timestamp_no_can_match_shortcut.ppl
+++ b/big5/queries/ppl/desc_sort_timestamp_no_can_match_shortcut.ppl
@@ -1,0 +1,3 @@
+source = big5 match(`process.name`, 'kernel')
+| sort - `@timestamp`
+| head 10

--- a/big5/queries/ppl/desc_sort_with_after_timestamp.ppl
+++ b/big5/queries/ppl/desc_sort_with_after_timestamp.ppl
@@ -1,0 +1,3 @@
+source = big5
+| sort - `@timestamp`
+| head 10

--- a/big5/queries/ppl/keyword_in_range.ppl
+++ b/big5/queries/ppl/keyword_in_range.ppl
@@ -1,0 +1,4 @@
+source = big5 match(`process.name`, 'kernel')
+| where `@timestamp` >= '2023-01-01 00:00:00'
+  and `@timestamp` < '2023-01-03 00:00:00'
+| head 10

--- a/big5/queries/ppl/keyword_terms.ppl
+++ b/big5/queries/ppl/keyword_terms.ppl
@@ -1,0 +1,4 @@
+source = big5
+| stats count() as station by `aws.cloudwatch.log_stream`
+| sort - station
+| head 500

--- a/big5/queries/ppl/keyword_terms_low_cardinality.ppl
+++ b/big5/queries/ppl/keyword_terms_low_cardinality.ppl
@@ -1,0 +1,4 @@
+source = big5
+| stats count() as country by `aws.cloudwatch.log_stream`
+| sort - country
+| head 100

--- a/big5/queries/ppl/multi_terms_keyword.ppl
+++ b/big5/queries/ppl/multi_terms_keyword.ppl
@@ -1,0 +1,4 @@
+source = big5
+| where `@timestamp` >= '2022-12-30 00:00:00' and `@timestamp` < '2023-01-01 03:00:00'
+| stats count() by `process.name`, `event.id`, `cloud.region`
+| sort - `count()`

--- a/big5/queries/ppl/query_string_on_message.ppl
+++ b/big5/queries/ppl/query_string_on_message.ppl
@@ -1,0 +1,2 @@
+source = big5 query_string(['message'], 'shield AND carp AND shark')
+| head 10

--- a/big5/queries/ppl/query_string_on_message_filtered.ppl
+++ b/big5/queries/ppl/query_string_on_message_filtered.ppl
@@ -1,0 +1,4 @@
+source = big5 query_string(['message'], 'shield carp shark', default_operator='AND')
+| where `@timestamp` >= '2023-01-01 00:00:00'
+  and `@timestamp` < '2023-01-03 00:00:00'
+| head 10

--- a/big5/queries/ppl/query_string_on_message_filtered_sorted_num.ppl
+++ b/big5/queries/ppl/query_string_on_message_filtered_sorted_num.ppl
@@ -1,0 +1,5 @@
+source = big5 query_string(['message'], 'shield AND carp AND shark')
+| where `@timestamp` >= '2023-01-01 00:00:00'
+  and `@timestamp` < '2023-01-03 00:00:00'
+| sort - `metrics.size`
+| head 10

--- a/big5/queries/ppl/range.ppl
+++ b/big5/queries/ppl/range.ppl
@@ -1,0 +1,3 @@
+source = big5
+| where `@timestamp` >= '2023-01-01 00:00:00' and `@timestamp` < '2023-01-03 00:00:00'
+| head 10

--- a/big5/queries/ppl/range_auto_date_histo.ppl
+++ b/big5/queries/ppl/range_auto_date_histo.ppl
@@ -1,0 +1,10 @@
+source = big5
+| eval range_bucket = case(
+   `metrics.size` < -10, 'range_1',
+   `metrics.size` >= -10 and `metrics.size` < 10, 'range_2',
+   `metrics.size` >= 10 and `metrics.size` < 100, 'range_3',
+   `metrics.size` >= 100 and `metrics.size` < 1000, 'range_4',
+   `metrics.size` >= 1000 and `metrics.size` < 2000, 'range_5',
+   `metrics.size` >= 2000, 'range_6')
+| stats count() by range_bucket, span(`@timestamp`, 1h) as auto_span
+| sort + range_bucket, + auto_span

--- a/big5/queries/ppl/range_auto_date_histo_with_metrics.ppl
+++ b/big5/queries/ppl/range_auto_date_histo_with_metrics.ppl
@@ -1,0 +1,10 @@
+source = big5
+| eval range_bucket = case(
+   `metrics.size` < -10, 'range_1',
+   `metrics.size` >= -10 and `metrics.size` < 10, 'range_2',
+   `metrics.size` >= 10 and `metrics.size` < 100, 'range_3',
+   `metrics.size` >= 100 and `metrics.size` < 1000, 'range_4',
+   `metrics.size` >= 1000 and `metrics.size` < 2000, 'range_5',
+   `metrics.size` >= 2000, 'range_6')
+| stats min(`metrics.tmin`) as tmin, avg(`metrics.size`) as tavg, max(`metrics.size`) as tmax by range_bucket, span(`@timestamp`, 1h) as auto_span
+| sort + range_bucket, + auto_span

--- a/big5/queries/ppl/range_field_conjunction_big_range_big_term_query.ppl
+++ b/big5/queries/ppl/range_field_conjunction_big_range_big_term_query.ppl
@@ -1,0 +1,5 @@
+source = big5
+| where `process.name` = 'systemd'
+  and `metrics.size` >= 1
+  and `metrics.size` <= 1000
+| head 10

--- a/big5/queries/ppl/range_field_conjunction_small_range_big_term_query.ppl
+++ b/big5/queries/ppl/range_field_conjunction_small_range_big_term_query.ppl
@@ -1,0 +1,3 @@
+source = big5
+| where `metrics.size` >= 1 and `metrics.size` <= 42
+| head 10

--- a/big5/queries/ppl/range_field_conjunction_small_range_small_term_query.ppl
+++ b/big5/queries/ppl/range_field_conjunction_small_range_small_term_query.ppl
@@ -1,0 +1,4 @@
+source = big5
+| where `aws.cloudwatch.log_stream` = 'indigodagger'
+   or (`metrics.size` >= 1 and `metrics.size` <= 30)
+| head 10

--- a/big5/queries/ppl/range_field_disjunction_big_range_small_term_query.ppl
+++ b/big5/queries/ppl/range_field_disjunction_big_range_small_term_query.ppl
@@ -1,0 +1,4 @@
+source = big5
+| where `aws.cloudwatch.log_stream` = 'indigodagger'
+   or (`metrics.size` >= 1 and `metrics.size` <= 1000)
+| head 10

--- a/big5/queries/ppl/range_numeric.ppl
+++ b/big5/queries/ppl/range_numeric.ppl
@@ -1,0 +1,3 @@
+source = big5
+| where `metrics.size` >= 1 and `metrics.size` <= 1000
+| head 10

--- a/big5/queries/ppl/range_with_asc_sort.ppl
+++ b/big5/queries/ppl/range_with_asc_sort.ppl
@@ -1,0 +1,5 @@
+source = big5
+| where `@timestamp` >= '2023-01-01 00:00:00'
+  and `@timestamp` <= '2023-01-13 00:00:00'
+| sort + `@timestamp`
+| head 10

--- a/big5/queries/ppl/range_with_desc_sort.ppl
+++ b/big5/queries/ppl/range_with_desc_sort.ppl
@@ -1,0 +1,5 @@
+source = big5
+| where `@timestamp` >= '2023-01-01 00:00:00'
+  and `@timestamp` <= '2023-01-13 00:00:00'
+| sort - `@timestamp`
+| head 10

--- a/big5/queries/ppl/scroll.ppl
+++ b/big5/queries/ppl/scroll.ppl
@@ -1,0 +1,2 @@
+source = big5
+| head 10

--- a/big5/queries/ppl/sort_keyword_can_match_shortcut.ppl
+++ b/big5/queries/ppl/sort_keyword_can_match_shortcut.ppl
@@ -1,0 +1,3 @@
+source = big5 match(`process.name`, 'kernel')
+| sort + `@timestamp`
+| head 10

--- a/big5/queries/ppl/sort_keyword_no_can_match_shortcut.ppl
+++ b/big5/queries/ppl/sort_keyword_no_can_match_shortcut.ppl
@@ -1,0 +1,3 @@
+source = big5 match(`process.name`, 'kernel')
+| sort + `@timestamp`
+| head 10

--- a/big5/queries/ppl/sort_numeric_asc.ppl
+++ b/big5/queries/ppl/sort_numeric_asc.ppl
@@ -1,0 +1,3 @@
+source = big5
+| sort + `metrics.size`
+| head 10

--- a/big5/queries/ppl/sort_numeric_asc_with_match.ppl
+++ b/big5/queries/ppl/sort_numeric_asc_with_match.ppl
@@ -1,0 +1,3 @@
+source = big5 match(`log.file.path`, '/var/log/messages/solarshark')
+| sort + `metrics.size`
+| head 10

--- a/big5/queries/ppl/sort_numeric_desc.ppl
+++ b/big5/queries/ppl/sort_numeric_desc.ppl
@@ -1,0 +1,3 @@
+source = big5
+| sort - `metrics.size`
+| head 10

--- a/big5/queries/ppl/sort_numeric_desc_with_match.ppl
+++ b/big5/queries/ppl/sort_numeric_desc_with_match.ppl
@@ -1,0 +1,3 @@
+source = big5 match(`log.file.path`, '/var/log/messages/solarshark')
+| sort - `metrics.size`
+| head 10

--- a/big5/queries/ppl/term.ppl
+++ b/big5/queries/ppl/term.ppl
@@ -1,0 +1,3 @@
+source = big5
+| where `log.file.path` = '/var/log/messages/birdknight'
+| head 10

--- a/big5/queries/ppl/terms_significant_1.ppl
+++ b/big5/queries/ppl/terms_significant_1.ppl
@@ -1,0 +1,5 @@
+source = big5
+| where `@timestamp` >= '2023-01-01 00:00:00'
+  and `@timestamp` < '2023-01-03 00:00:00'
+| stats count() by `aws.cloudwatch.log_stream`
+| head 10

--- a/big5/queries/ppl/terms_significant_2.ppl
+++ b/big5/queries/ppl/terms_significant_2.ppl
@@ -1,0 +1,5 @@
+source = big5
+| where `@timestamp` >= '2023-01-01 00:00:00'
+  and `@timestamp` < '2023-01-03 00:00:00'
+| stats count() by `process.name`
+| head 10

--- a/big5/test_procedures/default.json
+++ b/big5/test_procedures/default.json
@@ -20,11 +20,23 @@
 },
 {
   "name": "ppl",
+  "description": "Indexes the whole document corpus using OpenSearch default settings and runs PPL (Piped Processing Language) queries. Requires the SQL plugin to be installed.",
   "default": false,
   "schedule": [
     {% with default_index_settings={}, index_name="big5" %}
     {{ benchmark.collect(parts="../../common_operations/workload_setup.json") }},
     {% endwith %}
     {{ benchmark.collect(parts="ppl/ppl-schedule.json") }}
+  ]
+},
+{
+  "name": "ppl-test",
+  "description": "Indexes the whole document corpus and runs a single PPL query to test SQL plugin availability.",
+  "default": false,
+  "schedule": [
+    {% with default_index_settings={}, index_name="big5" %}
+    {{ benchmark.collect(parts="../../common_operations/workload_setup.json") }},
+    {% endwith %}
+    {{ benchmark.collect(parts="ppl/ppl-test-schedule.json") }}
   ]
 }

--- a/big5/test_procedures/default.json
+++ b/big5/test_procedures/default.json
@@ -17,4 +17,14 @@
     {% endwith %}
     {{ benchmark.collect(parts="common/test-schedule.json") }}
   ]
+},
+{
+  "name": "ppl",
+  "default": false,
+  "schedule": [
+    {% with default_index_settings={}, index_name="big5" %}
+    {{ benchmark.collect(parts="../../common_operations/workload_setup.json") }},
+    {% endwith %}
+    {{ benchmark.collect(parts="ppl/ppl-schedule.json") }}
+  ]
 }

--- a/big5/test_procedures/ppl/ppl-schedule.json
+++ b/big5/test_procedures/ppl/ppl-schedule.json
@@ -1,287 +1,287 @@
 {
   "operation": "ppl-default",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_default_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_default_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_default_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_default_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-term",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_term_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_term_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_term_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_term_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-range",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_range_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_range_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_range_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_range_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-asc-sort-timestamp-can-match-shortcut",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_asc_sort_timestamp_can_match_shortcut_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_asc_sort_timestamp_can_match_shortcut_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_asc_sort_timestamp_can_match_shortcut_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_asc_sort_timestamp_can_match_shortcut_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-asc-sort-timestamp-no-can-match-shortcut",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_asc_sort_timestamp_no_can_match_shortcut_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_asc_sort_timestamp_no_can_match_shortcut_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_asc_sort_timestamp_no_can_match_shortcut_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_asc_sort_timestamp_no_can_match_shortcut_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-asc-sort-timestamp",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_asc_sort_timestamp_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_asc_sort_timestamp_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_asc_sort_timestamp_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_asc_sort_timestamp_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-asc-sort-with-after-timestamp",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_asc_sort_with_after_timestamp_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_asc_sort_with_after_timestamp_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_asc_sort_with_after_timestamp_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_asc_sort_with_after_timestamp_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-composite-date-histogram-daily",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_composite_date_histogram_daily_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_composite_date_histogram_daily_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_composite_date_histogram_daily_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_composite_date_histogram_daily_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-composite-terms-keyword",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_composite_terms_keyword_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_composite_terms_keyword_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_composite_terms_keyword_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_composite_terms_keyword_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-composite-terms",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_composite_terms_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_composite_terms_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_composite_terms_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_composite_terms_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-date-histogram-hourly-agg",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_date_histogram_hourly_agg_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_date_histogram_hourly_agg_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_date_histogram_hourly_agg_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_date_histogram_hourly_agg_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-date-histogram-minute-agg",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_date_histogram_minute_agg_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_date_histogram_minute_agg_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_date_histogram_minute_agg_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_date_histogram_minute_agg_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-desc-sort-timestamp-can-match-shortcut",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_desc_sort_timestamp_can_match_shortcut_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_desc_sort_timestamp_can_match_shortcut_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_desc_sort_timestamp_can_match_shortcut_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_desc_sort_timestamp_can_match_shortcut_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-desc-sort-timestamp-no-can-match-shortcut",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_desc_sort_timestamp_no_can_match_shortcut_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_desc_sort_timestamp_no_can_match_shortcut_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_desc_sort_timestamp_no_can_match_shortcut_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_desc_sort_timestamp_no_can_match_shortcut_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-desc-sort-timestamp",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_desc_sort_timestamp_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_desc_sort_timestamp_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_desc_sort_timestamp_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_desc_sort_timestamp_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-desc-sort-with-after-timestamp",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_desc_sort_with_after_timestamp_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_desc_sort_with_after_timestamp_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_desc_sort_with_after_timestamp_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_desc_sort_with_after_timestamp_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-keyword-in-range",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_keyword_in_range_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_keyword_in_range_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_keyword_in_range_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_keyword_in_range_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-keyword-terms-low-cardinality",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_keyword_terms_low_cardinality_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_keyword_terms_low_cardinality_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_keyword_terms_low_cardinality_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_keyword_terms_low_cardinality_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-keyword-terms",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_keyword_terms_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_keyword_terms_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_keyword_terms_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_keyword_terms_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-multi-terms-keyword",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_multi_terms_keyword_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_multi_terms_keyword_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_multi_terms_keyword_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_multi_terms_keyword_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-query-string-on-message-filtered-sorted-num",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_query_string_on_message_filtered_sorted_num_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_query_string_on_message_filtered_sorted_num_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_query_string_on_message_filtered_sorted_num_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_query_string_on_message_filtered_sorted_num_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-query-string-on-message-filtered",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_query_string_on_message_filtered_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_query_string_on_message_filtered_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_query_string_on_message_filtered_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_query_string_on_message_filtered_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-query-string-on-message",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_query_string_on_message_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_query_string_on_message_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_query_string_on_message_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_query_string_on_message_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-range-auto-date-histo-with-metrics",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_range_auto_date_histo_with_metrics_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_range_auto_date_histo_with_metrics_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_range_auto_date_histo_with_metrics_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_range_auto_date_histo_with_metrics_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-range-auto-date-histo",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_range_auto_date_histo_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_range_auto_date_histo_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_range_auto_date_histo_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_range_auto_date_histo_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-range-field-conjunction-big-range-big-term-query",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_range_field_conjunction_big_range_big_term_query_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_range_field_conjunction_big_range_big_term_query_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_range_field_conjunction_big_range_big_term_query_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_range_field_conjunction_big_range_big_term_query_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-range-field-conjunction-small-range-big-term-query",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_range_field_conjunction_small_range_big_term_query_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_range_field_conjunction_small_range_big_term_query_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_range_field_conjunction_small_range_big_term_query_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_range_field_conjunction_small_range_big_term_query_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-range-field-conjunction-small-range-small-term-query",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_range_field_conjunction_small_range_small_term_query_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_range_field_conjunction_small_range_small_term_query_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_range_field_conjunction_small_range_small_term_query_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_range_field_conjunction_small_range_small_term_query_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-range-field-disjunction-big-range-small-term-query",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_range_field_disjunction_big_range_small_term_query_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_range_field_disjunction_big_range_small_term_query_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_range_field_disjunction_big_range_small_term_query_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_range_field_disjunction_big_range_small_term_query_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-range-numeric",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_range_numeric_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_range_numeric_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_range_numeric_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_range_numeric_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-range-with-asc-sort",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_range_with_asc_sort_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_range_with_asc_sort_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_range_with_asc_sort_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_range_with_asc_sort_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-range-with-desc-sort",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_range_with_desc_sort_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_range_with_desc_sort_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_range_with_desc_sort_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_range_with_desc_sort_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-scroll",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_scroll_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_scroll_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_scroll_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_scroll_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-sort-keyword-can-match-shortcut",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_sort_keyword_can_match_shortcut_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_sort_keyword_can_match_shortcut_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_sort_keyword_can_match_shortcut_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_sort_keyword_can_match_shortcut_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-sort-keyword-no-can-match-shortcut",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_sort_keyword_no_can_match_shortcut_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_sort_keyword_no_can_match_shortcut_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_sort_keyword_no_can_match_shortcut_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_sort_keyword_no_can_match_shortcut_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-sort-numeric-asc-with-match",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_sort_numeric_asc_with_match_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_sort_numeric_asc_with_match_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_sort_numeric_asc_with_match_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_sort_numeric_asc_with_match_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-sort-numeric-asc",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_sort_numeric_asc_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_sort_numeric_asc_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_sort_numeric_asc_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_sort_numeric_asc_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-sort-numeric-desc-with-match",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_sort_numeric_desc_with_match_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_sort_numeric_desc_with_match_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_sort_numeric_desc_with_match_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_sort_numeric_desc_with_match_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-sort-numeric-desc",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_sort_numeric_desc_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_sort_numeric_desc_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_sort_numeric_desc_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_sort_numeric_desc_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-terms-significant-1",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_terms_significant_1_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_terms_significant_1_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_terms_significant_1_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_terms_significant_1_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-terms-significant-2",
-  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
-  "iterations": {{ test_iterations | default(100) | tojson }},
-  "target-throughput": {{ target_throughput | default(2) | tojson }},
-  "clients": {{ search_clients | default(1) }}
+  "warmup-iterations": {{ ppl_terms_significant_2_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_terms_significant_2_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_terms_significant_2_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_terms_significant_2_clients or search_clients | default(1) }}
 }

--- a/big5/test_procedures/ppl/ppl-schedule.json
+++ b/big5/test_procedures/ppl/ppl-schedule.json
@@ -1,0 +1,287 @@
+{
+  "operation": "ppl-default",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-term",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-range",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-asc-sort-timestamp-can-match-shortcut",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-asc-sort-timestamp-no-can-match-shortcut",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-asc-sort-timestamp",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-asc-sort-with-after-timestamp",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-composite-date-histogram-daily",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-composite-terms-keyword",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-composite-terms",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-date-histogram-hourly-agg",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-date-histogram-minute-agg",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-desc-sort-timestamp-can-match-shortcut",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-desc-sort-timestamp-no-can-match-shortcut",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-desc-sort-timestamp",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-desc-sort-with-after-timestamp",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-keyword-in-range",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-keyword-terms-low-cardinality",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-keyword-terms",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-multi-terms-keyword",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-query-string-on-message-filtered-sorted-num",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-query-string-on-message-filtered",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-query-string-on-message",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-range-auto-date-histo-with-metrics",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-range-auto-date-histo",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-range-field-conjunction-big-range-big-term-query",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-range-field-conjunction-small-range-big-term-query",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-range-field-conjunction-small-range-small-term-query",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-range-field-disjunction-big-range-small-term-query",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-range-numeric",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-range-with-asc-sort",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-range-with-desc-sort",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-scroll",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-sort-keyword-can-match-shortcut",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-sort-keyword-no-can-match-shortcut",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-sort-numeric-asc-with-match",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-sort-numeric-asc",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-sort-numeric-desc-with-match",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-sort-numeric-desc",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-terms-significant-1",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "ppl-terms-significant-2",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+}

--- a/big5/test_procedures/ppl/ppl-test-schedule.json
+++ b/big5/test_procedures/ppl/ppl-test-schedule.json
@@ -1,0 +1,7 @@
+{
+  "name": "ppl-default",
+  "operation": "ppl-default",
+  "warmup-iterations": 500,
+  "iterations": 100,
+  "target-throughput": 2
+}


### PR DESCRIPTION
### Description

This enhancement adds 42 PPL queries that enabling performance testing of OpenSearch's SQL plugin PPL functionality on log analytics data covering aggregations, filtering, sorting, and complex analytical operations.

### Issues Resolved
N/A - New feature addition

### Testing
☑️ New functionality includes testing

Tested workload execution with OpenSearch Benchmark in test-mode to verify:
* Index creation and data ingestion from Big5 dataset
* All 42 PPL operations execute successfully via raw-request to `/_plugins/_ppl` endpoint
* Proper parameter handling and test procedure execution (`--test-procedure=ppl`)
* PPL queries cover the same `Big 5` performance areas as existing operations: text querying, sorting, date histograms, range queries, and terms aggregations
Documentation updated with PPL prerequisites and usage instructions

#### Prerequisites
OpenSearch SQL Plugin must be installed and enabled for PPL operations to function

### Backport to Branches:
- [ ] 6
- [ ] 7
- [ ] 1
- [ ] 2
- [x] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
