### PR TITLE
[Backport to 3] Add faiss-sq-1bit.json schema for vector search. (#769)

### DIFF
--- a/vectorsearch/indices/faiss-sq-1bit-index.json
+++ b/vectorsearch/indices/faiss-sq-1bit-index.json
@@ -1,0 +1,53 @@
+{
+    "settings": {
+      "index": {
+        "knn": true
+        {%- if target_index_primary_shards is defined and target_index_primary_shards %}
+        ,"number_of_shards": {{ target_index_primary_shards }}
+        {%- endif %}
+        {%- if target_index_replica_shards is defined %}
+        ,"number_of_replicas": {{ target_index_replica_shards }}
+        {%- endif %}
+        {%- if derived_source_enabled is defined and derived_source_enabled %}
+        ,"knn.derived_source.enabled": true
+        {%- endif %}
+        {%- if remote_index_build_enabled is defined and remote_index_build_enabled %}
+        ,"knn.remote_index_build.enabled": true
+        {%- endif %}
+        {%- if remote_index_build_enabled is defined and remote_index_build_enabled and remote_index_build_size_threshold is defined %}
+        ,"knn.remote_index_build.size_threshold": "{{ remote_index_build_size_threshold }}"
+        {%- endif %}
+      }
+    },
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        {% if id_field_name is defined and id_field_name != "_id" %}
+          "{{id_field_name}}": {
+            "type": "keyword"
+          },
+        {%- endif %}
+        "{{ target_field_name }}": {
+          "type": "knn_vector",
+          "dimension": {{ target_index_dimension }},
+          "mode": "on_disk",
+          "compression_level": "32x",
+          "method": {
+            "name": "hnsw",
+            "space_type": "{{ target_index_space_type }}",
+            "engine": "faiss",
+            "parameters": {
+              "ef_search": {{ hnsw_ef_search }},
+              "ef_construction": {{ hnsw_ef_construction }},
+              "encoder": {
+                "name": "sq",
+                "parameters": {
+                  "bits": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }


### PR DESCRIPTION
(cherry picked from commit f7738e2e891dc9817f4aafd1782d33b3fbd037f5)

Backporting https://github.com/opensearch-project/opensearch-benchmark-workloads/pull/769 to 3