### PR TITLE
Adds _source:false in query body for vectors

### DIFF
--- a/vectorsearch/params/aoss/10million/faiss-cohere-768-dp.json
+++ b/vectorsearch/params/aoss/10million/faiss-cohere-768-dp.json
@@ -17,7 +17,8 @@
     "query_k": 100,
     "query_body": {
          "docvalue_fields" : ["id"],
-         "stored_fields" : "_none_"
+         "stored_fields" : "_none_",
+         "_source": false
     },
 
     "query_data_set_format": "hdf5",

--- a/vectorsearch/params/aoss/10million/nmslib-cohere-768-dp.json
+++ b/vectorsearch/params/aoss/10million/nmslib-cohere-768-dp.json
@@ -17,7 +17,8 @@
     "query_k": 100,
     "query_body": {
          "docvalue_fields" : ["id"],
-         "stored_fields" : "_none_"
+         "stored_fields" : "_none_",
+         "_source": false
     },
 
     "query_data_set_format": "hdf5",

--- a/vectorsearch/params/aoss/1million/faiss-cohere-768-dp.json
+++ b/vectorsearch/params/aoss/1million/faiss-cohere-768-dp.json
@@ -17,7 +17,8 @@
     "query_k": 100,
     "query_body": {
          "docvalue_fields" : ["id"],
-         "stored_fields" : "_none_"
+         "stored_fields" : "_none_",
+         "_source": false
     },
 
     "query_data_set_format": "hdf5",

--- a/vectorsearch/params/aoss/1million/nmslib-cohere-768-dp.json
+++ b/vectorsearch/params/aoss/1million/nmslib-cohere-768-dp.json
@@ -17,7 +17,8 @@
     "query_k": 100,
     "query_body": {
          "docvalue_fields" : ["id"],
-         "stored_fields" : "_none_"
+         "stored_fields" : "_none_",
+         "_source": false
     },
 
     "query_data_set_format": "hdf5",

--- a/vectorsearch/params/corpus/10million/faiss-cohere-768-disk-based-vector.json
+++ b/vectorsearch/params/corpus/10million/faiss-cohere-768-disk-based-vector.json
@@ -19,7 +19,8 @@
     "query_k": 100,
     "query_body": {
          "docvalue_fields" : ["_id"],
-         "stored_fields" : "_none_"
+         "stored_fields" : "_none_",
+         "_source": false
     },
 
     "query_data_set_format": "hdf5",

--- a/vectorsearch/params/corpus/10million/faiss-cohere-768-dp.json
+++ b/vectorsearch/params/corpus/10million/faiss-cohere-768-dp.json
@@ -20,7 +20,8 @@
     "query_k": 100,
     "query_body": {
          "docvalue_fields" : ["_id"],
-         "stored_fields" : "_none_"
+         "stored_fields" : "_none_",
+         "_source": false
     },
 
     "query_data_set_format": "hdf5",

--- a/vectorsearch/params/corpus/10million/lucene-cohere-768-dp.json
+++ b/vectorsearch/params/corpus/10million/lucene-cohere-768-dp.json
@@ -19,7 +19,8 @@
     "query_k": 100,
     "query_body": {
          "docvalue_fields" : ["_id"],
-         "stored_fields" : "_none_"
+         "stored_fields" : "_none_",
+         "_source": false
     },
 
     "query_data_set_format": "hdf5",

--- a/vectorsearch/params/corpus/10million/nmslib-cohere-768-dp.json
+++ b/vectorsearch/params/corpus/10million/nmslib-cohere-768-dp.json
@@ -19,7 +19,8 @@
     "query_k": 100,
     "query_body": {
          "docvalue_fields" : ["_id"],
-         "stored_fields" : "_none_"
+         "stored_fields" : "_none_",
+         "_source": false
     },
 
     "query_data_set_format": "hdf5",

