### PR TITLE
[Backport 3] Add gRPC and CBOR workload operations for http_logs and vectorsearch

### DIFF
--- a/http_logs/operations/default.json
+++ b/http_logs/operations/default.json
@@ -13,6 +13,14 @@
       "corpora": "http_logs"
     },
     {
+      "name": "grpc-cbor-index-append",
+      "operation-type": "proto-bulk",
+      "bulk-size": {{bulk_size | default(5000)}},
+      "ingest-percentage": {{ingest_percentage | default(100)}},
+      "document-format": "cbor",
+      "corpora": "http_logs"
+    },
+    {
       "name": "index-append-with-ingest-baseline-pipeline",
       "operation-type": "bulk",
       "bulk-size": {{bulk_size | default(5000)}},

--- a/vectorsearch/operations/default.json
+++ b/vectorsearch/operations/default.json
@@ -38,4 +38,31 @@
     }
   },
   "include-in-reporting": true
+},
+{
+    "name": "grpc-vector-bulk",
+    "operation-type": "proto-bulk-vector-data-set",
+    "index": "{{ target_index_name | default('target_index') }}",
+    "field": "{{ target_field_name | default('target_field') }}",
+    "bulk_size": {{ target_index_bulk_size | default(500)}},
+    "data_set_format": "{{ target_index_bulk_index_data_set_format | default('hdf5') }}",
+    "data_set_path": "{{ target_index_bulk_index_data_set_path  }}",
+    "data_set_corpus": "{{ target_index_bulk_index_data_set_corpus  }}",
+    "num_vectors": {{ target_index_num_vectors | default(-1) }},
+    "id-field-name": "{{ id_field_name }}",
+    "filter_attributes": {{ target_dataset_filter_attributes | default([]) | tojson }}
+},
+{
+    "name": "grpc-cbor-vector-bulk",
+    "operation-type": "proto-bulk-vector-data-set",
+    "index": "{{ target_index_name | default('target_index') }}",
+    "field": "{{ target_field_name | default('target_field') }}",
+    "bulk_size": {{ target_index_bulk_size | default(500)}},
+    "data_set_format": "{{ target_index_bulk_index_data_set_format | default('hdf5') }}",
+    "data_set_path": "{{ target_index_bulk_index_data_set_path  }}",
+    "data_set_corpus": "{{ target_index_bulk_index_data_set_corpus  }}",
+    "num_vectors": {{ target_index_num_vectors | default(-1) }},
+    "id-field-name": "{{ id_field_name }}",
+    "filter_attributes": {{ target_dataset_filter_attributes | default([]) | tojson }},
+    "document-format": "cbor"
 }

--- a/vectorsearch/test_procedures/default.json
+++ b/vectorsearch/test_procedures/default.json
@@ -176,4 +176,64 @@
        {{ benchmark.collect(parts="common/update-prefetch-schedule.json") }},
        {{ benchmark.collect(parts="common/random-search-only-schedule.json") }}
     ]
+},
+{
+    "name": "grpc-no-train-test-index-only",
+    "description": "Vector index-only via gRPC with JSON documents",
+    "default": false,
+    "schedule": [
+        {
+          "operation": {
+            "name": "delete-target-index",
+            "operation-type": "delete-index",
+            "only-if-exists": true,
+            "index": "{{ target_index_name | default('target_index') }}"
+          }
+        },
+        {
+          "operation": {
+            "name": "create-target-index",
+            "operation-type": "create-index",
+            "index": "{{ target_index_name | default('target_index') }}"
+          }
+        },
+        {
+          "operation": "grpc-vector-bulk",
+          "clients": {{ target_index_bulk_indexing_clients | default(1)}}
+        },
+        {
+          "name": "refresh-target-index",
+          "operation": "refresh-target-index"
+        }
+    ]
+},
+{
+    "name": "grpc-cbor-no-train-test-index-only",
+    "description": "Vector index-only via gRPC with CBOR documents",
+    "default": false,
+    "schedule": [
+        {
+          "operation": {
+            "name": "delete-target-index",
+            "operation-type": "delete-index",
+            "only-if-exists": true,
+            "index": "{{ target_index_name | default('target_index') }}"
+          }
+        },
+        {
+          "operation": {
+            "name": "create-target-index",
+            "operation-type": "create-index",
+            "index": "{{ target_index_name | default('target_index') }}"
+          }
+        },
+        {
+          "operation": "grpc-cbor-vector-bulk",
+          "clients": {{ target_index_bulk_indexing_clients | default(1)}}
+        },
+        {
+          "name": "refresh-target-index",
+          "operation": "refresh-target-index"
+        }
+    ]
 }


### PR DESCRIPTION
Backport of #785 to branch 3.

**Changes:**
- http_logs: Add grpc-index-append and grpc-cbor-index-append operations
- vectorsearch: Add grpc-vector-bulk and grpc-cbor-vector-bulk operations
- vectorsearch: Add grpc-no-train-test-index-only and grpc-cbor-no-train-test-index-only test procedures

**Excluded from backport** (not present in 3.x):
- update-cluster-settings-for-knn-prefetch operation
- random-vector-* test procedures
- prefetch-related test procedures

**Testing:**
- Verified no conflict markers remain
- Operations and test procedures structurally valid

Signed-off-by: Finn Carroll <carrofin@amazon.com>