### PR TITLE
New Queries to test intra segment search

### DIFF
--- a/big5/operations/intra-segment.json
+++ b/big5/operations/intra-segment.json
@@ -1,0 +1,543 @@
+    {
+      "name": "intra-metrics-agg",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "size": 0,
+        "track_total_hits": false,
+        "aggs": {
+          "tsum": { "sum": { "field": "metrics.size" } },
+          "tmin": { "min": { "field": "metrics.tmin" } },
+          "tavg": { "avg": { "field": "metrics.size" } },
+          "tmax": { "max": { "field": "metrics.size" } },
+          "tstats": { "stats": { "field": "metrics.size" } }
+        }
+      }
+    },
+    {
+      "name": "intra-bool-must-double-phrase",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "query": {
+          "bool": {
+            "must": [
+              { "match_phrase": { "message": "monkey monkey" } },
+              { "match_phrase": { "message": "jackal" } }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-span-near-query",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "track_total_hits": false,
+        "query": {
+          "span_near": {
+            "clauses": [
+              { "span_term": { "message": "monkey" } },
+              { "span_term": { "message": "jackal" } }
+            ],
+            "slop": 10,
+            "in_order": false
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-intervals-ordered-message",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "track_total_hits": false,
+        "query": {
+          "intervals": {
+            "message": {
+              "all_of": {
+                "ordered": true,
+                "intervals": [
+                  { "match": { "query": "monkey" } },
+                  { "match": { "query": "rabbit" } }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-bool-must-match-message",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "track_total_hits": false,
+        "query": {
+          "bool": {
+            "must": [
+              { "match": { "message": "monkey" } },
+              { "match": { "message": "rabbit" } }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-bool-should-match-med",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "track_total_hits": false,
+        "query": {
+          "bool": {
+            "should": [
+              { "match": { "message": "monkey" } },
+              { "match": { "message": "spirit" } }
+            ],
+            "minimum_should_match": 1
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-bool-must-term-keyword",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "track_total_hits": false,
+        "query": {
+          "bool": {
+            "must": [
+              { "term": { "message": "monkey" } },
+              { "term": { "message": "spirit" } }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-query-string-on-message",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "query": {
+          "query_string": {
+            "query": "message: monkey jackal bear"
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-metrics-stats-agg",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "aggs": {
+          "metrics_stats": {
+            "stats": {
+              "field": "metrics.size"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-sum-agg-with-total-hits",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "track_total_hits": true,
+        "aggs": {
+          "tsum": {
+            "sum": {
+              "field": "metrics.size"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-percentiles-agg",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "size": 0,
+        "aggs": {
+          "size_percentiles": {
+            "percentiles": {
+              "field": "metrics.size"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-extended-stats-agg",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "track_total_hits": true,
+        "aggs": {
+          "size_extended": {
+            "extended_stats": {
+              "field": "metrics.size"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-value-count-agg",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "size": 0,
+        "track_total_hits": false,
+        "aggs": {
+          "count_values": {
+            "value_count": {
+              "field": "metrics.size"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-percentile-ranks-agg",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "size": 0,
+        "track_total_hits": false,
+        "aggs": {
+          "size_ranks": {
+            "percentile_ranks": {
+              "field": "metrics.size",
+              "values": [100, 500, 1000]
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-matrix-stats-agg",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "track_total_hits": true,
+        "aggs": {
+          "matrix": {
+            "matrix_stats": {
+              "fields": ["metrics.size", "metrics.tmin"]
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-terms-top-hits-agg",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "size": 0,
+        "track_total_hits": false,
+        "aggs": {
+          "by_region": {
+            "terms": {
+              "field": "cloud.region",
+              "size": 5
+            },
+            "aggs": {
+              "top_docs": {
+                "top_hits": {
+                  "size": 3
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-significant-terms-agg",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "size": 0,
+        "query": {
+          "match": {
+            "cloud.region": "us-east-1"
+          }
+        },
+        "aggs": {
+          "significant_hosts": {
+            "significant_terms": {
+              "field": "host.name",
+              "size": 10
+            },
+            "aggs": {
+              "avg_size": {
+                "avg": {
+                  "field": "metrics.size"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-terms-stats-agg",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "size": 0,
+        "track_total_hits": false,
+        "aggs": {
+          "by_region": {
+            "terms": {
+              "field": "cloud.region",
+              "size": 5
+            },
+            "aggs": {
+              "size_stats": {
+                "stats": {
+                  "field": "metrics.size"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-multi-terms-agg",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "size": 0,
+        "track_total_hits": false,
+        "aggs": {
+          "a": {
+            "multi_terms": {
+              "terms": [
+                { "field": "process.name" },
+                { "field": "cloud.region" }
+              ],
+              "size": 10
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-histogram-agg",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "size": 0,
+        "track_total_hits": false,
+        "aggs": {
+          "a": {
+            "histogram": {
+              "field": "metrics.size",
+              "interval": 100
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-filter-agg",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "size": 0,
+        "track_total_hits": false,
+        "aggs": {
+          "a": {
+            "filter": {
+              "term": { "cloud.region": "us-east-1" }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-filters-agg",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "size": 0,
+        "track_total_hits": false,
+        "aggs": {
+          "a": {
+            "filters": {
+              "filters": {
+                "east": { "term": { "cloud.region": "us-east-1" } },
+                "west": { "term": { "cloud.region": "us-west-2" } }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-adjacency-matrix-agg",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "size": 0,
+        "track_total_hits": false,
+        "aggs": {
+          "a": {
+            "adjacency_matrix": {
+              "filters": {
+                "east": { "term": { "cloud.region": "us-east-1" } },
+                "west": { "term": { "cloud.region": "us-west-2" } },
+                "kernel": { "term": { "process.name": "kernel" } }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-global-agg-with-query",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "query": {
+          "match": { "message": "monkey" }
+        },
+        "aggs": {
+          "filtered_avg": {
+            "avg": { "field": "metrics.size" }
+          },
+          "all_docs": {
+            "global": {},
+            "aggs": {
+              "total_avg": {
+                "avg": { "field": "metrics.size" }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-global-agg",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "size": 0,
+        "aggs": {
+          "all_docs": {
+            "global": {},
+            "aggs": {
+              "total_avg": {
+                "avg": { "field": "metrics.size" }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-post-filter-agg",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "size": 0,
+        "track_total_hits": true,
+        "query": {
+          "bool": {
+            "must": [
+              { "match": { "message": "monkey" } }
+            ]
+          }
+        },
+        "post_filter": {
+          "term": {
+            "cloud.region": "us-east-1"
+          }
+        },
+        "aggs": {
+          "by_region": {
+            "terms": {
+              "field": "cloud.region",
+              "size": 5
+            },
+            "aggs": {
+              "avg_size": {
+                "avg": {
+                  "field": "metrics.size"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-min-score-agg",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "min_score": 0.5,
+        "query": {
+          "bool": {
+            "must": [
+              { "match": { "message": "monkey" } }
+            ]
+          }
+        },
+        "aggs": {
+          "avg_size": {
+            "avg": {
+              "field": "metrics.size"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-search-after-agg",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "size": 3,
+        "sort": [{ "metrics.size": "desc" }],
+        "search_after": [9999],
+        "query": {
+          "bool": {
+            "must": [{ "match": { "message": "monkey" } }]
+          }
+        },
+        "aggs": {
+          "avg_size": { "avg": { "field": "metrics.size" } }
+        }
+      }
+    },
+    {
+      "name": "intra-span-near-agg",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "query": {
+          "span_near": {
+            "clauses": [
+              { "span_term": { "message": "monkey" } },
+              { "span_term": { "message": "jackal" } }
+            ],
+            "slop": 10,
+            "in_order": false
+          }
+        },
+        "aggs": {
+          "avg_size": { "avg": { "field": "metrics.size" } }
+        }
+      }
+    }

--- a/big5/test_procedures/intra_segment/intra-segment-schedule.json
+++ b/big5/test_procedures/intra_segment/intra-segment-schedule.json
@@ -1,0 +1,210 @@
+    {
+      "operation": "intra-metrics-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-bool-must-double-phrase",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-span-near-query",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-intervals-ordered-message",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-bool-must-match-message",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-bool-should-match-med",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-bool-must-term-keyword",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-query-string-on-message",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-metrics-stats-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-sum-agg-with-total-hits",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-percentiles-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-extended-stats-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-value-count-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-percentile-ranks-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-matrix-stats-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-terms-top-hits-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-cardinality-agg-high",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-significant-terms-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-terms-stats-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-multi-terms-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-histogram-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-filter-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-filters-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-adjacency-matrix-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-global-agg-with-query",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-global-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-post-filter-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-min-score-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-search-after-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-span-near-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    }

--- a/http_logs/operations/intra-segment.json
+++ b/http_logs/operations/intra-segment.json
@@ -1,0 +1,445 @@
+    {
+      "name": "intra-cardinality-agg",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "size": 0,
+        "track_total_hits": false,
+        "aggs": {
+          "unique_clients": {
+            "cardinality": {
+              "field": "clientip"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-cardinality-agg-with-total-hits",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "track_total_hits": true,
+        "aggs": {
+          "unique_clients": {
+            "cardinality": {
+              "field": "clientip"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-multi-cardinality-agg",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "size": 0,
+        "aggs": {
+          "clientip_cardinality": { "cardinality": { "field": "clientip" } },
+          "status_cardinality": { "cardinality": { "field": "status" } },
+          "size_cardinality": { "cardinality": { "field": "size" } }
+        }
+      }
+    },
+    {
+      "name": "intra-span-near-query",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "track_total_hits": true,
+        "query": {
+          "span_near": {
+            "clauses": [
+              { "span_term": { "request": "images" } },
+              { "span_term": { "request": "french" } }
+            ],
+            "slop": 10,
+            "in_order": false
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-intervals-ordered-query",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "track_total_hits": true,
+        "query": {
+          "intervals": {
+            "request": {
+              "all_of": {
+                "ordered": true,
+                "intervals": [
+                  { "match": { "query": "french" } },
+                  { "match": { "query": "images" } }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-bool-must-double-phrase",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "track_total_hits": true,
+        "query": {
+          "bool": {
+            "must": [
+              { "match_phrase": { "request": "french images" } },
+              { "match_phrase": { "request": "HTTP" } }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-bool-must-match",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "track_total_hits": true,
+        "query": {
+          "bool": {
+            "must": [
+              { "match": { "request": "french" } },
+              { "match": { "request": "images" } }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-bool-should-match",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "track_total_hits": false,
+        "query": {
+          "bool": {
+            "should": [
+              { "match": { "clientip": "129.0.0.0" } },
+              { "match": { "clientip": "10.0.0.1" } }
+            ],
+            "minimum_should_match": 1
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-query-string",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "query": {
+          "query_string": {
+            "query": "request: french images GET"
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-stats-agg",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "aggs": {
+          "size_stats": {
+            "stats": { "field": "size" }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-sum-agg",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "aggs": {
+          "size_stats": {
+            "sum": { "field": "size" }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-percentiles-agg",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "track_total_hits": true,
+        "aggs": {
+          "size_percentiles": {
+            "percentiles": { "field": "size" }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-extended-stats-agg",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "track_total_hits": false,
+        "aggs": {
+          "size_extended": {
+            "extended_stats": { "field": "size" }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-multi-metrics-agg",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "track_total_hits": false,
+        "aggs": {
+          "tsum": { "sum": { "field": "size" } },
+          "tmin": { "min": { "field": "size" } },
+          "tavg": { "avg": { "field": "size" } },
+          "tmax": { "max": { "field": "size" } },
+          "tstats": { "stats": { "field": "size" } }
+        }
+      }
+    },
+    {
+      "name": "intra-value-count-agg",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "track_total_hits": true,
+        "aggs": {
+          "count_values": {
+            "value_count": { "field": "size" }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-percentile-ranks-agg",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "track_total_hits": true,
+        "aggs": {
+          "size_ranks": {
+            "percentile_ranks": {
+              "field": "size",
+              "values": [100, 500, 1000]
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-matrix-stats-agg",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "track_total_hits": true,
+        "aggs": {
+          "matrix": {
+            "matrix_stats": {
+              "fields": ["size", "status"]
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-terms-top-hits-agg",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "track_total_hits": true,
+        "aggs": {
+          "by_status": {
+            "terms": { "field": "status", "size": 5 },
+            "aggs": {
+              "top_docs": { "top_hits": { "size": 3 } }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-match-top-hits-agg",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "query": { "match": { "request": "french images" } },
+        "aggs": {
+          "top_docs": { "top_hits": { "size": 3 } }
+        }
+      }
+    },
+    {
+      "name": "intra-terms-significant-terms-agg",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "track_total_hits": true,
+        "aggs": {
+          "by_status": {
+            "terms": { "field": "status", "size": 5 },
+            "aggs": {
+              "significant_ips": {
+                "significant_terms": { "field": "clientip" }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-significant-terms-agg",
+      "operation-type": "search",
+      "index": "logs-181998",
+      "body": {
+        "track_total_hits": true,
+        "aggs": {
+          "significant_status": {
+            "significant_terms": { "field": "status", "size": 5 }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-match-significant-terms-agg",
+      "operation-type": "search",
+      "index": "logs-181998",
+      "body": {
+        "track_total_hits": true,
+        "query": {
+          "match": { "request": "french" }
+        },
+        "aggs": {
+          "significant_status": {
+            "significant_terms": { "field": "status", "size": 5 }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-multi-terms-agg",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "track_total_hits": false,
+        "aggs": {
+          "a": {
+            "multi_terms": {
+              "terms": [
+                { "field": "status" },
+                { "field": "clientip" }
+              ],
+              "size": 10
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-histogram-agg",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "track_total_hits": true,
+        "aggs": {
+          "a": {
+            "histogram": {
+              "field": "size",
+              "interval": 100
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-filter-agg",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "track_total_hits": true,
+        "aggs": {
+          "a": {
+            "filter": { "term": { "status": 200 } }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-filters-agg",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "track_total_hits": true,
+        "aggs": {
+          "a": {
+            "filters": {
+              "filters": {
+                "ok": { "term": { "status": 200 } },
+                "error": { "term": { "status": 500 } }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-adjacency-matrix-agg",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "track_total_hits": false,
+        "aggs": {
+          "a": {
+            "adjacency_matrix": {
+              "filters": {
+                "ok": { "term": { "status": 200 } },
+                "not_found": { "term": { "status": 404 } },
+                "large": { "range": { "size": { "gte": 1000 } } }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-global-agg-with-query",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "query": { "match": { "request": "french" } },
+        "aggs": {
+          "filtered_avg": { "avg": { "field": "size" } },
+          "all_docs": {
+            "global": {},
+            "aggs": {
+              "total_avg": { "avg": { "field": "size" } }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "intra-global-agg",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "track_total_hits": false,
+        "aggs": {
+          "all_docs": {
+            "global": {},
+            "aggs": {
+              "total_avg": { "avg": { "field": "size" } }
+            }
+          }
+        }
+      }
+    }

--- a/http_logs/test_procedures/intra_segment/intra-segment-schedule.json
+++ b/http_logs/test_procedures/intra_segment/intra-segment-schedule.json
@@ -1,0 +1,203 @@
+    {
+      "operation": "intra-cardinality-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-cardinality-agg-with-total-hits",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-multi-cardinality-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-span-near-query",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-intervals-ordered-query",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-bool-must-double-phrase",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-bool-must-match",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-bool-should-match",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-query-string",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-stats-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-sum-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-percentiles-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-extended-stats-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-multi-metrics-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-value-count-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-percentile-ranks-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-matrix-stats-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-terms-top-hits-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-match-top-hits-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-terms-significant-terms-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-significant-terms-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-match-significant-terms-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-multi-terms-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-histogram-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-filter-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-filters-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-adjacency-matrix-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-global-agg-with-query",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    },
+    {
+      "operation": "intra-global-agg",
+      "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+      "iterations": {{ test_iterations | default(100) | tojson }},
+      "target-throughput": {{ target_throughput | default(2) | tojson }},
+      "clients": {{ search_clients | default(1) }}
+    }


### PR DESCRIPTION
### Description
- New Queries to test intra segment search.
- New test procedure `intra-segment`

### Issues Resolved
Related Issues https://github.com/opensearch-project/OpenSearch/issues/20202

### Testing
- [ ] New functionality includes testing

[Describe how this change was tested]

### Backport to Branches:
- [ ] 6
- [ ] 7
- [ ] 1
- [ ] 2
- [ ] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