--- a/vectorsearch/params/corpus/1million/faiss-cohere-768-dp.json
+++ b/vectorsearch/params/corpus/1million/faiss-cohere-768-dp.json
@@ -5,13 +5,12 @@
     "target_index_primary_shards": 3,
     "target_index_dimension": 768,
     "target_index_space_type": "innerproduct",
-    "approximate_graph_build_threshold": 0,
-    
+
     "target_index_bulk_size": 100,
     "target_index_bulk_index_data_set_format": "hdf5",
     "target_index_bulk_index_data_set_corpus": "cohere-1m",
     "target_index_bulk_indexing_clients": 10,
-    
+
     "target_index_max_num_segments": 1,
     "hnsw_ef_search": 256,
     "hnsw_ef_construction": 256,
@@ -19,7 +18,8 @@
     "query_k": 100,
     "query_body": {
          "docvalue_fields" : ["_id"],
-         "stored_fields" : "_none_"
+         "stored_fields" : "_none_",
+         "_source": false
     },
 
     "query_data_set_format": "hdf5",

--- a/vectorsearch/params/corpus/1million/lucene-cohere-768-dp.json
+++ b/vectorsearch/params/corpus/1million/lucene-cohere-768-dp.json
@@ -18,7 +18,8 @@
     "query_k": 100,
     "query_body": {
          "docvalue_fields" : ["_id"],
-         "stored_fields" : "_none_"
+         "stored_fields" : "_none_",
+         "_source": false
     },
 
     "query_data_set_format": "hdf5",

--- a/vectorsearch/params/corpus/1million/nmslib-cohere-768-dp.json
+++ b/vectorsearch/params/corpus/1million/nmslib-cohere-768-dp.json
@@ -18,7 +18,8 @@
     "query_k": 100,
     "query_body": {
          "docvalue_fields" : ["_id"],
-         "stored_fields" : "_none_"
+         "stored_fields" : "_none_",
+         "_source": false
     },
 
     "query_data_set_format": "hdf5",

--- a/vectorsearch/params/faiss-sift-128-l2.json
+++ b/vectorsearch/params/faiss-sift-128-l2.json
@@ -23,7 +23,8 @@
     "query_k": 100,
     "query_body": {
          "docvalue_fields" : ["_id"],
-         "stored_fields" : "_none_"
+         "stored_fields" : "_none_",
+         "_source": false
     },
 
     "query_data_set_format": "hdf5",

