### PR TITLE
Remove additional PPL queries from Non-Calcite schedule in big5 workl…

### DIFF
--- a/big5/README.md
+++ b/big5/README.md
@@ -87,6 +87,30 @@ curl -XPUT "http://localhost:9200/_cluster/settings" \
 }'
 ```
 
+#### PPL Test Procedures for Version 3.2.0
+
+For OpenSearch version 3.2.0, two test procedures are available depending on whether Calcite is enabled:
+
+**When Calcite is enabled:**
+```bash
+osb execute-test --workload=big5 --test-procedure=ppl
+```
+This runs all 50 PPL operations including histogram queries.
+
+**When Calcite is disabled:**
+```bash
+osb execute-test --workload=big5 --test-procedure=ppl-calcite-disabled
+```
+This runs 42 PPL operations, excluding the following queries that require Calcite support:
+- `ppl-composite-date-histogram-daily`
+- `ppl-date-histogram-hourly-agg`
+- `ppl-date-histogram-minute-agg`
+- `ppl-range-auto-date-histo-with-metrics`
+- `ppl-range-auto-date-histo`
+- `ppl-range-agg-1`
+- `ppl-range-agg-2`
+- `ppl-cardinality-agg-high-2`
+
 ### gRPC Operations Support
 
 Limited gRPC support is provided for the big5 workload over an protobuf/gRPC transport. gRPC operations can be found in `operations/grpc.json` with new operations added as support is expanded for gRPC APIs in OpenSearch. All supported big5 operations can be run with the `big5/test_procedures/grpc/grpc-schedule.json` (`--test-procedure="grpc-big5"`). To benchmark with the gRPC transport ensure the `transport-grpc` plugin is installed on the cluster and enabled in settings. See the `transport-grpc` [README.md](https://github.com/opensearch-project/OpenSearch/tree/main/modules/transport-grpc#readme) for guidance on enabling and using this transport. Note that the gRPC transport starts on a seperate endpoint from the default REST API, specify this endpoint with `--grpc-target-hosts=<host:port>`. 

--- a/big5/test_procedures/ppl/ppl-schedule-histogram-only.json
+++ b/big5/test_procedures/ppl/ppl-schedule-histogram-only.json
@@ -1,0 +1,56 @@
+{
+  "operation": "ppl-composite-date-histogram-daily",
+  "warmup-iterations": {{ ppl_composite_date_histogram_daily_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_composite_date_histogram_daily_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_composite_date_histogram_daily_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_composite_date_histogram_daily_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-date-histogram-hourly-agg",
+  "warmup-iterations": {{ ppl_date_histogram_hourly_agg_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_date_histogram_hourly_agg_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_date_histogram_hourly_agg_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_date_histogram_hourly_agg_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-date-histogram-minute-agg",
+  "warmup-iterations": {{ ppl_date_histogram_minute_agg_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_date_histogram_minute_agg_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_date_histogram_minute_agg_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_date_histogram_minute_agg_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-range-auto-date-histo-with-metrics",
+  "warmup-iterations": {{ ppl_range_auto_date_histo_with_metrics_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_range_auto_date_histo_with_metrics_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_range_auto_date_histo_with_metrics_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_range_auto_date_histo_with_metrics_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-range-auto-date-histo",
+  "warmup-iterations": {{ ppl_range_auto_date_histo_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_range_auto_date_histo_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_range_auto_date_histo_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_range_auto_date_histo_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-range-agg-1",
+  "warmup-iterations": {{ ppl_range_agg_1_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_range_agg_1_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_range_agg_1_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_range_agg_1_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-range-agg-2",
+  "warmup-iterations": {{ ppl_range_agg_2_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_range_agg_2_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_range_agg_2_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_range_agg_2_clients or search_clients | default(1) }}
+},
+{
+  "operation": "ppl-cardinality-agg-high-2",
+  "warmup-iterations": {{ ppl_cardinality_agg_high_2_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_cardinality_agg_high_2_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_cardinality_agg_high_2_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_cardinality_agg_high_2_clients or search_clients | default(1) }}
+}

--- a/big5/test_procedures/ppl/ppl-schedule.json
+++ b/big5/test_procedures/ppl/ppl-schedule.json
@@ -167,11 +167,11 @@
   "clients": {{ ppl_range_auto_date_histo_with_metrics_clients or search_clients | default(1) }}
 },
 {
-  "operation": "ppl-range-auto-date-histo",
-  "warmup-iterations": {{ ppl_range_auto_date_histo_warmup_iterations or warmup_iterations | default(200) | tojson }},
-  "iterations": {{ ppl_range_auto_date_histo_iterations or test_iterations | default(100) | tojson }},
-  "target-throughput": {{ ppl_range_auto_date_histo_target_throughput or target_throughput | default(2) | tojson }},
-  "clients": {{ ppl_range_auto_date_histo_clients or search_clients | default(1) }}
+  "operation": "ppl-cardinality-agg-low",
+  "warmup-iterations": {{ ppl_cardinality_agg_low_warmup_iterations or warmup_iterations | default(200) | tojson }},
+  "iterations": {{ ppl_cardinality_agg_low_iterations or test_iterations | default(100) | tojson }},
+  "target-throughput": {{ ppl_cardinality_agg_low_target_throughput or target_throughput | default(2) | tojson }},
+  "clients": {{ ppl_cardinality_agg_low_clients or search_clients | default(1) }}
 },
 {
   "operation": "ppl-range-field-conjunction-big-range-big-term-query",


### PR DESCRIPTION
### Description
Backport/backport 738 to 3. 

### Issues Resolved
[List any issues this PR will resolve]

### Testing
- [ ] New functionality includes testing

[Describe how this change was tested]

### Backport to Branches:
- [ ] 6
- [ ] 7
- [ ] 1
- [ ] 2
- [ ] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
