### PR TITLE
Reduce radial search default size from 10000 to 100

### DIFF
--- a/vectorsearch/_tools/generate_radial_ground_truth.py
+++ b/vectorsearch/_tools/generate_radial_ground_truth.py
@@ -166,16 +166,14 @@ def generate_ground_truth(input_path, output_path, space_type, threshold, max_le
             for key in copied_keys:
                 f_in.copy(key, f_out)
 
-        f_out.create_dataset("max_distance_neighbors", data=padded_data)
-        f_out.create_dataset("min_score_neighbors", data=padded_data)
+        f_out.create_dataset("radial_neighbors", data=padded_data)
 
         f_out.attrs["max_distance_threshold"] = threshold
         f_out.attrs["min_score_threshold"] = score_threshold
         f_out.attrs["space_type"] = space_type
 
         print(f"\nWrote to {output_path}:")
-        print(f"  - max_distance_neighbors (threshold: {threshold})")
-        print(f"  - min_score_neighbors (threshold: {score_threshold})")
+        print(f"  - radial_neighbors (max_distance: {threshold}, min_score: {score_threshold})")
         print(f"  - Copied: {copied_keys}")
 
 

--- a/vectorsearch/params/radial_search/faiss-hnsw-cohere-768-1m-inner-product.json
+++ b/vectorsearch/params/radial_search/faiss-hnsw-cohere-768-1m-inner-product.json
@@ -18,7 +18,7 @@
     "target_index_num_vectors": 1000000,
     "query_max_distance": "<your-threshold>",
     "query_body": {
-         "size": 10000,
+         "size": 100,
          "docvalue_fields" : ["_id"],
          "stored_fields" : "_none_",
          "_source": false

--- a/vectorsearch/params/radial_search/lucene-hnsw-cohere-768-1m-inner-product.json
+++ b/vectorsearch/params/radial_search/lucene-hnsw-cohere-768-1m-inner-product.json
@@ -19,7 +19,7 @@
     "query_max_distance": "<your-threshold>",
 
     "query_body": {
-         "size": 10000,
+         "size": 100,
          "docvalue_fields" : ["_id"],
          "stored_fields" : "_none_",
          "_source": false


### PR DESCRIPTION
### Description

 - Follow-up to PR #791. Per reviewer @shatejas feedback, reduce size in radial search template param files from 10000 to 100.
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
