### PR TITLE
Manual backport - Big5 term has no hits

### DIFF
--- a/big5/operations/default.json
+++ b/big5/operations/default.json
@@ -23,7 +23,7 @@
         "query": {
           "term": {
             "log.file.path": {
-              "value": "/var/log/messages/fuschiashoulder"
+              "value": "/var/log/messages/birdknight"
             }
           }
         }
@@ -387,7 +387,7 @@
       "operation-type": "search",
       "request-timeout": 7200,
       "index": "{{index_name | default('big5')}}",
-      "body": 
+      "body":
         {
           "track_total_hits": false,
           "size": 0,

--- a/big5/queries/term.json
+++ b/big5/queries/term.json
@@ -2,7 +2,7 @@
   "query": {
     "term": {
       "log.file.path": {
-        "value": "/var/log/messages/fuschiashoulder"
+        "value": "/var/log/messages/birdknight"
       }
     }
   }


### PR DESCRIPTION
### Description
Manual backport:
https://github.com/opensearch-project/opensearch-benchmark-workloads/pull/420

### Issues Resolved
N/A

### Testing
~~- [] New functionality includes testing~~

[Describe how this change was tested]

### Backport to Branches:
- [ ] 6
- [ ] 7
- [x] 1
- [x] 2
- [ ] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
