### PR TITLE
Add rescore support

### DIFF
--- a/vectorsearch/README.md
+++ b/vectorsearch/README.md
@@ -114,6 +114,9 @@ This workload allows the following parameters to be specified using `--workload-
 | remote_index_build_size_threshold       | If remote_index_build_enabled, indicates the size threshold above which remote vector builds will be enabled (default 50mb)          |
 | memory_optimized_search_enabled         | Whether to enable memory optimized search on the index. (default false, pass in either true or fals)                                 |
 | knn_prefetch_enabled                    | Enable disable the prefetch based on the value. (default is false)                                                                   |
+| mode                                    | Vector workload index mode. Set to `on_disk` to enable disk-based features like rescoring with `oversample_factor`. |
+| compression_level                       | Compression level for disk-based vector indices. Use with `mode=on_disk`. |
+| oversample_factor                       | Oversample factor for rescoring in disk-based vector search. Retrieves (k × oversample_factor) candidates and rescores to return top k results. Higher values typically improve recall but may affect latency; optimal value depends on dataset characteristics. Applicable only when `mode=on_disk`. |
 
 
 

--- a/vectorsearch/indices/lucene-index.json
+++ b/vectorsearch/indices/lucene-index.json
@@ -32,6 +32,12 @@
         "{{ target_field_name }}": {
           "type": "knn_vector",
           "dimension": {{ target_index_dimension }},
+          {%- if mode is defined %}
+          "mode": "{{ mode }}",
+          {%- endif %}
+          {%- if compression_level is defined %}
+          "compression_level": "{{ compression_level }}",
+          {%- endif %}
           "method": {
             "name": "hnsw",
             "space_type": "{{ target_index_space_type }}",

--- a/vectorsearch/params/rescore/faiss-cohere-768.json
+++ b/vectorsearch/params/rescore/faiss-cohere-768.json
@@ -1,0 +1,31 @@
+{
+    "target_index_name": "target_index",
+    "target_field_name": "target_field",
+    "target_index_body": "indices/faiss-index.json",
+    "target_index_primary_shards": 3,
+    "target_index_dimension": 768,
+    "target_index_space_type": "innerproduct",
+    "mode": "on_disk",
+    "compression_level": "32x",
+    "approximate_graph_build_threshold": 0,
+
+    "target_index_bulk_size": 100,
+    "target_index_bulk_index_data_set_format": "hdf5",
+    "target_index_bulk_index_data_set_corpus": "cohere-1m",
+    "target_index_bulk_indexing_clients": 10,
+
+    "target_index_max_num_segments": 1,
+    "hnsw_ef_search": 256,
+    "hnsw_ef_construction": 256,
+
+    "query_k": 100,
+    "query_body": {
+         "docvalue_fields" : ["_id"],
+         "stored_fields" : "_none_"
+    },
+
+    "query_data_set_format": "hdf5",
+    "query_data_set_corpus": "cohere-1m",
+    "query_count": 10000,
+    "oversample_factor": 2.0
+}

--- a/vectorsearch/params/rescore/lucene-cohere-768.json
+++ b/vectorsearch/params/rescore/lucene-cohere-768.json
@@ -1,0 +1,30 @@
+{
+    "target_index_name": "target_index",
+    "target_field_name": "target_field",
+    "target_index_body": "indices/lucene-index.json",
+    "target_index_primary_shards": 3,
+    "target_index_dimension": 768,
+    "target_index_space_type": "innerproduct",
+    "mode": "on_disk",
+    "compression_level": "32x",
+
+    "target_index_bulk_size": 100,
+    "target_index_bulk_index_data_set_format": "hdf5",
+    "target_index_bulk_index_data_set_corpus": "cohere-1m",
+    "target_index_bulk_indexing_clients": 10,
+
+    "target_index_max_num_segments": 1,
+    "hnsw_ef_search": 256,
+    "hnsw_ef_construction": 256,
+
+    "query_k": 100,
+    "query_body": {
+         "docvalue_fields" : ["_id"],
+         "stored_fields" : "_none_"
+    },
+
+    "query_data_set_format": "hdf5",
+    "query_data_set_corpus": "cohere-1m",
+    "query_count": 10000,
+    "oversample_factor": 2.0
+}

--- a/vectorsearch/test_procedures/common/search-only-schedule.json
+++ b/vectorsearch/test_procedures/common/search-only-schedule.json
@@ -27,6 +27,9 @@
         "neighbors_data_set_format" : "{{ neighbors_data_set_format | default('hdf5') }}",
         "num_vectors" : {{ query_count | default(-1) }},
         "id-field-name": "{{ id_field_name }}",
+        {% if oversample_factor is defined %}
+        "oversample_factor": {{ oversample_factor }},
+        {% endif %}
         "body": {{ query_body | default ({}) | tojson }},
         "filter_body": {{ filter_body | default ({}) | tojson }},
         "filter_type": {{filter_type  | default ({}) | tojson }},


### PR DESCRIPTION
  ### Description                                                                                                          
  This PR implements the `oversample_factor` parameter for vector search rescoring in the opensearch-benchmark vectorsearch workload.                                                                                                               
                                                                                                                           
  **Changes:**                                                                                                             
  - Registered oversample_factor in search-only-schedule.json                                                    
  - Added optional mode and compression_level conditionals to lucene-index.json 
  - Created param files for Lucene and Faiss rescore benchmarks                                                              
  - Updated README.md with parameter documentation   
  
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
