### PR TITLE
Add date_histogram_hourly_with_filter_agg operation to big5

### DIFF
--- a/big5/operations/default.json
+++ b/big5/operations/default.json
@@ -106,6 +106,31 @@
       }
     },
     {
+      "name": "date_histogram_hourly_with_filter_agg",
+      "operation-type": "search",
+      "index": "{{index_name | default('big5')}}",
+      "body": {
+        "size": 0,
+        "query": {
+          "term": {
+            "process.name": "systemd"
+          }
+        },
+        "aggs": {
+          "by_hour": {
+            "date_histogram": {
+              "field": "@timestamp",
+              {% if distribution_version.split('.') | map('int') | list < "6.0.0".split('.') | map('int') | list or distribution_version.split('.') | map('int') | list >= "7.0.0".split('.') | map('int') | list %}
+                "calendar_interval": "hour"
+              {% else %}
+                "interval": "hour"
+              {% endif %}
+            }
+          }
+        }
+      }
+    },
+    {
       "name": "date_histogram_minute_agg",
       "operation-type": "search",
       "index": "{{index_name | default('big5')}}",

--- a/big5/test_procedures/common/big5-schedule.json
+++ b/big5/test_procedures/common/big5-schedule.json
@@ -142,6 +142,13 @@
   "clients": {{ search_clients | default(1) }}
 },
 {
+  "operation": "date_histogram_hourly_with_filter_agg",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
   "operation": "date_histogram_minute_agg",
   "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
   "iterations": {{ test_iterations | default(100) | tojson }},


### PR DESCRIPTION


### Description
* to test out skiplist based date histogram
* skiplist is enabled by default http_logs has @timestamp field: https://github.com/opensearch-project/OpenSearch/pull/19480
* TODO: add index.sort.field option on @timestamp

### Issues Resolved
Part of https://github.com/opensearch-project/OpenSearch/issues/18882

### Testing
- [x] New functionality includes testing

[Describe how this change was tested]


```
[ec2-user@ip-172-31-61-197 .benchmark]$ opensearch-benchmark run --pipeline=benchmark-only --workload=big5 --target-hosts=localhost:9200 --kill-running-processes --include-tasks "date_histogram_hourly_with_filter_agg" --workload-param "warmup_iterations:10,test_iterations:20" --user-tag asimmahm:3_4-skiplist-date_histogram_hourly_with_filter_agg



   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/

[INFO] [Test Run ID]: 9d3191ec-6ca1-4fff-be9b-43d4f93fbf6d
[WARNING] Local changes in [/home/ec2-user/.osb/benchmarks/workloads/default] prevent workloads update from remote. Please commit your changes.
[WARNING] Local changes in [/home/ec2-user/.osb/benchmarks/workloads/default] prevent workloads update from remote. Please commit your changes.
[WARNING] Local changes in [/home/ec2-user/.osb/benchmarks/workloads/default] prevent workloads update from remote. Please commit your changes.

Running date_histogram_hourly_with_filter_agg                                  [100% done]

------------------------------------------------------
    _______             __   _____
   / ____(_)___  ____ _/ /  / ___/_________  ________
  / /_  / / __ \/ __ `/ /   \__ \/ ___/ __ \/ ___/ _ \
 / __/ / / / / / /_/ / /   ___/ / /__/ /_/ / /  /  __/
/_/   /_/_/ /_/\__,_/_/   /____/\___/\____/_/   \___/
------------------------------------------------------

|                                                         Metric |                                  Task |       Value |   Unit |
|---------------------------------------------------------------:|--------------------------------------:|------------:|-------:|
|                     Cumulative indexing time of primary shards |                                       |           0 |    min |
|             Min cumulative indexing time across primary shards |                                       |           0 |    min |
|          Median cumulative indexing time across primary shards |                                       |           0 |    min |
|             Max cumulative indexing time across primary shards |                                       |           0 |    min |
|            Cumulative indexing throttle time of primary shards |                                       |           0 |    min |
|    Min cumulative indexing throttle time across primary shards |                                       |           0 |    min |
| Median cumulative indexing throttle time across primary shards |                                       |           0 |    min |
|    Max cumulative indexing throttle time across primary shards |                                       |           0 |    min |
|                        Cumulative merge time of primary shards |                                       |           0 |    min |
|                       Cumulative merge count of primary shards |                                       |           0 |        |
|                Min cumulative merge time across primary shards |                                       |           0 |    min |
|             Median cumulative merge time across primary shards |                                       |           0 |    min |
|                Max cumulative merge time across primary shards |                                       |           0 |    min |
|               Cumulative merge throttle time of primary shards |                                       |           0 |    min |
|       Min cumulative merge throttle time across primary shards |                                       |           0 |    min |
|    Median cumulative merge throttle time across primary shards |                                       |           0 |    min |
|       Max cumulative merge throttle time across primary shards |                                       |           0 |    min |
|                      Cumulative refresh time of primary shards |                                       |           0 |    min |
|                     Cumulative refresh count of primary shards |                                       |           2 |        |
|              Min cumulative refresh time across primary shards |                                       |           0 |    min |
|           Median cumulative refresh time across primary shards |                                       |           0 |    min |
|              Max cumulative refresh time across primary shards |                                       |           0 |    min |
|                        Cumulative flush time of primary shards |                                       |           0 |    min |
|                       Cumulative flush count of primary shards |                                       |           1 |        |
|                Min cumulative flush time across primary shards |                                       |           0 |    min |
|             Median cumulative flush time across primary shards |                                       |           0 |    min |
|                Max cumulative flush time across primary shards |                                       |           0 |    min |
|                                        Total Young Gen GC time |                                       |           0 |      s |
|                                       Total Young Gen GC count |                                       |           0 |        |
|                                          Total Old Gen GC time |                                       |           0 |      s |
|                                         Total Old Gen GC count |                                       |           0 |        |
|                                                     Store size |                                       |     4.70978 |     GB |
|                                                  Translog size |                                       | 5.12227e-08 |     GB |
|                                         Heap used for segments |                                       |           0 |     MB |
|                                       Heap used for doc values |                                       |           0 |     MB |
|                                            Heap used for terms |                                       |           0 |     MB |
|                                            Heap used for norms |                                       |           0 |     MB |
|                                           Heap used for points |                                       |           0 |     MB |
|                                    Heap used for stored fields |                                       |           0 |     MB |
|                                                  Segment count |                                       |           7 |        |
|                                                 Min Throughput | date_histogram_hourly_with_filter_agg |        2.07 |  ops/s |
|                                                Mean Throughput | date_histogram_hourly_with_filter_agg |        2.11 |  ops/s |
|                                              Median Throughput | date_histogram_hourly_with_filter_agg |         2.1 |  ops/s |
|                                                 Max Throughput | date_histogram_hourly_with_filter_agg |        2.19 |  ops/s |
|                                        50th percentile latency | date_histogram_hourly_with_filter_agg |     16.2749 |     ms |
|                                        90th percentile latency | date_histogram_hourly_with_filter_agg |     17.0053 |     ms |
|                                       100th percentile latency | date_histogram_hourly_with_filter_agg |      17.992 |     ms |
|                                   50th percentile service time | date_histogram_hourly_with_filter_agg |     14.9735 |     ms |
|                                   90th percentile service time | date_histogram_hourly_with_filter_agg |     15.3939 |     ms |
|                                  100th percentile service time | date_histogram_hourly_with_filter_agg |      16.667 |     ms |
|                                                     error rate | date_histogram_hourly_with_filter_agg |           0 |      % |


----------------------------------
[INFO] ✅ SUCCESS (took 22 seconds)
----------------------------------
```



### Backport to Branches:
- [ ] 6
- [ ] 7
- [ ] 1
- [ ] 2
- [ ] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
