### PR TITLE
Update big5 ppl queries (#708)

### DIFF
--- a/big5/operations/ppl.json
+++ b/big5/operations/ppl.json
@@ -1,0 +1,414 @@
+    {
+      "name": "ppl-default",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | head 10"
+      }
+    },
+    {
+      "name": "ppl-term",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `log.file.path` = '/var/log/messages/birdknight' | head 10"
+      }
+    },
+    {
+      "name": "ppl-range",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `@timestamp` >= '2023-01-01 00:00:00' and `@timestamp` < '2023-01-03 00:00:00' | head 10"
+      }
+    },
+    {
+      "name": "ppl-asc-sort-timestamp-can-match-shortcut",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} {% if distribution_version.split('.') | map('int') | list >= '3.3.0'.split('.') | map('int') | list %}process.name=kernel{% else %}match(`process.name`, 'kernel'){% endif %} | sort + `@timestamp` | head 10"
+      }
+    },
+    {
+      "name": "ppl-asc-sort-timestamp-no-can-match-shortcut",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} {% if distribution_version.split('.') | map('int') | list >= '3.3.0'.split('.') | map('int') | list %}process.name=kernel{% else %}match(`process.name`, 'kernel'){% endif %} | sort + `@timestamp` | head 10"
+      }
+    },
+    {
+      "name": "ppl-asc-sort-timestamp",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | sort + `@timestamp` | head 10"
+      }
+    },
+    {
+      "name": "ppl-asc-sort-with-after-timestamp",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | sort + `@timestamp` | head 10"
+      }
+    },
+    {
+      "name": "ppl-composite-date-histogram-daily",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `@timestamp` >= '2022-12-30 00:00:00' and `@timestamp` < '2023-01-07 12:00:00' | stats count() by span(`@timestamp`, 1d)"
+      }
+    },
+    {
+      "name": "ppl-composite-terms-keyword",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `@timestamp` >= '2023-01-02 00:00:00' and `@timestamp` < '2023-01-02 10:00:00' | stats {% if distribution_version.split('.') | map('int') | list >= '3.3.0'.split('.') | map('int') | list %}bucket_nullable = false {% endif %}count() by `process.name`, `cloud.region`, `aws.cloudwatch.log_stream` | sort - `process.name`, + `cloud.region`, + `aws.cloudwatch.log_stream` | head 10"
+      }
+    },
+    {
+      "name": "ppl-composite-terms",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `@timestamp` >= '2023-01-02 00:00:00' and `@timestamp` < '2023-01-02 10:00:00' | stats {% if distribution_version.split('.') | map('int') | list >= '3.3.0'.split('.') | map('int') | list %}bucket_nullable = false {% endif %}count() by `process.name`, `cloud.region` | sort - `process.name`, + `cloud.region` | head 10"
+      }
+    },
+    {
+      "name": "ppl-date-histogram-hourly-agg",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | stats count() by span(`@timestamp`, 1h)"
+      }
+    },
+    {
+      "name": "ppl-date-histogram-minute-agg",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `@timestamp` >= '2023-01-01 00:00:00' and `@timestamp` < '2023-01-03 00:00:00' | stats count() by span(`@timestamp`, 1m)"
+      }
+    },
+    {
+      "name": "ppl-desc-sort-timestamp-can-match-shortcut",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} {% if distribution_version.split('.') | map('int') | list >= '3.3.0'.split('.') | map('int') | list %}process.name=kernel{% else %}match(`process.name`, 'kernel'){% endif %} | sort - `@timestamp` | head 10"
+      }
+    },
+    {
+      "name": "ppl-desc-sort-timestamp-no-can-match-shortcut",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} {% if distribution_version.split('.') | map('int') | list >= '3.3.0'.split('.') | map('int') | list %}process.name=kernel{% else %}match(`process.name`, 'kernel'){% endif %} | sort - `@timestamp` | head 10"
+      }
+    },
+    {
+      "name": "ppl-desc-sort-timestamp",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | sort - `@timestamp` | head 10"
+      }
+    },
+    {
+      "name": "ppl-desc-sort-with-after-timestamp",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | sort - `@timestamp` | head 10"
+      }
+    },
+    {
+      "name": "ppl-keyword-in-range",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} {% if distribution_version.split('.') | map('int') | list >= '3.3.0'.split('.') | map('int') | list %}process.name=kernel{% else %}match(`process.name`, 'kernel'){% endif %} | where `@timestamp` >= '2023-01-01 00:00:00' and `@timestamp` < '2023-01-03 00:00:00' | head 10"
+      }
+    },
+    {
+      "name": "ppl-keyword-terms-low-cardinality",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | stats {% if distribution_version.split('.') | map('int') | list >= '3.3.0'.split('.') | map('int') | list %}bucket_nullable = false {% endif %}count() as country by `aws.cloudwatch.log_stream` | sort - country | head 50"
+      }
+    },
+    {
+      "name": "ppl-keyword-terms",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | stats {% if distribution_version.split('.') | map('int') | list >= '3.3.0'.split('.') | map('int') | list %}bucket_nullable = false {% endif %}count() as station by `aws.cloudwatch.log_stream` | sort - station | head 500"
+      }
+    },
+    {
+      "name": "ppl-multi-terms-keyword",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `@timestamp` >= '2023-01-05 00:00:00' and `@timestamp` < '2023-01-05 05:00:00' | stats {% if distribution_version.split('.') | map('int') | list >= '3.3.0'.split('.') | map('int') | list %}bucket_nullable = false {% endif %}count() by `process.name`, `cloud.region` | sort - `count()` | head 10"
+      }
+    },
+    {
+      "name": "ppl-query-string-on-message-filtered-sorted-num",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where query_string(['message'], 'monkey jackal bear') and `@timestamp` >= '2023-01-03 00:00:00' and `@timestamp` < '2023-01-03 10:00:00' | sort + `@timestamp` | head 10"
+      }
+    },
+    {
+      "name": "ppl-query-string-on-message-filtered",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where query_string(['message'], 'monkey jackal bear') and `@timestamp` >= '2023-01-03 00:00:00' and `@timestamp` < '2023-01-03 10:00:00' | head 10"
+      }
+    },
+    {
+      "name": "ppl-query-string-on-message",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} {% if distribution_version.split('.') | map('int') | list >= '3.3.0'.split('.') | map('int') | list %}| where query_string(['message'], 'monkey jackal bear'){% else %}query_string(['message'], 'monkey jackal bear'){% endif %} | head 10"
+      }
+    },
+    {
+      "name": "ppl-range-auto-date-histo-with-metrics",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | eval range_bucket = case(`metrics.size` < -10, 'range_1', `metrics.size` >= -10 and `metrics.size` < 10, 'range_2', `metrics.size` >= 10 and `metrics.size` < 100, 'range_3', `metrics.size` >= 100 and `metrics.size` < 1000, 'range_4', `metrics.size` >= 1000 and `metrics.size` < 2000, 'range_5', `metrics.size` >= 2000, 'range_6') | {% if distribution_version.split('.') | map('int') | list >= '3.4.0'.split('.') | map('int') | list %}bin `@timestamp` bins=10 | stats min(`metrics.tmin`) as tmin, avg(`metrics.size`) as tavg, max(`metrics.size`) as tmax by range_bucket, `@timestamp`{% else %}stats min(`metrics.tmin`) as tmin, avg(`metrics.size`) as tavg, max(`metrics.size`) as tmax by range_bucket, span(`@timestamp`, 1h) as auto_span | sort + range_bucket, + auto_span{% endif %}"
+      }
+    },
+    {
+      "name": "ppl-range-auto-date-histo",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | eval range_bucket = case(`metrics.size` < -10, 'range_1', `metrics.size` >= -10 and `metrics.size` < 10, 'range_2', `metrics.size` >= 10 and `metrics.size` < 100, 'range_3', `metrics.size` >= 100 and `metrics.size` < 1000, 'range_4', `metrics.size` >= 1000 and `metrics.size` < 2000, 'range_5', `metrics.size` >= 2000, 'range_6') | {% if distribution_version.split('.') | map('int') | list >= '3.4.0'.split('.') | map('int') | list %}bin `@timestamp` bins=20 | stats count() by range_bucket, `@timestamp`{% else %}stats count() by range_bucket, span(`@timestamp`, 1h) as auto_span | sort + range_bucket, + auto_span{% endif %}"
+      }
+    },
+    {
+      "name": "ppl-cardinality-agg-high",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | stats {% if distribution_version.split('.') | map('int') | list >= '3.3.0'.split('.') | map('int') | list %}bucket_nullable = false {% endif %}dc(`agent.name`)"
+      }
+    },
+    {
+      "name": "ppl-cardinality-agg-high-2",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | stats {% if distribution_version.split('.') | map('int') | list >= '3.3.0'.split('.') | map('int') | list %}bucket_nullable = false {% endif %}dc(`event.id`)"
+      }
+    },
+    {
+      "name": "ppl-cardinality-agg-low",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | stats {% if distribution_version.split('.') | map('int') | list >= '3.3.0'.split('.') | map('int') | list %}bucket_nullable = false {% endif %}dc(`cloud.region`)"
+      }
+    },
+    {
+      "name": "ppl-range-agg-1",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | eval range_bucket = case(`metrics.size` < -10, 'range_1', `metrics.size` >= -10 and `metrics.size` < 10, 'range_2', `metrics.size` >= 10 and `metrics.size` < 100, 'range_3', `metrics.size` >= 100 and `metrics.size` < 1000, 'range_4', `metrics.size` >= 1000 and `metrics.size` < 2000, 'range_5', `metrics.size` >= 2000, 'range_6') | stats count() by range_bucket"
+      }
+    },
+    {
+      "name": "ppl-range-agg-2",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | eval range_bucket = case(`metrics.size` < 100, 'range_1', `metrics.size` >= 100 and `metrics.size` < 1000, 'range_2', `metrics.size` >= 1000 and `metrics.size` < 2000, 'range_3', `metrics.size` >= 2000, 'range_4') | stats count() by range_bucket"
+      }
+    },
+    {
+      "name": "ppl-range-field-conjunction-big-range-big-term-query",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `process.name` = 'systemd' and `metrics.size` >= 1 and `metrics.size` <= 100 | head 10"
+      }
+    },
+    {
+      "name": "ppl-range-field-conjunction-small-range-big-term-query",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `metrics.size` >= 20 and `metrics.size` <= 30 | head 10"
+      }
+    },
+    {
+      "name": "ppl-range-field-conjunction-small-range-small-term-query",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `aws.cloudwatch.log_stream` = 'indigodagger' or (`metrics.size` >= 10 and `metrics.size` <= 20) | head 10"
+      }
+    },
+    {
+      "name": "ppl-range-field-disjunction-big-range-small-term-query",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `aws.cloudwatch.log_stream` = 'indigodagger' or (`metrics.size` >= 1 and `metrics.size` <= 100) | head 10"
+      }
+    },
+    {
+      "name": "ppl-range-numeric",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `metrics.size` >= 20 and `metrics.size` <= 200 | head 10"
+      }
+    },
+    {
+      "name": "ppl-range-with-asc-sort",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `@timestamp` >= '2023-01-01 00:00:00' and `@timestamp` <= '2023-01-13 00:00:00' | sort + `@timestamp` | head 10"
+      }
+    },
+    {
+      "name": "ppl-range-with-desc-sort",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `@timestamp` >= '2023-01-01 00:00:00' and `@timestamp` <= '2023-01-13 00:00:00' | sort - `@timestamp` | head 10"
+      }
+    },
+    {
+      "name": "ppl-scroll",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | head 10"
+      }
+    },
+    {
+      "name": "ppl-sort-keyword-can-match-shortcut",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} {% if distribution_version.split('.') | map('int') | list >= '3.3.0'.split('.') | map('int') | list %}process.name=kernel{% else %}match(`process.name`, 'kernel'){% endif %} | sort + `meta.file` | head 10"
+      }
+    },
+    {
+      "name": "ppl-sort-keyword-no-can-match-shortcut",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} {% if distribution_version.split('.') | map('int') | list >= '3.3.0'.split('.') | map('int') | list %}process.name=kernel{% else %}match(`process.name`, 'kernel'){% endif %} | sort + `meta.file` | head 10"
+      }
+    },
+    {
+      "name": "ppl-sort-numeric-asc-with-match",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} {% if distribution_version.split('.') | map('int') | list >= '3.3.0'.split('.') | map('int') | list %}log.file.path=\"/var/log/messages/solarshark\"{% else %}match(`log.file.path`, '/var/log/messages/solarshark'){% endif %} | sort + `metrics.size` | head 10"
+      }
+    },
+    {
+      "name": "ppl-sort-numeric-asc",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | sort + `metrics.size` | head 10"
+      }
+    },
+    {
+      "name": "ppl-sort-numeric-desc-with-match",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} {% if distribution_version.split('.') | map('int') | list >= '3.3.0'.split('.') | map('int') | list %}log.file.path=\"/var/log/messages/solarshark\"{% else %}match(`log.file.path`, '/var/log/messages/solarshark'){% endif %} | sort - `metrics.size` | head 10"
+      }
+    },
+    {
+      "name": "ppl-sort-numeric-desc",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | sort - `metrics.size` | head 10"
+      }
+    },
+    {
+      "name": "ppl-terms-significant-1",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `@timestamp` >= '2023-01-01 00:00:00' and `@timestamp` < '2023-01-03 00:00:00' | stats count() by `aws.cloudwatch.log_stream`, `process.name` | head 10"
+      }
+    },
+    {
+      "name": "ppl-terms-significant-2",
+      "operation-type": "raw-request",
+      "path": "/_plugins/_ppl",
+      "method": "POST",
+      "body": {
+        "query": "source = {{index_name | default('big5')}} | where `@timestamp` >= '2023-01-01 00:00:00' and `@timestamp` < '2023-01-03 00:00:00' | stats count() by `process.name`, `aws.cloudwatch.log_stream` | head 10"
+      }
+    }

