### PR TITLE
Fix document-count for cohere-nested-uniform corpus

### DIFF
--- a/vectorsearch/workload.json
+++ b/vectorsearch/workload.json
@@ -94,7 +94,7 @@
         {
           "source-file": "cohere-10m-nested-uniform.hdf5.bz2",
           "source-format": "hdf5",
-          "document-count": 1000000
+          "document-count": 10550170
         }
       ]
     },


### PR DESCRIPTION
### Description
Update from 1000000 to 10550170 to match what _cat/indices reports. For nested indices, the doc count includes both vectors (~9.55M) and parent documents (1M).

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
