### PR TITLE
Add PPL legacy syntax setting to clickbench schedules

### DIFF
--- a/clickbench/test_procedures/ppl/clickbench-schedule.json
+++ b/clickbench/test_procedures/ppl/clickbench-schedule.json
@@ -1,4 +1,14 @@
 {
+  "operation": {
+    "operation-type": "put-settings",
+    "body": {
+      "transient": {
+        "plugins.ppl.syntax.legacy.preferred": "{{legacy_syntax | default("false")}}"
+      }
+    }
+  }
+},
+{
   "operation": "q01-count-all",
   "warmup-iterations": {{ q01_count_all_warmup_iterations or warmup_iterations | default(100) | tojson }},
   "iterations": {{ q01_count_all_iterations or test_iterations | default(100) | tojson }},

--- a/clickbench/test_procedures/ppl/mustang-clickbench-schedule.json
+++ b/clickbench/test_procedures/ppl/mustang-clickbench-schedule.json
@@ -1,4 +1,14 @@
 {
+  "operation": {
+    "operation-type": "put-settings",
+    "body": {
+      "transient": {
+        "plugins.ppl.syntax.legacy.preferred": "{{legacy_syntax | default("false")}}"
+      }
+    }
+  }
+},
+{
   "operation": "q01-count-all",
   "warmup-iterations": {{ q01_count_all_warmup_iterations or warmup_iterations | default(100) | tojson }},
   "iterations": {{ q01_count_all_iterations or test_iterations | default(100) | tojson }},


### PR DESCRIPTION
Adds a put-settings operation at the top of clickbench-schedule.json and mustang-clickbench-schedule.json to set `plugins.ppl.syntax.legacy.preferred`. Defaults to false, configurable via `legacy_syntax` workload param.