--- a/big5/queries/ppl/cardinality_agg_high.ppl
+++ b/big5/queries/ppl/cardinality_agg_high.ppl
@@ -1,0 +1,22 @@
+/*
+{
+  "name": "cardinality-agg-high",
+  "operation-type": "search",
+  "index": "{{index_name | default('big5')}}",
+  "body": {
+    "size": 0,
+    "aggs": {
+      "agent": {
+        "cardinality": {
+         "field": "agent.name"
+          {% if distribution_version.split('.') | map('int') | list  >= "2.19.1".split('.') | map('int') | list and distribution_version.split('.') | map('int') | list  < "6.0.0".split('.') | map('int') | list %}
+            , "execution_hint": "ordinals"
+          {% endif %}
+        }
+      }
+    }
+  }
+}
+*/
+source = big5
+| stats dc(`agent.name`)

--- a/big5/queries/ppl/cardinality_agg_high_2.ppl
+++ b/big5/queries/ppl/cardinality_agg_high_2.ppl
@@ -1,0 +1,21 @@
+/*
+{
+  "name": "cardinality-agg-high-2",
+  "operation-type": "search",
+  "index": "{{index_name | default('big5')}}",
+  "request-timeout": 1800,
+  "body": {
+    "size": 0,
+    "aggs": {
+      "agent": {
+        "cardinality": {
+         "field": "event.id",
+         "execution_hint":"ordinals"
+        }
+      }
+    }
+  }
+}
+*/
+source = big5
+| stats dc(`event.id`)

