### PR TITLE
Remove radial_engine param, pass target_index_body through search

### DIFF
--- a/vectorsearch/params/radial_search/faiss-hnsw-cohere-768-10m-radial-perquery.json
+++ b/vectorsearch/params/radial_search/faiss-hnsw-cohere-768-10m-radial-perquery.json
@@ -18,7 +18,6 @@
     "target_index_num_vectors": 10000000,
 
     "radial_search_type": "max_distance",
-    "radial_engine": "faiss",
     "query_k": 100,
 
     "query_body": {

--- a/vectorsearch/params/radial_search/lucene-hnsw-cohere-768-10m-radial-perquery.json
+++ b/vectorsearch/params/radial_search/lucene-hnsw-cohere-768-10m-radial-perquery.json
@@ -18,7 +18,6 @@
     "target_index_num_vectors": 10000000,
 
     "radial_search_type": "max_distance",
-    "radial_engine": "lucene",
     "query_k": 100,
 
     "query_body": {

--- a/vectorsearch/test_procedures/common/search-only-premerge-schedule.json
+++ b/vectorsearch/test_procedures/common/search-only-premerge-schedule.json
@@ -25,8 +25,8 @@
         {% if radial_search_type is defined %}
         "radial_search_type": "{{ radial_search_type }}",
         {% endif %}
-        {% if radial_engine is defined %}
-        "radial_engine": "{{ radial_engine }}",
+        {% if target_index_body is defined %}
+        "target_index_body": "{{ target_index_body }}",
         {% endif %}
         "field" : "{{ target_field_name | default('target_field') }}",
         "data_set_format" : "{{ query_data_set_format | default('hdf5') }}",

--- a/vectorsearch/test_procedures/common/search-only-schedule.json
+++ b/vectorsearch/test_procedures/common/search-only-schedule.json
@@ -21,8 +21,8 @@
         {% if radial_search_type is defined %}
         "radial_search_type": "{{ radial_search_type }}",
         {% endif %}
-        {% if radial_engine is defined %}
-        "radial_engine": "{{ radial_engine }}",
+        {% if target_index_body is defined %}
+        "target_index_body": "{{ target_index_body }}",
         {% endif %}
         "field" : "{{ target_field_name | default('target_field') }}",
         "data_set_format" : "{{ query_data_set_format | default('hdf5') }}",


### PR DESCRIPTION
### Description
Remove radial_engine param, pass target_index_body through search templates

### Testing
OSB unit tests pass with `target_index_body` for engine detection

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
