### PR TITLE
Adding lucene-1bit index and flat index.

### DIFF
--- a/vectorsearch/indices/flat-index.json
+++ b/vectorsearch/indices/flat-index.json
@@ -31,17 +31,12 @@
           "type": "knn_vector",
           "dimension": {{ target_index_dimension | default(768) }},
           "mode": "on_disk",
-          "compression_level": "32x",
           "method": {
             "name": "hnsw",
             "space_type": "{{ target_index_space_type }}",
-            "engine": "lucene",
             "parameters": {
               "encoder": {
-                "name": "sq",
-                "parameters": {
-                  "bits": 1
-                }
+                "name": "flat"
               }
             }
           }

--- a/vectorsearch/indices/lucene-sq-1bit-index.json
+++ b/vectorsearch/indices/lucene-sq-1bit-index.json
@@ -1,0 +1,51 @@
+{
+    "settings": {
+      "index": {
+        "knn": true
+        {%- if target_index_primary_shards is defined and target_index_primary_shards %}
+        ,"number_of_shards": {{ target_index_primary_shards }}
+        {%- endif %}
+        {%- if target_index_replica_shards is defined %}
+        ,"number_of_replicas": {{ target_index_replica_shards }}
+        {%- endif %}
+        {%- if derived_source_enabled is defined and derived_source_enabled %}
+        ,"knn.derived_source.enabled": true
+        {%- endif %}
+        {%- if remote_index_build_enabled is defined and remote_index_build_enabled %}
+        ,"knn.remote_index_build.enabled": true
+        {%- endif %}
+        {%- if remote_index_build_enabled is defined and remote_index_build_enabled and remote_index_build_size_threshold is defined %}
+        ,"knn.remote_index_build.size_threshold": "{{ remote_index_build_size_threshold }}"
+        {%- endif %}
+      }
+    },
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        {% if id_field_name is defined and id_field_name != "_id" %}
+          "{{id_field_name}}": {
+            "type": "keyword"
+          },
+        {%- endif %}
+        "{{ target_field_name }}": {
+          "type": "knn_vector",
+          "dimension": {{ target_index_dimension }},
+          "mode": "on_disk",
+          "compression_level": "32x",
+          "method": {
+            "name": "hnsw",
+            "space_type": "{{ target_index_space_type }}",
+            "engine": "lucene",
+            "parameters": {
+              "encoder": {
+                "name": "sq",
+                "parameters": {
+                  "bits": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }


### PR DESCRIPTION
### Description
Adding two index schemas.
1. Lucene SQ 1bit
2. Flat

Will follow up on consolidating all schemas into a single file to improve scalability.

### Issues Resolved
N/A

### Testing
- [O] New functionality includes testing

[Describe how this change was tested]

### Backport to Branches:
- [O] 3

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