--- a/vectorsearch/params/filters/efficient/faiss-hnsw-relaxed.json
+++ b/vectorsearch/params/filters/efficient/faiss-hnsw-relaxed.json
@@ -22,7 +22,8 @@
     "query_k": 100,
     "query_body": {
          "docvalue_fields" : ["_id"],
-         "stored_fields" : "_none_"
+         "stored_fields" : "_none_",
+         "_source": false
     },
     "filter_type": "efficient",
     "filter_body": {

--- a/vectorsearch/params/filters/efficient/faiss-hnsw-restrictive.json
+++ b/vectorsearch/params/filters/efficient/faiss-hnsw-restrictive.json
@@ -22,7 +22,8 @@
     "query_k": 100,
     "query_body": {
         "docvalue_fields" : ["_id"],
-        "stored_fields" : "_none_"
+        "stored_fields" : "_none_",
+        "_source": false
     },
     "filter_type": "efficient",
     "filter_body": {

--- a/vectorsearch/params/filters/efficient/faiss-ivf-relaxed.json
+++ b/vectorsearch/params/filters/efficient/faiss-ivf-relaxed.json
@@ -36,7 +36,8 @@
     "query_k": 100,
     "query_body": {
          "docvalue_fields" : ["_id"],
-         "stored_fields" : "_none_"
+         "stored_fields" : "_none_",
+         "_source": false
     },
 
     "filter_type": "efficient",

--- a/vectorsearch/params/filters/efficient/faiss-ivf-restrictive.json
+++ b/vectorsearch/params/filters/efficient/faiss-ivf-restrictive.json
@@ -37,7 +37,8 @@
     "query_k": 100,
     "query_body": {
          "docvalue_fields" : ["_id"],
-         "stored_fields" : "_none_"
+         "stored_fields" : "_none_",
+         "_source": false
     },
     
     "filter_type": "efficient",

--- a/vectorsearch/params/filters/efficient/lucene-hnsw-relaxed.json
+++ b/vectorsearch/params/filters/efficient/lucene-hnsw-relaxed.json
@@ -21,7 +21,8 @@
     "query_k": 100,
     "query_body": {
          "docvalue_fields" : ["_id"],
-         "stored_fields" : "_none_"
+         "stored_fields" : "_none_",
+         "_source": false
     },
     "filter_type": "efficient",
     "filter_body": {

--- a/vectorsearch/params/filters/efficient/lucene-hnsw-restrictive.json
+++ b/vectorsearch/params/filters/efficient/lucene-hnsw-restrictive.json
@@ -21,7 +21,8 @@
     "query_k": 100,
     "query_body": {
          "docvalue_fields" : ["_id"],
-         "stored_fields" : "_none_"
+         "stored_fields" : "_none_",
+         "_source": false
     },
     "filter_type": "efficient",
     "filter_body": {

--- a/vectorsearch/params/filters/post/faiss-bool.json
+++ b/vectorsearch/params/filters/post/faiss-bool.json
@@ -23,7 +23,8 @@
     "query_k": 100,
     "query_body": {
          "docvalue_fields" : ["_id"],
-         "stored_fields" : "_none_"
+         "stored_fields" : "_none_",
+         "_source": false
     },
     "filter_type": "boolean",
     "filter_body": {

--- a/vectorsearch/params/filters/post/faiss-post-filter.json
+++ b/vectorsearch/params/filters/post/faiss-post-filter.json
@@ -22,7 +22,8 @@
     "query_k": 100,
     "query_body": {
          "docvalue_fields" : ["_id"],
-         "stored_fields" : "_none_"
+         "stored_fields" : "_none_",
+         "_source": false
     },
     "filter_type": "post_filter",
     "filter_body": {

--- a/vectorsearch/params/filters/script-filter.json
+++ b/vectorsearch/params/filters/script-filter.json
@@ -20,7 +20,8 @@
     "query_k": 100,
     "query_body": {
          "docvalue_fields" : ["_id"],
-         "stored_fields" : "_none_"
+         "stored_fields" : "_none_",
+         "_source": false
     },
     "filter_type": "script",
     "filter_body": {

--- a/vectorsearch/params/lucene-sift-128-l2.json
+++ b/vectorsearch/params/lucene-sift-128-l2.json
@@ -19,7 +19,8 @@
     "query_k": 100,
     "query_body": {
          "docvalue_fields" : ["_id"],
-         "stored_fields" : "_none_"
+         "stored_fields" : "_none_",
+         "_source": false
     },
 
     "query_data_set_format": "hdf5",

--- a/vectorsearch/params/nested/nested-faiss.json
+++ b/vectorsearch/params/nested/nested-faiss.json
@@ -14,7 +14,8 @@
     "query_k": 5,
     "query_body": {
          "docvalue_fields" : ["_id"],
-         "stored_fields" : "_none_"
+         "stored_fields" : "_none_",
+         "_source": false
     },
 
     "query_data_set_format": "hdf5",

--- a/vectorsearch/params/nested/nested-lucene.json
+++ b/vectorsearch/params/nested/nested-lucene.json
@@ -14,7 +14,8 @@
     "query_k": 5,
     "query_body": {
          "docvalue_fields" : ["_id"],
-         "stored_fields" : "_none_"
+         "stored_fields" : "_none_",
+         "_source": false
     },
 
     "query_data_set_format": "hdf5",

--- a/vectorsearch/params/nested/nested-nmslib.json
+++ b/vectorsearch/params/nested/nested-nmslib.json
@@ -14,7 +14,8 @@
     "query_k": 5,
     "query_body": {
          "docvalue_fields" : ["_id"],
-         "stored_fields" : "_none_"
+         "stored_fields" : "_none_",
+         "_source": false
     },
 
     "query_data_set_format": "hdf5",

--- a/vectorsearch/params/nmslib-sift-128-l2.json
+++ b/vectorsearch/params/nmslib-sift-128-l2.json
@@ -19,7 +19,8 @@
     "query_k": 100,
     "query_body": {
          "docvalue_fields" : ["_id"],
-         "stored_fields" : "_none_"
+         "stored_fields" : "_none_",
+         "_source": false
     },
 
     "query_data_set_format": "hdf5",

--- a/vectorsearch/params/radial_search/faiss-hnsw-cohere-768-1m-inner-product.json
+++ b/vectorsearch/params/radial_search/faiss-hnsw-cohere-768-1m-inner-product.json
@@ -19,7 +19,8 @@
     "query_max_distance": -160.0,
     "query_body": {
          "docvalue_fields" : ["_id"],
-         "stored_fields" : "_none_"
+         "stored_fields" : "_none_",
+         "_source": false
     },
 
     "query_data_set_format": "hdf5",

--- a/vectorsearch/params/radial_search/lucene-hnsw-cohere-768-1m-inner-product.json
+++ b/vectorsearch/params/radial_search/lucene-hnsw-cohere-768-1m-inner-product.json
@@ -20,7 +20,8 @@
 
     "query_body": {
          "docvalue_fields" : ["_id"],
-         "stored_fields" : "_none_"
+         "stored_fields" : "_none_",
+         "_source": false
     },
 
     "query_data_set_format": "hdf5",

--- a/vectorsearch/params/train/train-faiss-sift-128-hnsw-pq.json
+++ b/vectorsearch/params/train/train-faiss-sift-128-hnsw-pq.json
@@ -41,7 +41,8 @@
     "query_k": 100,
     "query_body": {
          "docvalue_fields" : ["_id"],
-         "stored_fields" : "_none_"
+         "stored_fields" : "_none_",
+         "_source": false
     },
 
     "query_data_set_format": "hdf5",

--- a/vectorsearch/params/train/train-faiss-sift-128-l2-pq.json
+++ b/vectorsearch/params/train/train-faiss-sift-128-l2-pq.json
@@ -40,7 +40,8 @@
     "query_k": 100,
     "query_body": {
          "docvalue_fields" : ["_id"],
-         "stored_fields" : "_none_"
+         "stored_fields" : "_none_",
+         "_source": false
     },
 
     "query_data_set_format": "hdf5",

--- a/vectorsearch/params/train/train-faiss-sift-128-l2-sq.json
+++ b/vectorsearch/params/train/train-faiss-sift-128-l2-sq.json
@@ -40,7 +40,8 @@
     "query_k": 100,
     "query_body": {
          "docvalue_fields" : ["_id"],
-         "stored_fields" : "_none_"
+         "stored_fields" : "_none_",
+         "_source": false
     },
 
     "query_data_set_format": "hdf5",

--- a/vectorsearch/params/train/train-faiss-sift-128-l2.json
+++ b/vectorsearch/params/train/train-faiss-sift-128-l2.json
@@ -37,7 +37,8 @@
     "query_k": 100,
     "query_body": {
          "docvalue_fields" : ["_id"],
-         "stored_fields" : "_none_"
+         "stored_fields" : "_none_",
+         "_source": false
     },
 
     "query_data_set_format": "hdf5",


### PR DESCRIPTION
Plan is to remove defaulting to _source:false from request_params. request_params overrides query body making it difficult to have _source values for benchmarking


### Testing
- [ ] New functionality includes testing

[Describe how this change was tested]

### Backport to Branches:
- [ ] 6
- [ ] 7
- [ ] 1
- [ ] 2
- [ ] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
