### PR TITLE
Add index_sort param to enable sort on @timestamp field in big5 and http_logs

### DIFF
--- a/big5/README.md
+++ b/big5/README.md
@@ -153,6 +153,7 @@ This workload allows the following parameters to be specified using `--workload-
 * `target_throughput` (default: 2): Target throughput for each query operation in requests per second, use 0 or "" for no throughput throttling.
 * `warmup_iterations` (default: 100): Number of warmup query iterations prior to actual measurements commencing.
 * `index_translog_durability` (default: "async"): Controls the transaction log flush behavior. "request" flushes after every operation to avoid data loss, while "async" batches changes for efficiency.
+* `index_sort` (default: false): If true, enabled index time asc sort on `@timestamp` field
 
 NOTE: If disabling `target_throughput`, know that `target_throughput:""` is snynonymous with `target_throughput:0`.
 

--- a/big5/index.json
+++ b/big5/index.json
@@ -20,9 +20,13 @@
     "index.codec": "best_compression",
     "index.translog.sync_interval": "30s",
     "index.translog.durability": {{index_translog_durability | default("async") | tojson}},
+    {% if index_sort | default(false) %}
+    "index.sort.field": "@timestamp",
+    "index.sort.order": "asc",
+    {% endif %}
     "index.query.default_field": [
       "message"
-    ]
+    ],
   },
   "mappings": {
     {% if distribution_version.split('.') | map('int') | list  < "6.0.0".split('.') | map('int') | list %}

--- a/http_logs/README.md
+++ b/http_logs/README.md
@@ -50,6 +50,8 @@ node pipeline to run. Valid options are `'baseline'` (default), `'grok'`  and `'
 * `error_level` (default: "non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
 * `target_throughput` (default: default values for each operation): Number of requests per second, `none` for no limit.
 * `search_clients`: Number of clients that issues search requests.
+* `index_sort` (default: false): If true, enabled index time asc sort on `@timestamp` field
+
 
 
 ### Beta Feature: Increasing the size of the data corpus

--- a/http_logs/index.json
+++ b/http_logs/index.json
@@ -4,6 +4,10 @@
     "index.number_of_replicas": {{ number_of_replicas | default(0) }},
     "index.queries.cache.enabled": {{query_cache_enabled | default(false) | tojson}},
     "index.requests.cache.enable": {{requests_cache_enabled | default(false) | tojson}}
+    {% if index_sort | default(false) %}
+    ,"index.sort.field": "@timestamp",
+    "index.sort.order": "asc"
+    {% endif %}
   },
   "mappings": {
     "dynamic": "strict",


### PR DESCRIPTION
### Description
* plan is to run these side by side with non-sorted
* this to show the additional benefit of sorted index for time-series data
* also to help code issues, e.g. non-sorted index shows regression but sorted is unchanged, there's a good chance is a data distribution or indexing issue instead of search code issue

### Issues Resolved
https://github.com/opensearch-project/opensearch-benchmark-workloads/issues/724

### Testing
- [x] New functionality includes testing

[Describe how this change was tested]

### Backport to Branches:
- [ ] 6
- [ ] 7
- [ ] 1
- [ ] 2
- [x] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
