### PR TITLE
Add cohere-10m-radial corpus for radial search nightly benchmarks

### DIFF
--- a/vectorsearch/workload.json
+++ b/vectorsearch/workload.json
@@ -63,6 +63,17 @@
       ]
     },
     {
+      "name": "cohere-10m-radial",
+      "base-url": "https://dbyiw3u3rf9yr.cloudfront.net/corpora/vectorsearch/cohere-wikipedia-22-12-en-embeddings",
+      "documents": [
+        {
+          "source-file": "cohere-10m-radial.hdf5.bz2",
+          "source-format": "hdf5",
+          "document-count": 10000000
+        }
+      ]
+    },
+    {
       "name": "cohere-nested",
       "base-url": "https://dbyiw3u3rf9yr.cloudfront.net/corpora/vectorsearch/cohere-wikipedia-22-12-en-embeddings",
       "target-index": "{{ target_index_name }}",

--- a/vectorsearch/workload.json
+++ b/vectorsearch/workload.json
@@ -65,6 +65,7 @@
     {
       "name": "cohere-10m-radial",
       "base-url": "https://dbyiw3u3rf9yr.cloudfront.net/corpora/vectorsearch/cohere-wikipedia-22-12-en-embeddings",
+      "target-index": "{{ target_index_name }}",
       "documents": [
         {
           "source-file": "cohere-10m-radial.hdf5.bz2",


### PR DESCRIPTION
### Description
- Register cohere-10m-radial corpus in workload.json for radial search nightly benchmarks
- Contains query vectors (10K) and radial ground truth neighbors for Cohere 10M inner product dataset
- Used as query_data_set_corpus and neighbors_data_set_corpus (indexing uses existing cohere-10m corpus)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
