### PR TITLE
remove trailing comma in big5 index.json

### DIFF
--- a/big5/index.json
+++ b/big5/index.json
@@ -26,7 +26,7 @@
     {% endif %}
     "index.query.default_field": [
       "message"
-    ],
+    ]
   },
   "mappings": {
     {% if distribution_version.split('.') | map('int') | list  < "6.0.0".split('.') | map('int') | list %}


### PR DESCRIPTION
### Description
Trailing comma in big5's index.json was causing an error when running benchmarks:
```
2026-02-02 19:21:11,805 ActorAddr-(T|:45055)/PID:867049 osbenchmark.workload.loader ERROR Could not load file template for definition for index big5 in index.json.
Traceback (most recent call last):

  File "/home/ec2-user/opensearch-benchmark/osbenchmark/workload/loader.py", line 1572, in _load_template
    return json.loads(rendered)
           ^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.11/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.11/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.11/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
               ^^^^^^^^^^^^^^^^^^^^^^

json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 23 column 3 (char 426)

2026-02-02 19:21:11,806 ActorAddr-(T|:45055)/PID:867049 osbenchmark.workload.loader ERROR Cannot load workload [big5]
Traceback (most recent call last):

  File "/home/ec2-user/opensearch-benchmark/osbenchmark/workload/loader.py", line 1572, in _load_template
    return json.loads(rendered)
           ^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.11/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.11/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.11/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
               ^^^^^^^^^^^^^^^^^^^^^^

json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 23 column 3 (char 426)


During handling of the above exception, another exception occurred:


Traceback (most recent call last):

  File "/home/ec2-user/opensearch-benchmark/osbenchmark/workload/loader.py", line 203, in _load_single_workload
    current_workload = reader.read(workload_name, workload_repository.workload_file(workload_name), workload_dir)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/ec2-user/opensearch-benchmark/osbenchmark/workload/loader.py", line 1376, in read
    current_workload = self.read_workload(workload_name, workload_spec, mapping_dir)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/ec2-user/opensearch-benchmark/osbenchmark/workload/loader.py", line 1478, in __call__
    indices = [self._create_index(idx, mapping_dir)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/ec2-user/opensearch-benchmark/osbenchmark/workload/loader.py", line 1478, in <listcomp>
    indices = [self._create_index(idx, mapping_dir)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/ec2-user/opensearch-benchmark/osbenchmark/workload/loader.py", line 1529, in _create_index
    body = self._load_template(
           ^^^^^^^^^^^^^^^^^^^^

  File "/home/ec2-user/opensearch-benchmark/osbenchmark/workload/loader.py", line 1575, in _load_template
    raise WorkloadSyntaxError("Could not load file template for '%s'" % description, str(e))

osbenchmark.workload.loader.WorkloadSyntaxError: Could not load file template for 'definition for index big5 in index.json'

2026-02-02 19:21:11,807 ActorAddr-(T|:45055)/PID:867049 osbenchmark.actor ERROR Error in test run orchestrator
Traceback (most recent call last):

  File "/home/ec2-user/opensearch-benchmark/osbenchmark/workload/loader.py", line 1572, in _load_template
    return json.loads(rendered)
           ^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.11/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.11/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.11/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
               ^^^^^^^^^^^^^^^^^^^^^^

json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 23 column 3 (char 426)


During handling of the above exception, another exception occurred:


Traceback (most recent call last):

  File "/home/ec2-user/opensearch-benchmark/osbenchmark/actor.py", line 92, in guard
    return f(self, msg, sender)
           ^^^^^^^^^^^^^^^^^^^^

  File "/home/ec2-user/opensearch-benchmark/osbenchmark/test_run_orchestrator.py", line 108, in receiveMsg_Setup
    self.coordinator.setup(sources=msg.sources)

  File "/home/ec2-user/opensearch-benchmark/osbenchmark/test_run_orchestrator.py", line 205, in setup
    self.current_workload = workload.load_workload(self.cfg)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/ec2-user/opensearch-benchmark/osbenchmark/workload/loader.py", line 196, in load_workload
    return _load_single_workload(cfg, repo, repo.workload_name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/ec2-user/opensearch-benchmark/osbenchmark/workload/loader.py", line 203, in _load_single_workload
    current_workload = reader.read(workload_name, workload_repository.workload_file(workload_name), workload_dir)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/ec2-user/opensearch-benchmark/osbenchmark/workload/loader.py", line 1376, in read
    current_workload = self.read_workload(workload_name, workload_spec, mapping_dir)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/ec2-user/opensearch-benchmark/osbenchmark/workload/loader.py", line 1478, in __call__
    indices = [self._create_index(idx, mapping_dir)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/ec2-user/opensearch-benchmark/osbenchmark/workload/loader.py", line 1478, in <listcomp>
    indices = [self._create_index(idx, mapping_dir)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/ec2-user/opensearch-benchmark/osbenchmark/workload/loader.py", line 1529, in _create_index
    body = self._load_template(
           ^^^^^^^^^^^^^^^^^^^^

  File "/home/ec2-user/opensearch-benchmark/osbenchmark/workload/loader.py", line 1575, in _load_template
    raise WorkloadSyntaxError("Could not load file template for '%s'" % description, str(e))

osbenchmark.workload.loader.WorkloadSyntaxError: Could not load file template for 'definition for index big5 in index.json'

2026-02-02 19:21:11,809 ActorAddr-(T|:45055)/PID:867049 osbenchmark.actor INFO BenchmarkActor received unknown message [ActorExitRequest] (ignoring).
2026-02-02 19:21:14,810 -not-actor-/PID:866976 osbenchmark.benchmark INFO Attempting to shutdown internal actor system.
2026-02-02 19:21:14,811 -not-actor-/PID:867048 root INFO ActorSystem Logging Shutdown
2026-02-02 19:21:14,832 -not-actor-/PID:867047 root INFO ---- Actor System shutdown
2026-02-02 19:21:14,833 -not-actor-/PID:866976 osbenchmark.benchmark INFO Actor system is still running. Waiting...
2026-02-02 19:21:15,833 -not-actor-/PID:866976 osbenchmark.benchmark INFO Shutdown completed.
2026-02-02 19:21:15,834 -not-actor-/PID:866976 osbenchmark.benchmark ERROR Cannot run subcommand [run].
Traceback (most recent call last):
  File "/home/ec2-user/opensearch-benchmark/osbenchmark/benchmark.py", line 1245, in dispatch_sub_command
    run_test(cfg, args.kill_running_processes)
  File "/home/ec2-user/opensearch-benchmark/osbenchmark/benchmark.py", line 937, in run_test
    with_actor_system(test_run_orchestrator.run, cfg)
  File "/home/ec2-user/opensearch-benchmark/osbenchmark/benchmark.py", line 964, in with_actor_system
    runnable(cfg)
  File "/home/ec2-user/opensearch-benchmark/osbenchmark/test_run_orchestrator.py", line 395, in run
    raise e
  File "/home/ec2-user/opensearch-benchmark/osbenchmark/test_run_orchestrator.py", line 392, in run
    pipeline(cfg)
  File "/home/ec2-user/opensearch-benchmark/osbenchmark/test_run_orchestrator.py", line 69, in __call__
    self.target(cfg)
  File "/home/ec2-user/opensearch-benchmark/osbenchmark/test_run_orchestrator.py", line 328, in benchmark_only
    return run_test(cfg, external=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ec2-user/opensearch-benchmark/osbenchmark/test_run_orchestrator.py", line 287, in run_test
    raise exceptions.BenchmarkError(result.message, result.cause)
osbenchmark.exceptions.BenchmarkError: Error in test run orchestrator (Could not load file template for 'definition for index big5 in index.json')
```

### Issues Resolved
[List any issues this PR will resolve]

### Testing
- [x] New functionality includes testing

Tested by running big5 in test mode

### Backport to Branches:
- [ ] 6
- [ ] 7
- [ ] 1
- [ ] 2
- [x] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
