### PR TITLE
 Fix: Handle false values for boolean parameters in FAISS index template

### DIFF
--- a/vectorsearch/indices/faiss-index.json
+++ b/vectorsearch/indices/faiss-index.json
@@ -2,8 +2,8 @@
     "settings": {
       "index": {
         "knn": true
-        {%- if memory_optimized_search_enabled is defined and memory_optimized_search_enabled %}
-        ,"knn.memory_optimized_search": true
+        {%- if memory_optimized_search_enabled is defined %}
+        ,"knn.memory_optimized_search": {{ memory_optimized_search_enabled | tojson }}
         {%- endif %}
         {%- if target_index_primary_shards is defined and target_index_primary_shards %}
         ,"number_of_shards": {{ target_index_primary_shards }}
@@ -11,11 +11,11 @@
         {%- if target_index_replica_shards is defined %}
         ,"number_of_replicas": {{ target_index_replica_shards }}
         {%- endif %}
-        {%- if derived_source_enabled is defined and derived_source_enabled %}
-        ,"knn.derived_source.enabled": true
+        {%- if derived_source_enabled is defined %}
+        ,"knn.derived_source.enabled": {{ derived_source_enabled | tojson }}
         {%- endif %}
-        {%- if remote_index_build_enabled is defined and remote_index_build_enabled %}
-        ,"knn.remote_index_build.enabled": true
+        {%- if remote_index_build_enabled is defined %}
+        ,"knn.remote_index_build.enabled": {{ remote_index_build_enabled | tojson }}
         {%- endif %}
         {%- if remote_index_build_enabled is defined and remote_index_build_enabled and remote_index_build_size_threshold is defined %}
         ,"knn.remote_index_build.size_threshold": "{{ remote_index_build_size_threshold }}"


### PR DESCRIPTION
### Description

Fix boolean parameter handling in FAISS index template to support both true and false values.

### Problem

The current template only checks if boolean parameters are defined and truthy , which means:
- false values are ignored and the setting is not applied
- Only true values work correctly

This affects the following KNN settings:
- knn.memory_optimized_search
- knn.derived_source.enabled
- knn.remote_index_build.enabled

Especially, this fix is essential because the default values for knn.remote_index_build.enabled and knn.derived_source.enabled are true.

### Solution

Changed the template logic to:
- Check only if the parameter is defined (is defined)
- Use tojson filter to properly serialize boolean values

This allows users to explicitly set these parameters to either true or false.

### Changes

- Updated vectorsearch/indices/faiss-index.json template conditions
- Modified 3 boolean parameter checks to handle both true and false values



### Testing

Verify that the following parameters work correctly with both values:
- memory_optimized_search_enabled: false
- derived_source_enabled: false
- remote_index_build_enabled: false


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