--- a/big5/queries/ppl/cardinality_agg_low.ppl
+++ b/big5/queries/ppl/cardinality_agg_low.ppl
@@ -1,0 +1,19 @@
+/*
+{
+  "name": "cardinality-agg-low",
+  "operation-type": "search",
+  "index": "{{index_name | default('big5')}}",
+  "body": {
+    "size": 0,
+    "aggs": {
+      "region": {
+        "cardinality": {
+          "field": "cloud.region"
+        }
+      }
+    }
+  }
+}
+*/
+source = big5
+| stats dc(`cloud.region`)

--- a/big5/queries/ppl/range_agg_1.ppl
+++ b/big5/queries/ppl/range_agg_1.ppl
@@ -1,0 +1,50 @@
+/*
+{
+  "name": "range-agg-1",
+  "operation-type": "search",
+  "index": "{{index_name | default('big5')}}",
+  "body": {
+    "size": 0,
+    "aggs": {
+      "tmax": {
+        "range": {
+          "field": "metrics.size",
+          "ranges": [
+            {
+              "to": -10
+            },
+            {
+              "from": -10,
+              "to": 10
+            },
+            {
+              "from": 10,
+              "to": 100
+            },
+            {
+              "from": 100,
+              "to": 1000
+            },
+            {
+              "from": 1000,
+              "to": 2000
+            },
+            {
+              "from": 2000
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+*/
+source = big5
+| eval range_bucket = case(
+   `metrics.size` < -10, 'range_1',
+   `metrics.size` >= -10 and `metrics.size` < 10, 'range_2',
+   `metrics.size` >= 10 and `metrics.size` < 100, 'range_3',
+   `metrics.size` >= 100 and `metrics.size` < 1000, 'range_4',
+   `metrics.size` >= 1000 and `metrics.size` < 2000, 'range_5',
+   `metrics.size` >= 2000, 'range_6')
+| stats count() by range_bucket

