### PR TITLE
big5: gate parquet/composite index settings behind parquet_enabled_index

### DIFF
--- a/.github/workflows/workload-test.yml
+++ b/.github/workflows/workload-test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python3 -m pip install pandas
+          python3 -m pip install pandas scikit-learn
 
       - name: Install opensearch-benchmark
         run: pip install opensearch-benchmark

--- a/big5/index.json
+++ b/big5/index.json
@@ -27,6 +27,11 @@
     "index.query.default_field": [
       "message"
     ]
+    {%- if parquet_enabled_index is defined and parquet_enabled_index %}
+    ,"index.pluggable.dataformat.enabled": true
+    ,"index.pluggable.dataformat": "composite"
+    ,"index.composite.primary_data_format": "parquet"
+    {%- endif %}
   },
   "mappings": {
     {% if distribution_version.split('.') | map('int') | list  < "6.0.0".split('.') | map('int') | list %}


### PR DESCRIPTION
## Summary

Mirrors the same opt-in pattern already in [`clickbench/index.json`](https://github.com/opensearch-project/opensearch-benchmark-workloads/blob/main/clickbench/index.json#L9-L14) — adding the parquet/composite index settings to `big5/index.json`, gated behind a `parquet_enabled_index` workload param. Off by default so existing big5 runs are unaffected.

When opted in, big5 indices get:
- \`index.pluggable.dataformat.enabled = true\`
- \`index.pluggable.dataformat = composite\`
- \`index.composite.primary_data_format = parquet\`

## Why

We're testing the analytics/DataFusion engine ([Mustang](https://opensearch.org/blog/introducing-the-opensearch-3-2-launch/)) on big5 in addition to clickbench. Without these settings, big5 indices fall back to the row-store path, so the analytics query engine can't read them. Currently we have to fork the index file or drop the settings via `_template` after-the-fact — adding the same gated pattern that already exists for clickbench keeps the workload self-contained.

## How to use

```bash
opensearch-benchmark run --workload=big5 \
  --workload-params='{"parquet_enabled_index":true,...}' ...
```

## Test plan

- [x] Renders to valid JSON with \`parquet_enabled_index=True\` (3 settings present)
- [x] Renders to valid JSON without the flag (no parquet keys, byte-identical to current behavior)
- [ ] Smoke test: ingest into big5 with the flag, verify shard files are composite