### PR TITLE
Fix grpc-index parsing error on http_logs info

### DIFF
--- a/common_operations/grpc_index_append.json
+++ b/common_operations/grpc_index_append.json
@@ -1,19 +1,11 @@
-{%- set version_parts = distribution_version.split('.') | map('int') | list %}
-{%- set min_version = "3.3.0".split('.') | map('int') | list %}
-{%- set max_version = "6.0.0".split('.') | map('int') | list %}
-
-{%- if version_parts >= min_version and version_parts < max_version or unknown_distribution is defined %}
-    {
-        "name": "grpc-index-append",
-        "operation": "grpc-index-append",
-        "warmup-time-period": {{ warmup_time_period | default(120) | tojson }},
-        "clients": {{bulk_indexing_clients | default(8)}},
-        "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
-    },
-    {
-        "name": "refresh-after-index",
-        "operation": "refresh"
-    }
-{% else %}
-    {% include 'error: Distribution version is ' ~ distribution_version ~ ' - gRPC is not supported in versions < 3.3.0' %}
-{% endif %}
+{
+    "name": "grpc-index-append",
+    "operation": "grpc-index-append",
+    "warmup-time-period": {{ warmup_time_period | default(120) | tojson }},
+    "clients": {{bulk_indexing_clients | default(8)}},
+    "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
+},
+{
+    "name": "refresh-after-index",
+    "operation": "refresh"
+}


### PR DESCRIPTION
### Description
`opensearch-benchmark info --workload=http_logs` produces a jinja error due to [`grpc_index_append.json` ](https://github.com/opensearch-project/opensearch-benchmark-workloads/commit/56acb80ae0df20feac394dd0b93fbf2614b7de8e#diff-88bbf0c5ddfe0e2086dfca231ce95918df00efb788ed8a97fbe3a9ff82832c8fR1-R5) which expects a `distribution_version`. When running benchmarks against a cluster distribution version is fetched from the cluster info directly, however the param remains unset in the case of "info".

This change removes the distribution version check in the http_logs workload. OpenSearch gRPC compatibility varies across versions and it will be better to track this in documentation instead of code. Opening an issue here for a version matrix for OSB: https://github.com/opensearch-project/opensearch-benchmark/issues/1009

### Issues Resolved
[[List any issues this PR will resolve]
](https://github.com/opensearch-project/opensearch-benchmark-workloads/issues/742#issuecomment-3815818121)

### Testing
- [x] New functionality includes testing

Testing with current main:
`opensearch-benchmark info --workload-path "<fork>/opensearch-benchmark-workloads/http_logs"`
```
[ERROR] ❌ Cannot info. Could not load '/Users/carrofin/fdev/repos/opensearch-benchmark-workloads/http_logs/workload.json'. The complete workload has been written to '/var/folders/zm/_3bfffj50_18hgvkb_qd4_s40000gq/T/tmpubm2vh6w.json' for diagnosis.

Suggestion: Verify that [http_logs] workload has correctly formatted JSON files and Jinja Templates. For Jinja2 errors, consider using a live Jinja2 parser. See common workload formatting errors:
    ---------------------------------------------------------------------------------------------------------------------------
    [Common workload formatting errors:]

    - Jinja2 expression missing parameters (e.g. got {{search_clients}} but needs {{search_clients | default(8)}})

    - Jinja2 expression missing "tojson" parameter when needed(e.g. got {{index_settings | default({})}} but needs {{index_settings | default({}) | tojson}})

    - JSON file might not be correctly formatted after rendering Jinja2 (e.g. additional brackets (}, ]) or missing commas (,))
    ---------------------------------------------------------------------------------------------------------------------------

	'distribution_version' is undefined

```


Testing with fix:
`opensearch-benchmark info --workload-path "<fork>/opensearch-benchmark-workloads/http_logs"`
```


   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/

Showing details for workload [http_logs]:

* Description: HTTP server log data
* Documents: 247,249,096
* Compressed Size: 1.2 GB
* Uncompressed Size: 31.1 GB

...

---------------------------------
[INFO] ✅ SUCCESS (took 1 seconds)
---------------------------------
```

Verifying http_logs benchmarks with fix:
```
opensearch-benchmark run --kill-running-processes \
    --pipeline=benchmark-only \
    --target-hosts=localhost:9200 \
    --workload-path "<fork>/opensearch-benchmark-workloads/http_logs" \
    --workload-params '{"number_of_shards":"5","number_of_replicas":"0", "ingest_percentage":"5.0"}'
```

```
   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/

[INFO] [Test Run ID]: 1efbf8df-63f1-4eab-a6b6-f9e3d8437b33
[INFO] Running test with workload [http_logs], test_procedure [append-no-conflicts] and cluster_config ['external'] with version [3.6.0-SNAPSHOT].

Running delete-index                                                           [100% done]

...

```

### Backport to Branches:
- [ ] 6
- [ ] 7
- [ ] 1
- [ ] 2
- [x] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
