### PR TITLE
Add encoder parameter in method to support faiss bq.

### DIFF
--- a/vectorsearch/indices/faiss-index.json
+++ b/vectorsearch/indices/faiss-index.json
@@ -70,6 +70,11 @@
               {%- endif %}
                 "m": {{ hnsw_m }}
               {%- endif %}
+              {%- if encoder is defined and encoder %}
+                , "encoder": {
+                  "name": "{{ encoder }}"
+                }
+              {%- endif %}
             }
           }
           {%- endif %}


### PR DESCRIPTION
### Description
Since on_disk with 32x will pick Faiss sq by default, existing Faiss BQ nightly will be running on Faiss sq.
Therefore, we should introduce `encoder` parameter so that existing workflow can pick up Faiss bq instead of sq.

### Issues Resolved
N/A

### Testing
- [O] New functionality includes testing
```
➜  ~ curl http://internal-kdy-kill-test-5-1991248707.us-east-2.elb.amazonaws.com:9200/target_index/_mappings | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   302  100   302    0     0  39369      0 --:--:-- --:--:-- --:--:-- 43142
{
  "target_index": {
    "mappings": {
      "dynamic": "strict",
      "properties": {
        "target_field": {
          "type": "knn_vector",
          "dimension": 768,
          "method": {
            "engine": "faiss",
            "space_type": "innerproduct",
            "name": "hnsw",
            "parameters": {
              "ef_search": 256,
              "ef_construction": 256,
              "encoder": {
                "name": "binary",
                "parameters": {}
              }
            }
          },
          "mode": "on_disk"
        }
      }
    }
  }
}

➜  ~ ./run_indexing.sh

   ____                  _____                      __       ____                  __                         __
  / __ \____  ___  ____ / ___/___  ____ ___________/ /_     / __ )___  ____  _____/ /_  ____ ___  ____ ______/ /__
 / / / / __ \/ _ \/ __ \\__ \/ _ \/ __ `/ ___/ ___/ __ \   / __  / _ \/ __ \/ ___/ __ \/ __ `__ \/ __ `/ ___/ //_/
/ /_/ / /_/ /  __/ / / /__/ /  __/ /_/ / /  / /__/ / / /  / /_/ /  __/ / / / /__/ / / / / / / / / /_/ / /  / ,<
\____/ .___/\___/_/ /_/____/\___/\__,_/_/   \___/_/ /_/  /_____/\___/_/ /_/\___/_/ /_/_/ /_/ /_/\__,_/_/  /_/|_|
    /_/

[INFO] [Test Run ID]: 3234764c-1fb9-479e-b491-e90b867878ab
[INFO] Running test with workload [vectorsearch], test_procedure [no-train-test-index-only] and cluster_config ['external'] with version [3.6.0-SNAPSHOT].

Running delete-target-index                                                    [100% done]
Running create-target-index                                                    [100% done]
Running custom-vector-bulk                                                     [100% done]
Running refresh-target-index                                                   [100% done]

------------------------------------------------------
    _______             __   _____
   / ____(_)___  ____ _/ /  / ___/_________  ________
  / /_  / / __ \/ __ `/ /   \__ \/ ___/ __ \/ ___/ _ \
 / __/ / / / / / /_/ / /   ___/ / /__/ /_/ / /  /  __/
/_/   /_/_/ /_/\__,_/_/   /____/\___/\____/_/   \___/
------------------------------------------------------

Metric,Task,Value,Unit
Cumulative indexing time of primary shards,,12.18845,min
Min cumulative indexing time across primary shards,,2.35615,min
Median cumulative indexing time across primary shards,,2.441933333333333,min
...
```

[Describe how this change was tested]

### Backport to Branches:
- [O] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
