### PR TITLE
Add date histogram with filter, and filter and metrics

### DIFF
--- a/http_logs/operations/default.json
+++ b/http_logs/operations/default.json
@@ -225,6 +225,53 @@
       }
     },
     {
+      "name": "hourly_agg_with_filter",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "query": {
+          "term": {
+            "status": 200
+          }
+        },
+        "size": 0,
+        "aggs": {
+          "by_hour": {
+            "date_histogram": {
+              "field": "@timestamp",
+              "calendar_interval": "hour"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "hourly_agg_with_filter_and_metrics",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "query": {
+          "term": {
+            "status": 200
+          }
+        },
+        "size": 0,
+        "aggs": {
+          "by_hour": {
+            "date_histogram": {
+              "field": "@timestamp",
+              "calendar_interval": "hour"
+            }
+          },
+          "size_stats": {
+            "stats": {
+              "field": "size"
+            }
+          }
+        }
+      }
+    },
+    {
       "name": "multi_term_agg",
       "operation-type": "search",
       "index": "logs-*",

--- a/http_logs/test_procedures/default.json
+++ b/http_logs/test_procedures/default.json
@@ -52,6 +52,20 @@
           "clients": {{ hourly_agg_search_clients or search_clients | default(1) }}
         },
         {
+          "operation": "hourly_agg_with_filter",
+          "warmup-iterations": {{ hourly_agg_with_filter_warmup_iterations or warmup_iterations | default(50) | tojson }},
+          "iterations": {{ hourly_agg_with_filter_iterations or iterations | default(100) | tojson }},
+          "target-throughput": {{ hourly_agg_with_filter_target_throughput or target_throughput | default(0.2) | tojson }},
+          "clients": {{ hourly_agg_with_filter_search_clients or search_clients | default(1) }}
+        },
+        {
+          "operation": "hourly_agg_with_filter_and_metrics",
+          "warmup-iterations": {{ hourly_agg_with_filter_and_metrics_warmup_iterations or warmup_iterations | default(50) | tojson }},
+          "iterations": {{ hourly_agg_with_filter_and_metrics_iterations or iterations | default(100) | tojson }},
+          "target-throughput": {{ hourly_agg_with_filter_and_metrics_target_throughput or target_throughput | default(0.2) | tojson }},
+          "clients": {{ hourly_agg_with_filter_and_metrics_search_clients or search_clients | default(1) }}
+        },
+        {
           "operation": "multi_term_agg",
           "warmup-iterations": {{ multi_term_agg_warmup_iterations or warmup_iterations | default(50) | tojson }},
           "iterations": {{ multi_term_agg_iterations or iterations | default(100) | tojson }},


### PR DESCRIPTION
### Description

* to test out skiplist based date histogram
* skiplist is enabled by default http_logs has @timestamp field: https://github.com/opensearch-project/OpenSearch/pull/19480
* TODO: add index.sort.field option on @timestamp


### Issues Resolved
Closes [https://github.com/opensearch-project/OpenSearch/issues/19123]

### Testing
- [x] New functionality includes testing

[Describe how this change was tested]

See

https://github.com/opensearch-project/OpenSearch/pull/19509#issuecomment-3378869054


### Backport to Branches:
- [ ] 6
- [ ] 7
- [ ] 1
- [ ] 2
- [x] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
