### PR TITLE
Add gRPC and CBOR workload operations for http_logs and vectorsearch

### DIFF
--- a/http_logs/operations/default.json
+++ b/http_logs/operations/default.json
@@ -13,6 +13,14 @@
       "corpora": "http_logs"
     },
     {
+      "name": "grpc-cbor-index-append",
+      "operation-type": "proto-bulk",
+      "bulk-size": {{bulk_size | default(5000)}},
+      "ingest-percentage": {{ingest_percentage | default(100)}},
+      "document-format": "cbor",
+      "corpora": "http_logs"
+    },
+    {
       "name": "index-append-with-ingest-baseline-pipeline",
       "operation-type": "bulk",
       "bulk-size": {{bulk_size | default(5000)}},

--- a/vectorsearch/operations/default.json
+++ b/vectorsearch/operations/default.json
@@ -38,4 +38,31 @@
     }
   },
   "include-in-reporting": true
+},
+{
+    "name": "grpc-vector-bulk",
+    "operation-type": "proto-bulk-vector-data-set",
+    "index": "{{ target_index_name | default('target_index') }}",
+    "field": "{{ target_field_name | default('target_field') }}",
+    "bulk_size": {{ target_index_bulk_size | default(500)}},
+    "data_set_format": "{{ target_index_bulk_index_data_set_format | default('hdf5') }}",
+    "data_set_path": "{{ target_index_bulk_index_data_set_path  }}",
+    "data_set_corpus": "{{ target_index_bulk_index_data_set_corpus  }}",
+    "num_vectors": {{ target_index_num_vectors | default(-1) }},
+    "id-field-name": "{{ id_field_name }}",
+    "filter_attributes": {{ target_dataset_filter_attributes | default([]) | tojson }}
+},
+{
+    "name": "grpc-cbor-vector-bulk",
+    "operation-type": "proto-bulk-vector-data-set",
+    "index": "{{ target_index_name | default('target_index') }}",
+    "field": "{{ target_field_name | default('target_field') }}",
+    "bulk_size": {{ target_index_bulk_size | default(500)}},
+    "data_set_format": "{{ target_index_bulk_index_data_set_format | default('hdf5') }}",
+    "data_set_path": "{{ target_index_bulk_index_data_set_path  }}",
+    "data_set_corpus": "{{ target_index_bulk_index_data_set_corpus  }}",
+    "num_vectors": {{ target_index_num_vectors | default(-1) }},
+    "id-field-name": "{{ id_field_name }}",
+    "filter_attributes": {{ target_dataset_filter_attributes | default([]) | tojson }},
+    "document-format": "cbor"
 }

--- a/vectorsearch/test_procedures/default.json
+++ b/vectorsearch/test_procedures/default.json
@@ -176,4 +176,64 @@
        {{ benchmark.collect(parts="common/update-prefetch-schedule.json") }},
        {{ benchmark.collect(parts="common/random-search-only-schedule.json") }}
     ]
+},
+{
+    "name": "grpc-no-train-test-index-only",
+    "description": "Vector index-only via gRPC with JSON documents",
+    "default": false,
+    "schedule": [
+        {
+          "operation": {
+            "name": "delete-target-index",
+            "operation-type": "delete-index",
+            "only-if-exists": true,
+            "index": "{{ target_index_name | default('target_index') }}"
+          }
+        },
+        {
+          "operation": {
+            "name": "create-target-index",
+            "operation-type": "create-index",
+            "index": "{{ target_index_name | default('target_index') }}"
+          }
+        },
+        {
+          "operation": "grpc-vector-bulk",
+          "clients": {{ target_index_bulk_indexing_clients | default(1)}}
+        },
+        {
+          "name": "refresh-target-index",
+          "operation": "refresh-target-index"
+        }
+    ]
+},
+{
+    "name": "grpc-cbor-no-train-test-index-only",
+    "description": "Vector index-only via gRPC with CBOR documents",
+    "default": false,
+    "schedule": [
+        {
+          "operation": {
+            "name": "delete-target-index",
+            "operation-type": "delete-index",
+            "only-if-exists": true,
+            "index": "{{ target_index_name | default('target_index') }}"
+          }
+        },
+        {
+          "operation": {
+            "name": "create-target-index",
+            "operation-type": "create-index",
+            "index": "{{ target_index_name | default('target_index') }}"
+          }
+        },
+        {
+          "operation": "grpc-cbor-vector-bulk",
+          "clients": {{ target_index_bulk_indexing_clients | default(1)}}
+        },
+        {
+          "name": "refresh-target-index",
+          "operation": "refresh-target-index"
+        }
+    ]
 }


### PR DESCRIPTION
### Description

http_logs:
- Add grpc-cbor-index-append operation (proto-bulk with document-format=cbor)

vectorsearch:
- Add grpc-vector-bulk operation (proto-bulk-vector-data-set, JSON)
- Add grpc-cbor-vector-bulk operation (proto-bulk-vector-data-set, CBOR)
- Add grpc-no-train-test-index-only test procedure
- Add grpc-cbor-no-train-test-index-only test procedure

These operations require opensearch-benchmark with CBOR support (feature/cbor-document-format branch) and a gRPC-enabled cluster.

### Issues Resolved
N/A

### Testing


### Backport to Branches:
- [ ] 6
- [ ] 7
- [x] 1
- [x] 2
- [x] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
