### PR TITLE
Add gRPC big5 workload

### DIFF
--- a/big5/operations/grpc.json
+++ b/big5/operations/grpc.json
@@ -1,0 +1,31 @@
+    {
+      "name": "grpc-index-append",
+      "operation-type": "bulk",
+      "bulk-size": {{bulk_size | default(500)}},
+      "ingest-percentage": {{ingest_percentage | default(100)}}
+    },
+    {
+      "name": "grpc-match-all",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "query": {
+          "match_all": {}
+        }
+      }
+    },
+    {
+      "name": "grpc-term",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "request-timeout": 7200,
+      "body": {
+        "query": {
+          "term": {
+            "log.file.path": {
+              "value": "/var/log/messages/birdknight"
+            }
+          }
+        }
+      }
+    }

--- a/big5/test_procedures/default.json
+++ b/big5/test_procedures/default.json
@@ -9,6 +9,14 @@
   ]
 },
 {
+  "name": "grpc-big5",
+  "default": false,
+  "schedule": [
+    {% endwith %}
+    {{ benchmark.collect(parts="grpc/grpc-schedule.json") }}
+  ]
+},
+{
   "name": "test",
   "default": false,
   "schedule": [

--- a/big5/test_procedures/grpc/grpc-schedule.json
+++ b/big5/test_procedures/grpc/grpc-schedule.json
@@ -1,0 +1,71 @@
+{
+    "operation": "delete-index"
+},
+{
+    "operation": {
+        "operation-type": "create-index",
+        "settings": {{index_settings | default(default_index_settings | default({})) | tojson}}
+    }
+},
+{
+    "name": "check-cluster-health",
+    "operation": {
+        "operation-type": "cluster-health",
+        "index": "{{ index_name }}",
+        "request-params": {
+            "wait_for_status": "{{cluster_health | default('green')}}",
+            "wait_for_no_relocating_shards": "true"
+        },
+        "retry-until-success": true
+    }
+},
+{
+    "operation": "index-append",
+    "warmup-time-period": {{ warmup_time_period | default(120) | tojson }},
+    "clients": {{bulk_indexing_clients | default(8)}},
+    "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
+},
+{
+    "name": "refresh-after-index",
+    "operation": "refresh"
+},
+{
+    "operation": {
+        "operation-type": "force-merge",
+        "request-timeout": {{ request_timeout | default(60) | tojson }}{%- if max_num_segments is defined %},
+        "max-num-segments": {{ max_num_segments | tojson }}
+        {%- endif %}
+    }
+},
+{
+    "name": "refresh-after-force-merge",
+    "operation": "refresh"
+},
+{
+    "name": "wait-until-merges-finish",
+    "operation": {
+        "operation-type": "index-stats",
+        "index": "_all",
+        "condition": {
+            "path": "_all.total.merges.current",
+            "expected-value": 0
+        },
+        "retry-until-success": true,
+        "include-in-reporting": false
+    }
+},
+{
+  "operation": "grpc-match-all",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "name": "grpc-term",
+  "operation": "term",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+}


### PR DESCRIPTION
### Description
Adds a new grpc-big5 workload with limited support for big5 operations but instead performed over the gRPC transport.
Purpose of this workload is to provide a point of comparison to measure performance benefits of gRPC vs REST.

### Issues Resolved
N/A

### Testing
~~- [ ] New functionality includes testing~~

Manually tested with OSB

### Backport to Branches:
- [ ] 6
- [ ] 7
- [ ] 1
- [ ] 2
- [ ] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
