### PR TITLE
Add optional DataFusion/parquet index settings to clickbench

### DIFF
--- a/clickbench/index.json
+++ b/clickbench/index.json
@@ -9,6 +9,12 @@
     "index.translog.durability": {{index_translog_durability | default("async") | tojson}},
     "index.sort.field": [ "CounterID", "EventDate", "UserID", "EventTime", "WatchID" ],
     "index.sort.order": [ "desc", "desc", "desc", "desc", "desc" ]
+    {%- if parquet_enabled_index is defined and parquet_enabled_index %}
+    ,"index.pluggable.dataformat.enabled": true
+    ,"index.pluggable.dataformat": "composite"
+    ,"index.composite.primary_data_format": "parquet"
+    ,"index.composite.secondary_data_formats": ["lucene"]
+    {%- endif %}
   },
   "mappings": {
     "dynamic": "false",


### PR DESCRIPTION
## Summary
Adds conditional DataFusion index settings to `clickbench/index.json`. When `parquet_enabled_index=true` is passed as a workload param, the index is created with composite parquet+lucene dataformat.

## Usage
```bash
opensearch-benchmark run \
  --workload=clickbench \
  --workload-params='{"parquet_enabled_index":true,"number_of_shards":1,"number_of_replicas":0}'
```

This removes the need to manually apply `cluster.pluggable.dataformat` settings before index creation for DataFusion benchmark runs.

## Changes
- `clickbench/index.json`: Added Jinja conditional block for `parquet_enabled_index` param

No impact on existing runs (param is optional, disabled by default).