### PR TITLE
Add random vector workload for testing indexing, search and merge using a random vectors without any dataset

### DIFF
--- a/vectorsearch/README.md
+++ b/vectorsearch/README.md
@@ -651,3 +651,184 @@ Currently, there is only one custom runner defined in [runners.py](runners.py).
 | Syntax             | Description                                         | Parameters                                                                                                   |
 |--------------------|-----------------------------------------------------|:-------------------------------------------------------------------------------------------------------------|
 | warmup-knn-indices | Warm up knn indices with retry until success.       | 1. index - name of index to warmup                                                                           |
+
+### Running a Random Dataset benchmark
+
+The vectorsearch workload supports generating random vectors for benchmarking without requiring external datasets. This is useful for quick performance testing and development.
+
+#### Available Test Procedures
+
+- `random-vector-index-only` - Index random vectors only
+- `random-vector-index-with-merge-only` - Index random vectors and force merge
+- `random-vector-search-only` - Search with random query vectors (requires pre-indexed data)
+- `random-vector-index-merge-search` - Complete workflow: index, merge, and search
+
+#### Ingestion
+Ingestion can be done in 2 modes  depending on whether `index_target_throughput` is specified or not. The workload 
+launches `indexing_clients` parallel clients. Each client sends `index_iterations` bulk requests, with each request 
+containing `target_index_bulk_size` documents.
+The total number of documents indexed is: `indexing_clients × index_iterations × target_index_bulk_size`
+
+1. If `index_target_throughput` is set, each client will send bulk operations at a rate of: `index_target_throughput ÷ 
+indexing_clients` bulk requests per second.
+2. If `index_target_throughput` is not set, each client will send bulk operations as fast as possible.
+
+#### Search
+The current random workload only do Approximate Nearest Neighbor search using `knn` query. The total number of 
+queries that will run will be `search_clients x query_iterations`. You can specify `warmup_search_iterations` to run 
+some warmup queries which will not be included in final results. 
+
+#### Example Command
+
+```bash
+# OpenSearch Cluster End point url with hostname and port
+export ENDPOINT=  
+# Absolute file path of Workload param file
+export PARAMS_FILE=
+
+opensearch-benchmark execute-test \
+    --target-hosts $ENDPOINT \
+    --workload vectorsearch \
+    --test-procedure=random-vector-index-only \
+    --workload-params ${PARAMS_FILE} \
+    --pipeline benchmark-only \
+    --kill-running-processes
+```
+
+#### Key Parameters
+
+You can customize the benchmark by modifying parameters in your workload-params file:
+
+The default values here will ingest 1M docs of 768D and will run 1K queries using 10 clients
+
+```json
+{
+    "target_index_name": "target_index",
+    "target_field_name": "target_field",
+    "target_index_body": "indices/faiss-index.json",
+    "target_index_primary_shards": 3,
+    "target_index_replica_shards": 0,
+    "target_index_dimension": 768,
+    "target_index_space_type": "innerproduct",
+    
+    "target_index_bulk_size": 100,
+    "indexing_clients": 10,
+    "index_iterations": 1000,
+    
+    "target_index_max_num_segments": 1,
+    "hnsw_ef_search": 100,
+    "hnsw_ef_construction": 100,
+
+    "query_k": 100,
+    "query_body": {
+         "docvalue_fields" : ["_id"],
+         "stored_fields" : "_none_"
+    },
+    "query_iterations": 100,
+    "search_clients": 10
+}
+
+```
+
+- `target_index_dimension` - Vector dimension size
+- `target_index_bulk_size` - Number of documents per bulk request
+- `target_index_bulk_indexing_clients` - Number of concurrent indexing clients
+- `index_iterations` - Number of indexing iterations
+- `query_k` - Number of nearest neighbors to retrieve
+- `query_iterations` - Number of search queries to execute
+- `search_clients` - Number of clients that will executing the 
+
+#### Sample Response
+```
+opensearch-benchmark run --target-host=$ENDPOINT \
+--workload-path=<PATH>/opensearch-benchmark-workloads/vectorsearch \
+--pipeline benchmark-only --workload-params $PARAMS \
+--test-procedure=random-vector-index-merge-search --kill-running-processes
+
+```
+
+```
+------------------------------------------------------
+    _______             __   _____
+   / ____(_)___  ____ _/ /  / ___/_________  ________
+  / /_  / / __ \/ __ `/ /   \__ \/ ___/ __ \/ ___/ _ \
+ / __/ / / / / / /_/ / /   ___/ / /__/ /_/ / /  /  __/
+/_/   /_/_/ /_/\__,_/_/   /____/\___/\____/_/   \___/
+------------------------------------------------------
+            
+|                                                         Metric |                   Task |       Value |   Unit |
+|---------------------------------------------------------------:|-----------------------:|------------:|-------:|
+|                     Cumulative indexing time of primary shards |                        |    0.374433 |    min |
+|             Min cumulative indexing time across primary shards |                        | 0.000233333 |    min |
+|          Median cumulative indexing time across primary shards |                        |    0.118133 |    min |
+|             Max cumulative indexing time across primary shards |                        |    0.137933 |    min |
+|            Cumulative indexing throttle time of primary shards |                        |           0 |    min |
+|    Min cumulative indexing throttle time across primary shards |                        |           0 |    min |
+| Median cumulative indexing throttle time across primary shards |                        |           0 |    min |
+|    Max cumulative indexing throttle time across primary shards |                        |           0 |    min |
+|                        Cumulative merge time of primary shards |                        |     0.01005 |    min |
+|                       Cumulative merge count of primary shards |                        |           3 |        |
+|                Min cumulative merge time across primary shards |                        |           0 |    min |
+|             Median cumulative merge time across primary shards |                        |  0.00328333 |    min |
+|                Max cumulative merge time across primary shards |                        |  0.00348333 |    min |
+|               Cumulative merge throttle time of primary shards |                        |           0 |    min |
+|       Min cumulative merge throttle time across primary shards |                        |           0 |    min |
+|    Median cumulative merge throttle time across primary shards |                        |           0 |    min |
+|       Max cumulative merge throttle time across primary shards |                        |           0 |    min |
+|                      Cumulative refresh time of primary shards |                        |   0.0324667 |    min |
+|                     Cumulative refresh count of primary shards |                        |          43 |        |
+|              Min cumulative refresh time across primary shards |                        |  0.00133333 |    min |
+|           Median cumulative refresh time across primary shards |                        |  0.00763333 |    min |
+|              Max cumulative refresh time across primary shards |                        |   0.0158667 |    min |
+|                        Cumulative flush time of primary shards |                        |      0.0024 |    min |
+|                       Cumulative flush count of primary shards |                        |           2 |        |
+|                Min cumulative flush time across primary shards |                        |           0 |    min |
+|             Median cumulative flush time across primary shards |                        |           0 |    min |
+|                Max cumulative flush time across primary shards |                        |      0.0024 |    min |
+|                                        Total Young Gen GC time |                        |       0.072 |      s |
+|                                       Total Young Gen GC count |                        |          15 |        |
+|                                          Total Old Gen GC time |                        |           0 |      s |
+|                                         Total Old Gen GC count |                        |           0 |        |
+|                                                     Store size |                        |   0.0290672 |     GB |
+|                                                  Translog size |                        | 6.78934e-07 |     GB |
+|                                         Heap used for segments |                        |           0 |     MB |
+|                                       Heap used for doc values |                        |           0 |     MB |
+|                                            Heap used for terms |                        |           0 |     MB |
+|                                            Heap used for norms |                        |           0 |     MB |
+|                                           Heap used for points |                        |           0 |     MB |
+|                                    Heap used for stored fields |                        |           0 |     MB |
+|                                                  Segment count |                        |           5 |        |
+|                                                 Min Throughput | random-vector-indexing |     2396.96 | docs/s |
+|                                                Mean Throughput | random-vector-indexing |     2983.55 | docs/s |
+|                                              Median Throughput | random-vector-indexing |     2983.55 | docs/s |
+|                                                 Max Throughput | random-vector-indexing |     3570.14 | docs/s |
+|                                        50th percentile latency | random-vector-indexing |     170.128 |     ms |
+|                                        90th percentile latency | random-vector-indexing |     288.014 |     ms |
+|                                        99th percentile latency | random-vector-indexing |     507.421 |     ms |
+|                                       100th percentile latency | random-vector-indexing |     567.818 |     ms |
+|                                   50th percentile service time | random-vector-indexing |     170.128 |     ms |
+|                                   90th percentile service time | random-vector-indexing |     288.014 |     ms |
+|                                   99th percentile service time | random-vector-indexing |     507.421 |     ms |
+|                                  100th percentile service time | random-vector-indexing |     567.818 |     ms |
+|                                                     error rate | random-vector-indexing |           0 |      % |
+|                                                 Min Throughput |   random-vector-search |     1976.22 |  ops/s |
+|                                                Mean Throughput |   random-vector-search |     1976.22 |  ops/s |
+|                                              Median Throughput |   random-vector-search |     1976.22 |  ops/s |
+|                                                 Max Throughput |   random-vector-search |     1976.22 |  ops/s |
+|                                        50th percentile latency |   random-vector-search |     2.90242 |     ms |
+|                                        90th percentile latency |   random-vector-search |     4.33686 |     ms |
+|                                        99th percentile latency |   random-vector-search |     18.2361 |     ms |
+|                                      99.9th percentile latency |   random-vector-search |     59.4897 |     ms |
+|                                       100th percentile latency |   random-vector-search |     60.4879 |     ms |
+|                                   50th percentile service time |   random-vector-search |     2.90242 |     ms |
+|                                   90th percentile service time |   random-vector-search |     4.33686 |     ms |
+|                                   99th percentile service time |   random-vector-search |     18.2361 |     ms |
+|                                 99.9th percentile service time |   random-vector-search |     59.4897 |     ms |
+|                                  100th percentile service time |   random-vector-search |     60.4879 |     ms |
+|                                                     error rate |   random-vector-search |           0 |      % |
+
+
+----------------------------------
+[INFO] ✅ SUCCESS (took 70 seconds)
+----------------------------------
+```

--- a/vectorsearch/indices/faiss-index.json
+++ b/vectorsearch/indices/faiss-index.json
@@ -33,6 +33,11 @@
             "type": "keyword"
           },
         {%- endif %}
+        {% if target_index_partition_metadata is defined and target_index_partition_metadata %}
+        "partition_id": {
+          "type": "integer"
+        },
+        {%- endif %}
         "{{ target_field_name }}": {
           "type": "knn_vector",
           "dimension": {{ target_index_dimension }},

--- a/vectorsearch/indices/lucene-index.json
+++ b/vectorsearch/indices/lucene-index.json
@@ -24,6 +24,11 @@
             "type": "keyword"
           },
         {%- endif %}
+        {% if target_index_partition_metadata is defined and target_index_partition_metadata %}
+          "partition_id": {
+            "type": "integer"
+          },
+        {%- endif %}
         "{{ target_field_name }}": {
           "type": "knn_vector",
           "dimension": {{ target_index_dimension }},

--- a/vectorsearch/params/random_vector/random-vector-faiss.json
+++ b/vectorsearch/params/random_vector/random-vector-faiss.json
@@ -1,0 +1,29 @@
+{
+    "target_index_name": "target_index",
+    "target_field_name": "target_field",
+    "target_index_body": "indices/faiss-index.json",
+    "target_index_primary_shards": 3,
+    "target_index_replica_shards": 0,
+    "target_index_dimension": 768,
+    "target_index_space_type": "innerproduct",
+    "approximate_graph_build_threshold": "0",
+    "memory_optimized_search_enabled": true,
+    "target_index_partition_metadata": true,
+    
+    "target_index_bulk_size": 100,
+    "indexing_clients": 10,
+    "index_iterations": 1000,
+    "index_target_throughput": 1,
+    
+    "target_index_max_num_segments": 1,
+    "hnsw_ef_search": 100,
+    "hnsw_ef_construction": 100,
+
+    "query_k": 100,
+    "query_body": {
+         "docvalue_fields" : ["_id"],
+         "stored_fields" : "_none_"
+    },
+    "search_iterations": 100,
+    "search_clients": 10
+}

--- a/vectorsearch/params/random_vector/random-vector-lucene.json
+++ b/vectorsearch/params/random_vector/random-vector-lucene.json
@@ -1,0 +1,26 @@
+{
+    "target_index_name": "target_index",
+    "target_field_name": "target_field",
+    "target_index_body": "indices/lucene-index.json",
+    "target_index_primary_shards": 3,
+    "target_index_replica_shards": 0,
+    "target_index_dimension": 768,
+    "target_index_space_type": "innerproduct",
+    "target_index_partition_metadata": true,
+    
+    "target_index_bulk_size": 100,
+    "indexing_clients": 10,
+    "index_iterations": 1000,
+    
+    "target_index_max_num_segments": 1,
+    "hnsw_ef_search": 100,
+    "hnsw_ef_construction": 100,
+
+    "query_k": 100,
+    "query_body": {
+         "docvalue_fields" : ["_id"],
+         "stored_fields" : "_none_"
+    },
+    "search_iterations": 100,
+    "search_clients": 10
+  }

--- a/vectorsearch/test_procedures/common/random-index-only-schedule.json
+++ b/vectorsearch/test_procedures/common/random-index-only-schedule.json
@@ -1,0 +1,37 @@
+{
+    "operation": {
+        "name": "delete-target-index",
+        "operation-type": "delete-index",
+        "only-if-exists": true,
+        "index": "{{ target_index_name | default('target_index') }}"
+    }
+},
+{
+    "operation": {
+        "name": "create-target-index",
+        "operation-type": "create-index",
+        "index": "{{ target_index_name | default('target_index') }}"
+    }
+},
+{
+    "operation": {
+        "name": "random-vector-indexing",
+        "operation-type": "bulk",
+        "param-source": "random-vector-bulk-param-source",
+        "dims": {{ target_index_dimension | default(768) | int }},
+        "index_name": "{{ target_index_name | default('target_index') }}",
+        "field" : "{{ target_field_name | default('target_field') }}",
+        "partitions": {{ partitions | default(1000) | int }},
+        "bulk-size": {{ target_index_bulk_size | default(100)}},
+        "detailed-results": true
+    },
+    "clients": {{ indexing_clients | default(10) | int }},
+    "iterations": {{ index_iterations | default(1) | int }}
+    {%- if index_target_throughput is defined %}
+    ,"target-throughput": {{ index_target_throughput | int }}
+    {%- endif %}
+},
+{
+    "name" : "refresh-target-index",
+    "operation" : "refresh-target-index"
+}

--- a/vectorsearch/test_procedures/common/random-search-only-schedule.json
+++ b/vectorsearch/test_procedures/common/random-search-only-schedule.json
@@ -1,0 +1,23 @@
+{
+    "name" : "refresh-target-index-before-search",
+    "operation" : "refresh-target-index"
+},
+{
+  "operation": {
+    "name": "random-vector-search",
+    "operation-type": "search",
+    "param-source": "random-vector-search-param-source",
+    "dims": {{ target_index_dimension | default(768) | int }},
+    "k": {{ query_k }},
+    "body": {{ query_body | default ({}) | tojson }},
+    "field" : "{{ target_field_name | default('target_field') }}"
+    {% if hnsw_ef_search is defined %}
+    ,"ef_search": {{ hnsw_ef_search }}
+    {% endif %}
+    ,"index_name": "{{ target_index_name | default('target_index') }}",
+    "detailed-results": true
+  },
+  "clients": {{ search_clients | default(1)}},
+  "iterations": {{search_iterations | default(1000)}},
+  "warmup-iterations": {{warmup_search_iterations | default(0)}}
+}

--- a/vectorsearch/test_procedures/default.json
+++ b/vectorsearch/test_procedures/default.json
@@ -70,4 +70,48 @@
         {{ benchmark.collect(parts="common/force-merge-schedule.json") }},
         {{ benchmark.collect(parts="common/search-only-schedule.json") }}
     ]
+},
+{
+    "name": "random-vector-index-merge-search",
+    "description": "Index and search using vectors generated randomly",
+    "default": false,
+    "schedule": [
+       {{ benchmark.collect(parts="common/random-index-only-schedule.json") }},
+       {{ benchmark.collect(parts="common/force-merge-schedule.json") }},
+       {{ benchmark.collect(parts="common/random-search-only-schedule.json") }}
+    ]
+},
+{
+    "name": "random-vector-index-search",
+    "description": "Index and search using vectors generated randomly",
+    "default": false,
+    "schedule": [
+       {{ benchmark.collect(parts="common/random-index-only-schedule.json") }},
+       {{ benchmark.collect(parts="common/random-search-only-schedule.json") }}
+    ]
+},
+{
+    "name": "random-vector-index-only",
+    "description": "Index and search using vectors generated randomly",
+    "default": false,
+    "schedule": [
+       {{ benchmark.collect(parts="common/random-index-only-schedule.json") }}
+    ]
+},
+{
+    "name": "random-vector-index-with-merge-only",
+    "description": "Index and merge using vectors generated randomly",
+    "default": false,
+    "schedule": [
+       {{ benchmark.collect(parts="common/random-index-only-schedule.json") }},
+       {{ benchmark.collect(parts="common/force-merge-schedule.json") }}
+    ]
+},
+{
+    "name": "random-vector-search-only",
+    "description": "Search using vectors generated randomly",
+    "default": false,
+    "schedule": [
+       {{ benchmark.collect(parts="common/random-search-only-schedule.json") }}
+    ]
 }

--- a/vectorsearch/workload.py
+++ b/vectorsearch/workload.py
@@ -5,7 +5,78 @@
 # compatible open source license.
 
 from .runners import register as register_runners
+from osbenchmark.workload.params import ParamSource
+import random
+import numpy as np
+import logging
 
 
 def register(registry):
     register_runners(registry)
+    # Register random-vector param-sources
+    registry.register_param_source("random-vector-bulk-param-source", RandomBulkParamSource)
+    registry.register_param_source("random-vector-search-param-source", RandomSearchParamSource)
+
+
+class RandomBulkParamSource(ParamSource):
+    def __init__(self, workload, params, **kwargs):
+        super().__init__(workload, params, **kwargs)
+        logging.getLogger(__name__).info("Workload: [%s], params: [%s]", workload, params)
+        self._bulk_size = params.get("bulk-size", 100)
+        self._index_name = params.get('index_name','target_index')
+        self._field = params.get("field", "target_field")
+        self._dims = params.get("dims", 768)
+        self._partitions = params.get("partitions", 1000)
+
+    def partition(self, partition_index, total_partitions):
+        return self
+
+    def params(self):
+        bulk_data = []
+        for _ in range(self._bulk_size):
+            vec = np.random.rand(self._dims)
+            partition_id = random.randint(0, self._partitions)
+            metadata = {"_index": self._index_name}
+            bulk_data.append({"create": metadata})
+            bulk_data.append({"partition_id": partition_id, self._field: vec.tolist()})
+
+        return {
+            "body": bulk_data,
+            "bulk-size": self._bulk_size,
+            "action-metadata-present": True,
+            "unit": "docs",
+            "index": self._index_name,
+            "type": "",
+        }
+
+class RandomSearchParamSource(ParamSource):
+    def __init__(self, workload, params, **kwargs):
+        super().__init__(workload, params, **kwargs)
+        logging.getLogger(__name__).info("Workload: [%s], params: [%s]", workload, params)
+        self._index_name = params.get('index_name', 'target_index')
+        self._dims = params.get("dims", 768)
+        self._cache = params.get("cache", False)
+        self._top_k = params.get("k", 100)
+        self._field = params.get("field", "target_field")
+        self._query_body = params.get("body", {})
+
+    def partition(self, partition_index, total_partitions):
+        return self
+
+    def params(self):
+        query_vec = np.random.rand(self._dims).tolist()
+        query = self.generate_knn_query(query_vec)
+        query.update(self._query_body)
+        return {"index": self._index_name, "cache": self._cache, "size": self._top_k, "body": query}
+
+    def generate_knn_query(self, query_vector):
+        return {
+            "query": {
+                "knn": {
+                    self._field: {
+                        "vector": query_vector,
+                        "k": self._top_k
+                    }
+                }
+            }
+        }


### PR DESCRIPTION
### Description
Add random vector workload for testing indexing, search and merge using a random vectors without any dataset.

Next Steps:
1. Add a search flow using the time based operation.
2. See why force merge and refresh operation details are not getting returned


### Issues Resolved
NA

### Testing
- [X] New functionality includes testing

Tested locally by spinning up cluster and running the workload. Result
```
------------------------------------------------------
    _______             __   _____
   / ____(_)___  ____ _/ /  / ___/_________  ________
  / /_  / / __ \/ __ `/ /   \__ \/ ___/ __ \/ ___/ _ \
 / __/ / / / / / /_/ / /   ___/ / /__/ /_/ / /  /  __/
/_/   /_/_/ /_/\__,_/_/   /____/\___/\____/_/   \___/
------------------------------------------------------
            
|                                                         Metric |                   Task |       Value |   Unit |
|---------------------------------------------------------------:|-----------------------:|------------:|-------:|
|                     Cumulative indexing time of primary shards |                        |     55.6283 |    min |
|             Min cumulative indexing time across primary shards |                        | 0.000316667 |    min |
|          Median cumulative indexing time across primary shards |                        |     18.4851 |    min |
|             Max cumulative indexing time across primary shards |                        |     18.6578 |    min |
|            Cumulative indexing throttle time of primary shards |                        |      1.5286 |    min |
|    Min cumulative indexing throttle time across primary shards |                        |           0 |    min |
| Median cumulative indexing throttle time across primary shards |                        |    0.455767 |    min |
|    Max cumulative indexing throttle time across primary shards |                        |    0.617067 |    min |
|                        Cumulative merge time of primary shards |                        |      31.032 |    min |
|                       Cumulative merge count of primary shards |                        |         123 |        |
|                Min cumulative merge time across primary shards |                        |           0 |    min |
|             Median cumulative merge time across primary shards |                        |     10.1439 |    min |
|                Max cumulative merge time across primary shards |                        |     10.7441 |    min |
|               Cumulative merge throttle time of primary shards |                        |     5.75528 |    min |
|       Min cumulative merge throttle time across primary shards |                        |           0 |    min |
|    Median cumulative merge throttle time across primary shards |                        |     1.64798 |    min |
|       Max cumulative merge throttle time across primary shards |                        |     2.45932 |    min |
|                      Cumulative refresh time of primary shards |                        |     6.82195 |    min |
|                     Cumulative refresh count of primary shards |                        |         351 |        |
|              Min cumulative refresh time across primary shards |                        |  0.00143333 |    min |
|           Median cumulative refresh time across primary shards |                        |     2.13805 |    min |
|              Max cumulative refresh time across primary shards |                        |     2.54442 |    min |
|                        Cumulative flush time of primary shards |                        |     1.21562 |    min |
|                       Cumulative flush count of primary shards |                        |          22 |        |
|                Min cumulative flush time across primary shards |                        |  0.00873333 |    min |
|             Median cumulative flush time across primary shards |                        |    0.362158 |    min |
|                Max cumulative flush time across primary shards |                        |    0.482567 |    min |
|                                        Total Young Gen GC time |                        |      32.524 |      s |
|                                       Total Young Gen GC count |                        |        7962 |        |
|                                          Total Old Gen GC time |                        |           0 |      s |
|                                         Total Old Gen GC count |                        |           0 |        |
|                                                     Store size |                        |     5.89181 |     GB |
|                                                  Translog size |                        | 6.83591e-07 |     GB |
|                                         Heap used for segments |                        |           0 |     MB |
|                                       Heap used for doc values |                        |           0 |     MB |
|                                            Heap used for terms |                        |           0 |     MB |
|                                            Heap used for norms |                        |           0 |     MB |
|                                           Heap used for points |                        |           0 |     MB |
|                                    Heap used for stored fields |                        |           0 |     MB |
|                                                  Segment count |                        |           7 |        |
|                                                 Min Throughput | random-vector-indexing |     2983.86 | docs/s |
|                                                Mean Throughput | random-vector-indexing |     3364.94 | docs/s |
|                                              Median Throughput | random-vector-indexing |     3292.23 | docs/s |
|                                                 Max Throughput | random-vector-indexing |     4294.74 | docs/s |
|                                        50th percentile latency | random-vector-indexing |     236.819 |     ms |
|                                        90th percentile latency | random-vector-indexing |     491.651 |     ms |
|                                        99th percentile latency | random-vector-indexing |     1292.62 |     ms |
|                                      99.9th percentile latency | random-vector-indexing |     2493.47 |     ms |
|                                     99.99th percentile latency | random-vector-indexing |     3296.73 |     ms |
|                                       100th percentile latency | random-vector-indexing |     3334.29 |     ms |
|                                   50th percentile service time | random-vector-indexing |     236.819 |     ms |
|                                   90th percentile service time | random-vector-indexing |     491.651 |     ms |
|                                   99th percentile service time | random-vector-indexing |     1292.62 |     ms |
|                                 99.9th percentile service time | random-vector-indexing |     2493.47 |     ms |
|                                99.99th percentile service time | random-vector-indexing |     3296.73 |     ms |
|                                  100th percentile service time | random-vector-indexing |     3334.29 |     ms |
|                                                     error rate | random-vector-indexing |           0 |      % |
|                                                 Min Throughput |   random-vector-search |        0.94 |  ops/s |
|                                                Mean Throughput |   random-vector-search |       50.55 |  ops/s |
|                                              Median Throughput |   random-vector-search |       29.18 |  ops/s |
|                                                 Max Throughput |   random-vector-search |      156.77 |  ops/s |
|                                        50th percentile latency |   random-vector-search |     21.8717 |     ms |
|                                        90th percentile latency |   random-vector-search |     80.6356 |     ms |
|                                        99th percentile latency |   random-vector-search |     347.515 |     ms |
|                                      99.9th percentile latency |   random-vector-search |     1056.52 |     ms |
|                                       100th percentile latency |   random-vector-search |     1056.57 |     ms |
|                                   50th percentile service time |   random-vector-search |     21.8717 |     ms |
|                                   90th percentile service time |   random-vector-search |     80.6356 |     ms |
|                                   99th percentile service time |   random-vector-search |     347.515 |     ms |
|                                 99.9th percentile service time |   random-vector-search |     1056.52 |     ms |
|                                  100th percentile service time |   random-vector-search |     1056.57 |     ms |
|                                                     error rate |   random-vector-search |           0 |      % |


-----------------------------------
[INFO] ✅ SUCCESS (took 728 seconds)
-----------------------------------

```

### Backport to Branches:
- [ ] 6
- [ ] 7
- [ ] 1
- [X] 2
- [X] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
