### PR TITLE
Add field collapsing queries to big5 workload

### DIFF
--- a/big5/operations/default.json
+++ b/big5/operations/default.json
@@ -1115,4 +1115,34 @@
           { "@timestamp": "desc" }
         ]
       }
+    },
+    {
+      "name": "field-collapsing-high-cardinality",
+      "operation-type": "search",
+      "index": "{{ index_name | default('big5') }}",
+      "body": {
+        "query": {
+          "match": {
+            "message": "50-136-239-27"
+          }
+        },
+        "collapse": {
+          "field": "host.name"
+        }
+      }
+    },
+    {
+      "name": "field-collapsing-low-cardinality",
+      "operation-type": "search",
+      "index": "{{ index_name | default('big5') }}",
+      "body": {
+        "query": {
+          "match": {
+            "message": "50-136-239-27"
+          }
+        },
+        "collapse": {
+          "field": "process.name"
+        }
+      }
     }

--- a/big5/queries/field-collapsing-high-cardinality.json
+++ b/big5/queries/field-collapsing-high-cardinality.json
@@ -1,0 +1,10 @@
+{
+  "query": {
+    "match": {
+      "message": "50-136-239-27"
+    }
+  },
+  "collapse": {
+    "field": "host.name"
+  }
+}

--- a/big5/queries/field-collapsing-low-cardinality.json
+++ b/big5/queries/field-collapsing-low-cardinality.json
@@ -1,0 +1,10 @@
+{
+  "query": {
+    "match": {
+      "message": "50-136-239-27"
+    }
+  },
+  "collapse": {
+    "field": "process.name"
+  }
+}

--- a/big5/test_procedures/common/big5-schedule.json
+++ b/big5/test_procedures/common/big5-schedule.json
@@ -323,6 +323,20 @@
   "iterations": {{ test_iterations | default(100) | tojson }},
   "target-throughput": {{ target_throughput | default(2) | tojson }},
   "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "field-collapsing-high-cardinality",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
+},
+{
+  "operation": "field-collapsing-low-cardinality",
+  "warmup-iterations": {{ warmup_iterations | default(200) | tojson }},
+  "iterations": {{ test_iterations | default(100) | tojson }},
+  "target-throughput": {{ target_throughput | default(2) | tojson }},
+  "clients": {{ search_clients | default(1) }}
 }
 {% endif %}
 


### PR DESCRIPTION
### Description
Add field collapsing queries to big5 workload, contain both cases of high cardinality and low cardinality.

With high cardinality(in the case the query size is less than the cardinality), field collapsing has some optimization to improve performance, so the search latency is much lower than the low cardinality case(query size is greater than the cardinality).


### Issues Resolved
No issue.

### Testing
- [ ] New functionality includes testing

[Describe how this change was tested]

### Backport to Branches:
- [ ] 6
- [ ] 7
- [ ] 1
- [x] 2
- [x] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
