### PR TITLE
Adding tests for high cardinality numeric term aggregation

### DIFF
--- a/geonames/operations/default.json
+++ b/geonames/operations/default.json
@@ -438,4 +438,19 @@
           }
         }
       }
+    },
+    {
+      "name": "numeric-term-cardinality-agg-high",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "aggs": {
+          "geonameids": {
+            "terms": {
+              "field": "geonameid",
+              "size": 50000
+            }
+          }
+        }
+      }
     }

--- a/geonames/test_procedures/default.json
+++ b/geonames/test_procedures/default.json
@@ -181,6 +181,13 @@
           "iterations": {{ asc_sort_with_after_geonameid_iterations or iterations | default(100) | tojson }},
           "target-throughput": {{ asc_sort_with_after_geonameid_target_throughput or target_throughput | default(6) | tojson }},
           "clients": {{ asc_sort_with_after_geonameid_search_clients or search_clients | default(1) }}
+        },
+        {
+          "operation": "numeric-term-cardinality-agg-high",
+          "warmup-iterations": {{ numeric_term_cardinality_agg_high_warmup_iterations or warmup_iterations | default(200) | tojson }},
+          "iterations": {{ numeric_term_cardinality_agg_high_iterations or iterations | default(100) | tojson }},
+          "target-throughput": {{ numeric_term_cardinality_agg_high_target_throughput or target_throughput | default(2) | tojson }},
+          "clients": {{ numeric_term_cardinality_agg_high_search_clients or search_clients | default(1) }}
         }
       ]
     },


### PR DESCRIPTION
### Description
Adding a new test for High cardinality numeric term aggregation. This is added as part of new algorithmic changes we added to optimize numeric term aggression : https://github.com/opensearch-project/OpenSearch/pull/18702

### Issues Resolved
Resolves #18703

### Testing
- [ Yes ] New functionality includes testing

Tested by running this tests in local

eg:
```
opensearch-benchmark execute-test \
--pipeline=benchmark-only \
--workload=geonames \
--target-hosts=localhost:9200 --kill-running-processes \
--include-tasks "numeric-term-cardinality-agg-high" \
--telemetry=node-stats \
--user-tag="type:numeric-after"
```

### Backport to Branches:
- [ ] 6
- [ ] 7
- [ ] 1
- [ ] 2
- [ ] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
