### PR TITLE
Add cohere-nested-uniform corpus for nested vector nightly benchmarks

### DIFF
--- a/vectorsearch/workload.json
+++ b/vectorsearch/workload.json
@@ -87,6 +87,18 @@
       ]
     },
     {
+      "name": "cohere-nested-uniform",
+      "base-url": "https://dbyiw3u3rf9yr.cloudfront.net/corpora/vectorsearch/cohere-wikipedia-22-12-en-embeddings",
+      "target-index": "{{ target_index_name }}",
+      "documents": [
+        {
+          "source-file": "cohere-10m-nested-uniform.hdf5.bz2",
+          "source-format": "hdf5",
+          "document-count": 1000000
+        }
+      ]
+    },
+    {
       "name": "cohere-relaxed",
       "base-url": "https://dbyiw3u3rf9yr.cloudfront.net/corpora/vectorsearch/cohere-wikipedia-22-12-en-embeddings",
       "target-index": "{{ target_index_name }}",


### PR DESCRIPTION
### Description
Register the uniform distribution nested dataset (1M docs, 1-20 vectors/doc, ~9.55M total vectors, Cohere 10M 768d) for use in nightly benchmark jobs.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