--- a/big5/queries/ppl/range_agg_2.ppl
+++ b/big5/queries/ppl/range_agg_2.ppl
@@ -1,0 +1,40 @@
+/*
+{
+  "name": "range-agg-2",
+  "operation-type": "search",
+  "index": "{{index_name | default('big5')}}",
+  "body": {
+    "size": 0,
+    "aggs": {
+      "tmax": {
+        "range": {
+          "field": "metrics.size",
+          "ranges": [
+            {
+              "to": 100
+            },
+            {
+              "from": 100,
+              "to": 1000
+            },
+            {
+              "from": 1000,
+              "to": 2000
+            },
+            {
+              "from": 2000
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+*/
+source = big5
+| eval range_bucket = case(
+   `metrics.size` < 100, 'range_1',
+   `metrics.size` >= 100 and `metrics.size` < 1000, 'range_2',
+   `metrics.size` >= 1000 and `metrics.size` < 2000, 'range_3',
+   `metrics.size` >= 2000, 'range_4')
+| stats count() by range_bucket

--- a/big5/test_procedures/ppl/ppl-schedule.json
+++ b/big5/test_procedures/ppl/ppl-schedule.json
@@ -1,0 +1,322 @@
+{
+  "operation": "ppl-default",
+  "warmup-iterations": {{ ppl_default_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_default_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_default_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_default_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-term",
+  "warmup-iterations": {{ ppl_term_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_term_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_term_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_term_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-range",
+  "warmup-iterations": {{ ppl_range_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_range_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_range_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_range_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-asc-sort-timestamp-can-match-shortcut",
+  "warmup-iterations": {{ ppl_asc_sort_timestamp_can_match_shortcut_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_asc_sort_timestamp_can_match_shortcut_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_asc_sort_timestamp_can_match_shortcut_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_asc_sort_timestamp_can_match_shortcut_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-asc-sort-timestamp-no-can-match-shortcut",
+  "warmup-iterations": {{ ppl_asc_sort_timestamp_no_can_match_shortcut_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_asc_sort_timestamp_no_can_match_shortcut_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_asc_sort_timestamp_no_can_match_shortcut_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_asc_sort_timestamp_no_can_match_shortcut_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-asc-sort-timestamp",
+  "warmup-iterations": {{ ppl_asc_sort_timestamp_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_asc_sort_timestamp_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_asc_sort_timestamp_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_asc_sort_timestamp_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-asc-sort-with-after-timestamp",
+  "warmup-iterations": {{ ppl_asc_sort_with_after_timestamp_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_asc_sort_with_after_timestamp_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_asc_sort_with_after_timestamp_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_asc_sort_with_after_timestamp_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-composite-date-histogram-daily",
+  "warmup-iterations": {{ ppl_composite_date_histogram_daily_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_composite_date_histogram_daily_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_composite_date_histogram_daily_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_composite_date_histogram_daily_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-composite-terms-keyword",
+  "warmup-iterations": {{ ppl_composite_terms_keyword_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_composite_terms_keyword_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_composite_terms_keyword_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_composite_terms_keyword_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-composite-terms",
+  "warmup-iterations": {{ ppl_composite_terms_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_composite_terms_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_composite_terms_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_composite_terms_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-date-histogram-hourly-agg",
+  "warmup-iterations": {{ ppl_date_histogram_hourly_agg_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_date_histogram_hourly_agg_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_date_histogram_hourly_agg_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_date_histogram_hourly_agg_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-date-histogram-minute-agg",
+  "warmup-iterations": {{ ppl_date_histogram_minute_agg_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_date_histogram_minute_agg_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_date_histogram_minute_agg_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_date_histogram_minute_agg_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-desc-sort-timestamp-can-match-shortcut",
+  "warmup-iterations": {{ ppl_desc_sort_timestamp_can_match_shortcut_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_desc_sort_timestamp_can_match_shortcut_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_desc_sort_timestamp_can_match_shortcut_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_desc_sort_timestamp_can_match_shortcut_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-desc-sort-timestamp-no-can-match-shortcut",
+  "warmup-iterations": {{ ppl_desc_sort_timestamp_no_can_match_shortcut_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_desc_sort_timestamp_no_can_match_shortcut_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_desc_sort_timestamp_no_can_match_shortcut_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_desc_sort_timestamp_no_can_match_shortcut_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-desc-sort-timestamp",
+  "warmup-iterations": {{ ppl_desc_sort_timestamp_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_desc_sort_timestamp_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_desc_sort_timestamp_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_desc_sort_timestamp_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-desc-sort-with-after-timestamp",
+  "warmup-iterations": {{ ppl_desc_sort_with_after_timestamp_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_desc_sort_with_after_timestamp_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_desc_sort_with_after_timestamp_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_desc_sort_with_after_timestamp_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-keyword-in-range",
+  "warmup-iterations": {{ ppl_keyword_in_range_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_keyword_in_range_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_keyword_in_range_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_keyword_in_range_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-keyword-terms-low-cardinality",
+  "warmup-iterations": {{ ppl_keyword_terms_low_cardinality_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_keyword_terms_low_cardinality_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_keyword_terms_low_cardinality_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_keyword_terms_low_cardinality_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-keyword-terms",
+  "warmup-iterations": {{ ppl_keyword_terms_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_keyword_terms_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_keyword_terms_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_keyword_terms_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-multi-terms-keyword",
+  "warmup-iterations": {{ ppl_multi_terms_keyword_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_multi_terms_keyword_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_multi_terms_keyword_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_multi_terms_keyword_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-query-string-on-message-filtered-sorted-num",
+  "warmup-iterations": {{ ppl_query_string_on_message_filtered_sorted_num_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_query_string_on_message_filtered_sorted_num_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_query_string_on_message_filtered_sorted_num_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_query_string_on_message_filtered_sorted_num_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-query-string-on-message-filtered",
+  "warmup-iterations": {{ ppl_query_string_on_message_filtered_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_query_string_on_message_filtered_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_query_string_on_message_filtered_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_query_string_on_message_filtered_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-query-string-on-message",
+  "warmup-iterations": {{ ppl_query_string_on_message_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_query_string_on_message_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_query_string_on_message_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_query_string_on_message_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-range-auto-date-histo-with-metrics",
+  "warmup-iterations": {{ ppl_range_auto_date_histo_with_metrics_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_range_auto_date_histo_with_metrics_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_range_auto_date_histo_with_metrics_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_range_auto_date_histo_with_metrics_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-range-auto-date-histo",
+  "warmup-iterations": {{ ppl_range_auto_date_histo_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_range_auto_date_histo_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_range_auto_date_histo_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_range_auto_date_histo_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-cardinality-agg-high",
+  "warmup-iterations": {{ ppl_cardinality_agg_high_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_cardinality_agg_high_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_cardinality_agg_high_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_cardinality_agg_high_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-cardinality-agg-high-2",
+  "warmup-iterations": {{ ppl_cardinality_agg_high_2_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_cardinality_agg_high_2_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_cardinality_agg_high_2_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_cardinality_agg_high_2_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-cardinality-agg-low",
+  "warmup-iterations": {{ ppl_cardinality_agg_low_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_cardinality_agg_low_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_cardinality_agg_low_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_cardinality_agg_low_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-range-agg-1",
+  "warmup-iterations": {{ ppl_range_agg_1_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_range_agg_1_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_range_agg_1_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_range_agg_1_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-range-agg-2",
+  "warmup-iterations": {{ ppl_range_agg_2_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_range_agg_2_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_range_agg_2_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_range_agg_2_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-range-field-conjunction-big-range-big-term-query",
+  "warmup-iterations": {{ ppl_range_field_conjunction_big_range_big_term_query_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_range_field_conjunction_big_range_big_term_query_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_range_field_conjunction_big_range_big_term_query_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_range_field_conjunction_big_range_big_term_query_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-range-field-conjunction-small-range-big-term-query",
+  "warmup-iterations": {{ ppl_range_field_conjunction_small_range_big_term_query_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_range_field_conjunction_small_range_big_term_query_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_range_field_conjunction_small_range_big_term_query_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_range_field_conjunction_small_range_big_term_query_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-range-field-conjunction-small-range-small-term-query",
+  "warmup-iterations": {{ ppl_range_field_conjunction_small_range_small_term_query_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_range_field_conjunction_small_range_small_term_query_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_range_field_conjunction_small_range_small_term_query_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_range_field_conjunction_small_range_small_term_query_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-range-field-disjunction-big-range-small-term-query",
+  "warmup-iterations": {{ ppl_range_field_disjunction_big_range_small_term_query_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_range_field_disjunction_big_range_small_term_query_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_range_field_disjunction_big_range_small_term_query_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_range_field_disjunction_big_range_small_term_query_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-range-numeric",
+  "warmup-iterations": {{ ppl_range_numeric_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_range_numeric_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_range_numeric_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_range_numeric_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-range-with-asc-sort",
+  "warmup-iterations": {{ ppl_range_with_asc_sort_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_range_with_asc_sort_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_range_with_asc_sort_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_range_with_asc_sort_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-range-with-desc-sort",
+  "warmup-iterations": {{ ppl_range_with_desc_sort_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_range_with_desc_sort_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_range_with_desc_sort_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_range_with_desc_sort_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-scroll",
+  "warmup-iterations": {{ ppl_scroll_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_scroll_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_scroll_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_scroll_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-sort-keyword-can-match-shortcut",
+  "warmup-iterations": {{ ppl_sort_keyword_can_match_shortcut_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_sort_keyword_can_match_shortcut_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_sort_keyword_can_match_shortcut_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_sort_keyword_can_match_shortcut_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-sort-keyword-no-can-match-shortcut",
+  "warmup-iterations": {{ ppl_sort_keyword_no_can_match_shortcut_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_sort_keyword_no_can_match_shortcut_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_sort_keyword_no_can_match_shortcut_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_sort_keyword_no_can_match_shortcut_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-sort-numeric-asc-with-match",
+  "warmup-iterations": {{ ppl_sort_numeric_asc_with_match_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_sort_numeric_asc_with_match_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_sort_numeric_asc_with_match_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_sort_numeric_asc_with_match_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-sort-numeric-asc",
+  "warmup-iterations": {{ ppl_sort_numeric_asc_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_sort_numeric_asc_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_sort_numeric_asc_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_sort_numeric_asc_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-sort-numeric-desc-with-match",
+  "warmup-iterations": {{ ppl_sort_numeric_desc_with_match_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_sort_numeric_desc_with_match_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_sort_numeric_desc_with_match_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_sort_numeric_desc_with_match_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-sort-numeric-desc",
+  "warmup-iterations": {{ ppl_sort_numeric_desc_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_sort_numeric_desc_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_sort_numeric_desc_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_sort_numeric_desc_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-terms-significant-1",
+  "warmup-iterations": {{ ppl_terms_significant_1_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_terms_significant_1_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_terms_significant_1_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_terms_significant_1_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-terms-significant-2",
+  "warmup-iterations": {{ ppl_terms_significant_2_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_terms_significant_2_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_terms_significant_2_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_terms_significant_2_clients or search_clients | default(1) }}
+}


### PR DESCRIPTION
* Update big5 ppl queries



* Fix json lint on s0



* Update match() and query_string() for 3.3.0 above



* Update bin on timestamp only support on 3.4.0



* Revised on Lantao's comments



---------


(cherry picked from commit ea2c75e92f68f0a8caf72233c89c442bd7d50028)

### Description
[Describe what this change achieves]

### Issues Resolved
[List any issues this PR will resolve]

### Testing
- [ ] New functionality includes testing

[Describe how this change was tested]

### Backport to Branches:
- [ ] 6
- [ ] 7
- [ ] 1
- [ ] 2
- [ ] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
