### PR TITLE
Add filtered radial search benchmark with per-percentage ground truth

### DIFF
--- a/vectorsearch/README.md
+++ b/vectorsearch/README.md
@@ -104,6 +104,9 @@ This workload allows the following parameters to be specified using `--workload-
 | query_data_set_format                   | Format of vector data set for queries                                                                                                |
 | query_data_set_path                     | Path to vector data set for queries                                                                                                  |
 | query_count                             | Number of queries for search operation                                                                                               |
+| filter_type                             | Type of filter to apply to the query: `efficient` (inside the knn clause), `post_filter`, `boolean`, or `script` (exact script-score search over filtered docs) |
+| filter_body                             | Body of the filter query (e.g. a term query on a filter field)                                                                       |
+| filter_percentage                       | Filter selectivity suffix for per-percentage ground truth datasets (e.g. `10pct` reads `neighbors_10pct`); must match the field used in filter_body |
 | query_body                              | Json properties that will be merged with search body                                                                                 |
 | search_clients                          | Number of clients to use for running queries                                                                                         |
 | repetitions                             | Number of repetitions until the data set is exhausted (default 1)                                                                    |

--- a/vectorsearch/_tools/enrich_radial_distances.py
+++ b/vectorsearch/_tools/enrich_radial_distances.py
@@ -53,26 +53,7 @@ import numpy as np
 import sys
 from tqdm import tqdm
 
-
-def calculate_distances_batch(queries, corpus, space_type):
-    """Compute raw distances from multiple queries to all corpus vectors.
-
-    Returns shape (num_queries, num_corpus).
-    """
-    if space_type == "l2":
-        q_norms = np.sum(queries ** 2, axis=1, keepdims=True)
-        c_norms = np.sum(corpus ** 2, axis=1, keepdims=True).T
-        dots = queries @ corpus.T
-        return q_norms + c_norms - 2 * dots
-    elif space_type == "innerproduct":
-        return -(queries @ corpus.T)
-    elif space_type == "cosine":
-        q_norms = np.linalg.norm(queries, axis=1, keepdims=True)
-        c_norms = np.linalg.norm(corpus, axis=1, keepdims=True).T
-        dots = queries @ corpus.T
-        return 1 - dots / (q_norms * c_norms)
-    else:
-        raise ValueError(f"Unsupported space type: {space_type}")
+from radial_threshold_utils import calculate_distances_batch, engine_threshold_values
 
 
 def calculate_distance_single(query, corpus_vecs, space_type):
@@ -85,24 +66,6 @@ def calculate_distance_single(query, corpus_vecs, space_type):
         norm_query = np.linalg.norm(query)
         norms_corpus = np.linalg.norm(corpus_vecs, axis=1)
         return 1 - (np.dot(corpus_vecs, query) / (norms_corpus * norm_query))
-    else:
-        raise ValueError(f"Unsupported space type: {space_type}")
-
-
-def raw_distance_to_opensearch_score(distances, space_type):
-    """Convert raw distances to OpenSearch scores (used as min_score for both engines).
-
-    SpaceType.scoreTranslation in the k-NN plugin:
-      l2:           1 / (1 + distance)
-      innerproduct: distance >= 0 ? 1/(1+distance) : -distance + 1
-      cosine:       (2 - distance) / 2
-    """
-    if space_type == "l2":
-        return 1.0 / (1.0 + distances)
-    elif space_type == "innerproduct":
-        return np.where(distances >= 0, 1.0 / (1.0 + distances), -distances + 1.0)
-    elif space_type == "cosine":
-        return (2.0 - distances) / 2.0
     else:
         raise ValueError(f"Unsupported space type: {space_type}")
 
@@ -240,15 +203,8 @@ def main():
     print()
     print("Computing engine-specific radial thresholds...")
 
-    # For max_distance: Faiss takes raw distance directly, but Lucene differs for IP
-    faiss_max_distance = new_distances.copy()
-    if args.space_type == "innerproduct":
-        lucene_max_distance = -new_distances
-    else:
-        lucene_max_distance = new_distances.copy()
-
-    # For min_score: both engines accept the same OpenSearch score value
-    min_score = raw_distance_to_opensearch_score(new_distances, args.space_type)
+    faiss_max_distance, min_score = engine_threshold_values("faiss", args.space_type, new_distances)
+    lucene_max_distance, _ = engine_threshold_values("lucene", args.space_type, new_distances)
 
     # Print stats at various k values
     k_values = [k for k in [100, 200, 500, 1000] if k <= new_distances.shape[1]]

--- a/vectorsearch/_tools/generate_radial_filter_percentage_ground_truth.py
+++ b/vectorsearch/_tools/generate_radial_filter_percentage_ground_truth.py
@@ -1,11 +1,11 @@
 """
 Generate a filtered radial search dataset with per-percentage ground truth.
 
-Each document gets boolean filter attribute fields (e.g. filter10pct = 'true'
-or 'false'). For each percentage, exactly that fraction of documents is marked
-'true', chosen uniformly at random. Filtering with a term query
-(e.g. {"term": {"filter10pct": "true"}}) therefore passes exactly that
-percentage of documents, scattered randomly across the HNSW graph.
+Each document gets one boolean filter attribute field per requested percentage,
+named filter<P>pct (e.g. filter1pct, filter25pct). For each field, exactly that
+fraction of documents is marked 'true', chosen uniformly at random. Filtering
+with a term query (e.g. {"term": {"filter25pct": "true"}}) therefore passes
+exactly that percentage of documents, scattered randomly across the HNSW graph.
 
 For each percentage, ground truth is computed by brute force over the passing
 documents only: the top take_n nearest passing docs per query, plus per-query
@@ -19,114 +19,117 @@ Usage:
         --input cohere-1m.hdf5 \
         --output cohere-1m-radial-filter-percentage.hdf5 \
         --space-type innerproduct \
-        --percentages 0.1 1 10 60 \
+        --percentages 0.1 1 5 10 25 50 75 90 99 \
         --take-n 1000
 
-Output HDF5 (for --percentages 0.1 1 10 60):
-    train:                       (N, dim)     float32  — corpus vectors (copied from input)
-    test:                        (Q, dim)     float32  — query vectors (copied from input)
-    attributes:                  (N, P)       |S8      — 'true'/'false' per percentage field
-    neighbors_01pct:             (Q, take_n)  int64    — top take_n passing docs, nearest first
-    distances_01pct:             (Q, take_n)  float32  — raw distances for those neighbors
-    faiss_max_distance_01pct:    (Q, take_n)  float32  — engine threshold values
-    faiss_min_score_01pct:       (Q, take_n)  float32
-    lucene_max_distance_01pct:   (Q, take_n)  float32
-    lucene_min_score_01pct:      (Q, take_n)  float32
-    ... same six datasets per percentage, suffixed _1pct, _10pct, _60pct
+Output HDF5 layout (one set of columns per percentage, suffixed by its field
+name — e.g. for percentage 10 the suffix is 10pct):
+    train:                      (N, dim)     float32  — corpus vectors (copied from input)
+    test:                       (Q, dim)     float32  — query vectors (copied from input)
+    attributes:                 (N, P)       |S8      — 'true'/'false' per percentage field
+    neighbors_<suffix>:         (Q, take_n)  int64    — top take_n passing docs, nearest first
+    distances_<suffix>:         (Q, take_n)  float32  — raw distances for those neighbors
+    faiss_max_distance_<suffix>, faiss_min_score_<suffix>,
+    lucene_max_distance_<suffix>, lucene_min_score_<suffix>:
+                                (Q, take_n)  float32  — per-engine radial thresholds
 
 Attribute column order matches --percentages order and maps to index fields:
-    0.1 -> filter01pct, 1 -> filter1pct, 10 -> filter10pct, 60 -> filter60pct
+    percentage P -> field filter<suffix> (0.1 -> filter01pct, 25 -> filter25pct, ...)
 
 Requires take_n <= passing docs at the smallest percentage.
 """
 
 import argparse
+import shutil
+import time
+
 import h5py
 import numpy as np
-import shutil
-import sys
-import time
+
+from radial_threshold_utils import (
+    SUPPORTED_SPACE_TYPES,
+    calculate_distances_batch,
+    engine_threshold_values,
+)
+
+ENGINES = ("faiss", "lucene")
 
 
 def pct_suffix(pct):
-    """0.1 -> '01pct', 1 -> '1pct', 10 -> '10pct', 60 -> '60pct'"""
+    """0.1 -> '01pct', 1 -> '1pct', 25 -> '25pct'"""
     if pct < 1:
         return f"0{str(pct).replace('0.', '')}pct"
     return f"{int(pct)}pct"
 
 
-def calculate_distances_batch(queries, corpus, space_type):
-    if space_type == "l2":
-        q_norms = np.sum(queries ** 2, axis=1, keepdims=True)
-        c_norms = np.sum(corpus ** 2, axis=1, keepdims=True).T
-        dots = queries @ corpus.T
-        return q_norms + c_norms - 2 * dots
-    elif space_type == "innerproduct":
-        return -(queries @ corpus.T)
-    elif space_type == "cosine":
-        q_norms = np.linalg.norm(queries, axis=1, keepdims=True)
-        c_norms = np.linalg.norm(corpus, axis=1, keepdims=True).T
-        dots = queries @ corpus.T
-        return 1 - dots / (q_norms * c_norms)
-    else:
-        raise ValueError(f"Unsupported space type: {space_type}")
-
-
-def raw_distance_to_opensearch_score(distances, space_type):
-    if space_type == "l2":
-        return 1.0 / (1.0 + distances)
-    elif space_type == "innerproduct":
-        return np.where(distances >= 0, 1.0 / (1.0 + distances), -distances + 1.0)
-    elif space_type == "cosine":
-        return (2.0 - distances) / 2.0
-    else:
-        raise ValueError(f"Unsupported space type: {space_type}")
-
-
-def main():
+def parse_args():
     parser = argparse.ArgumentParser(
         description="Generate per-percentage filtered radial ground truth for vector search benchmarks")
     parser.add_argument("--input", required=True, help="Input HDF5 with train/test")
     parser.add_argument("--output", required=True, help="Output HDF5 path")
-    parser.add_argument("--space-type", required=True, choices=["l2", "innerproduct", "cosine"])
-    parser.add_argument("--percentages", type=float, nargs="+", default=[0.1, 1, 10, 60],
-                        help="Filter percentages (default: 0.1 1 10 60)")
+    parser.add_argument("--space-type", required=True, choices=list(SUPPORTED_SPACE_TYPES))
+    parser.add_argument("--percentages", type=float, nargs="+",
+                        default=[0.1, 1, 5, 10, 25, 50, 75, 90, 99],
+                        help="Filter percentages (default: 0.1 1 5 10 25 50 75 90 99)")
     parser.add_argument("--take-n", type=int, default=1000,
                         help="Neighbors stored per query per percentage (default: 1000)")
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--query-batch-size", type=int, default=100)
-    args = parser.parse_args()
+    return parser.parse_args()
 
-    with h5py.File(args.input, "r") as f_in:
+
+def load_input(path):
+    """Load corpus and query vectors, failing clearly if keys are missing."""
+    with h5py.File(path, "r") as f_in:
+        for key in ("train", "test"):
+            if key not in f_in:
+                raise ValueError(f"Input {path} is missing dataset '{key}'. "
+                                 f"Available keys: {sorted(f_in.keys())}")
         print("Loading dataset...")
         train = f_in["train"][:]
         test = f_in["test"][:]
-    num_docs, num_queries = train.shape[0], test.shape[0]
     print(f"  train: {train.shape}, test: {test.shape}")
+    return train, test
 
+
+def validate_args(args, num_docs):
+    """Validate percentages and take_n before doing any work. Returns suffixes."""
+    if args.take_n <= 0:
+        raise ValueError(f"--take-n must be positive, got {args.take_n}")
     suffixes = [pct_suffix(p) for p in args.percentages]
-    print(f"Percentages: {args.percentages} -> fields filter{{{', filter'.join(suffixes)}}}")
-
-    # Validate take_n against smallest percentage
+    if len(set(suffixes)) != len(suffixes):
+        raise ValueError(f"Percentages {args.percentages} map to duplicate "
+                         f"field suffixes {suffixes}")
     for pct in args.percentages:
+        if not 0 < pct < 100:
+            raise ValueError(f"Percentages must be in (0, 100), got {pct}")
         n_pass = int(round(pct / 100.0 * num_docs))
         if n_pass < args.take_n:
-            print(f"ERROR: {pct}% passes only {n_pass} docs < take_n={args.take_n}. "
-                  f"Reduce --take-n or raise the percentage.")
-            sys.exit(1)
+            raise ValueError(f"{pct}% passes only {n_pass} docs < take_n={args.take_n}. "
+                             f"Reduce --take-n or raise the percentage.")
+    return suffixes
 
-    # Assign attributes: for each percentage, mark exactly n_pass random docs 'true'
-    rng = np.random.default_rng(args.seed)
-    attributes = np.full((num_docs, len(args.percentages)), b"false", dtype="|S8")
+
+def assign_attributes(num_docs, percentages, suffixes, seed):
+    """For each percentage, mark exactly n_pass random docs 'true'.
+
+    Returns the (num_docs, P) attribute matrix and per-column sorted passing ids.
+    """
+    rng = np.random.default_rng(seed)
+    attributes = np.full((num_docs, len(percentages)), b"false", dtype="|S8")
     passing_ids = {}
-    for col, pct in enumerate(args.percentages):
+    for col, pct in enumerate(percentages):
         n_pass = int(round(pct / 100.0 * num_docs))
         chosen = rng.permutation(num_docs)[:n_pass]
         attributes[chosen, col] = b"true"
         passing_ids[col] = np.sort(chosen)
         print(f"  filter{suffixes[col]}: exactly {n_pass} docs marked true")
+    return attributes, passing_ids
 
-    # Per-percentage output arrays
+
+def compute_ground_truth(train, test, passing_ids, suffixes, args):
+    """Filter-first brute force: per percentage, top take_n passing docs per query."""
+    num_queries = test.shape[0]
     out = {}
     for s in suffixes:
         out[s] = {
@@ -135,7 +138,7 @@ def main():
         }
 
     print(f"\nComputing ground truth for {num_queries} queries "
-          f"x {len(args.percentages)} percentages (take_n={args.take_n})...")
+          f"x {len(suffixes)} percentages (take_n={args.take_n})...")
     t0 = time.time()
     for batch_start in range(0, num_queries, args.query_batch_size):
         batch_end = min(batch_start + args.query_batch_size, num_queries)
@@ -157,8 +160,11 @@ def main():
                 out[s]["neighbors"][batch_start + i] = ids[idx]
                 out[s]["distances"][batch_start + i] = d[idx]
     print(f"Done in {time.time()-t0:.0f}s")
+    return out
 
-    # Write output
+
+def write_output(args, attributes, out, suffixes):
+    """Copy input to output and add/replace attribute + per-percentage datasets."""
     shutil.copy2(args.input, args.output)
     with h5py.File(args.output, "a") as f_out:
         def write(name, data):
@@ -171,17 +177,28 @@ def main():
             dist = out[s]["distances"]
             write(f"neighbors_{s}", out[s]["neighbors"])
             write(f"distances_{s}", dist)
-            write(f"faiss_max_distance_{s}", dist.copy())
-            lucene_dist = -dist if args.space_type == "innerproduct" else dist.copy()
-            write(f"lucene_max_distance_{s}", lucene_dist)
-            score = raw_distance_to_opensearch_score(dist, args.space_type).astype(np.float32)
-            write(f"faiss_min_score_{s}", score)
-            write(f"lucene_min_score_{s}", score)
+            for engine in ENGINES:
+                max_distance, min_score = engine_threshold_values(engine, args.space_type, dist)
+                write(f"{engine}_max_distance_{s}", max_distance)
+                write(f"{engine}_min_score_{s}", min_score)
 
         f_out.attrs["space_type"] = args.space_type
         f_out.attrs["percentages"] = args.percentages
         f_out.attrs["take_n"] = args.take_n
         f_out.attrs["seed"] = args.seed
+
+
+def main():
+    args = parse_args()
+    train, test = load_input(args.input)
+    num_docs, num_queries = train.shape[0], test.shape[0]
+
+    suffixes = validate_args(args, num_docs)
+    print(f"Percentages: {args.percentages} -> fields filter{{{', filter'.join(suffixes)}}}")
+
+    attributes, passing_ids = assign_attributes(num_docs, args.percentages, suffixes, args.seed)
+    out = compute_ground_truth(train, test, passing_ids, suffixes, args)
+    write_output(args, attributes, out, suffixes)
 
     print(f"\nWritten to {args.output}")
     print(f"  attributes: {attributes.shape}")

--- a/vectorsearch/_tools/generate_radial_filter_percentage_ground_truth.py
+++ b/vectorsearch/_tools/generate_radial_filter_percentage_ground_truth.py
@@ -1,0 +1,194 @@
+"""
+Generate a filtered radial search dataset with per-percentage ground truth.
+
+Each document gets boolean filter attribute fields (e.g. filter10pct = 'true'
+or 'false'). For each percentage, exactly that fraction of documents is marked
+'true', chosen uniformly at random. Filtering with a term query
+(e.g. {"term": {"filter10pct": "true"}}) therefore passes exactly that
+percentage of documents, scattered randomly across the HNSW graph.
+
+For each percentage, ground truth is computed by brute force over the passing
+documents only: the top take_n nearest passing docs per query, plus per-query
+radial search thresholds (distance to the k-th nearest passing neighbor,
+converted per engine). This mirrors the unfiltered radial per-query benchmark:
+at benchmark time query_k selects the ground truth depth (neighbors[:k]) and
+the radial threshold (threshold[k-1]).
+
+Usage:
+    python generate_radial_filter_percentage_ground_truth.py \
+        --input cohere-1m.hdf5 \
+        --output cohere-1m-radial-filter-percentage.hdf5 \
+        --space-type innerproduct \
+        --percentages 0.1 1 10 60 \
+        --take-n 1000
+
+Output HDF5 (for --percentages 0.1 1 10 60):
+    train:                       (N, dim)     float32  — corpus vectors (copied from input)
+    test:                        (Q, dim)     float32  — query vectors (copied from input)
+    attributes:                  (N, P)       |S8      — 'true'/'false' per percentage field
+    neighbors_01pct:             (Q, take_n)  int64    — top take_n passing docs, nearest first
+    distances_01pct:             (Q, take_n)  float32  — raw distances for those neighbors
+    faiss_max_distance_01pct:    (Q, take_n)  float32  — engine threshold values
+    faiss_min_score_01pct:       (Q, take_n)  float32
+    lucene_max_distance_01pct:   (Q, take_n)  float32
+    lucene_min_score_01pct:      (Q, take_n)  float32
+    ... same six datasets per percentage, suffixed _1pct, _10pct, _60pct
+
+Attribute column order matches --percentages order and maps to index fields:
+    0.1 -> filter01pct, 1 -> filter1pct, 10 -> filter10pct, 60 -> filter60pct
+
+Requires take_n <= passing docs at the smallest percentage.
+"""
+
+import argparse
+import h5py
+import numpy as np
+import shutil
+import sys
+import time
+
+
+def pct_suffix(pct):
+    """0.1 -> '01pct', 1 -> '1pct', 10 -> '10pct', 60 -> '60pct'"""
+    if pct < 1:
+        return f"0{str(pct).replace('0.', '')}pct"
+    return f"{int(pct)}pct"
+
+
+def calculate_distances_batch(queries, corpus, space_type):
+    if space_type == "l2":
+        q_norms = np.sum(queries ** 2, axis=1, keepdims=True)
+        c_norms = np.sum(corpus ** 2, axis=1, keepdims=True).T
+        dots = queries @ corpus.T
+        return q_norms + c_norms - 2 * dots
+    elif space_type == "innerproduct":
+        return -(queries @ corpus.T)
+    elif space_type == "cosine":
+        q_norms = np.linalg.norm(queries, axis=1, keepdims=True)
+        c_norms = np.linalg.norm(corpus, axis=1, keepdims=True).T
+        dots = queries @ corpus.T
+        return 1 - dots / (q_norms * c_norms)
+    else:
+        raise ValueError(f"Unsupported space type: {space_type}")
+
+
+def raw_distance_to_opensearch_score(distances, space_type):
+    if space_type == "l2":
+        return 1.0 / (1.0 + distances)
+    elif space_type == "innerproduct":
+        return np.where(distances >= 0, 1.0 / (1.0 + distances), -distances + 1.0)
+    elif space_type == "cosine":
+        return (2.0 - distances) / 2.0
+    else:
+        raise ValueError(f"Unsupported space type: {space_type}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate per-percentage filtered radial ground truth for vector search benchmarks")
+    parser.add_argument("--input", required=True, help="Input HDF5 with train/test")
+    parser.add_argument("--output", required=True, help="Output HDF5 path")
+    parser.add_argument("--space-type", required=True, choices=["l2", "innerproduct", "cosine"])
+    parser.add_argument("--percentages", type=float, nargs="+", default=[0.1, 1, 10, 60],
+                        help="Filter percentages (default: 0.1 1 10 60)")
+    parser.add_argument("--take-n", type=int, default=1000,
+                        help="Neighbors stored per query per percentage (default: 1000)")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--query-batch-size", type=int, default=100)
+    args = parser.parse_args()
+
+    with h5py.File(args.input, "r") as f_in:
+        print("Loading dataset...")
+        train = f_in["train"][:]
+        test = f_in["test"][:]
+    num_docs, num_queries = train.shape[0], test.shape[0]
+    print(f"  train: {train.shape}, test: {test.shape}")
+
+    suffixes = [pct_suffix(p) for p in args.percentages]
+    print(f"Percentages: {args.percentages} -> fields filter{{{', filter'.join(suffixes)}}}")
+
+    # Validate take_n against smallest percentage
+    for pct in args.percentages:
+        n_pass = int(round(pct / 100.0 * num_docs))
+        if n_pass < args.take_n:
+            print(f"ERROR: {pct}% passes only {n_pass} docs < take_n={args.take_n}. "
+                  f"Reduce --take-n or raise the percentage.")
+            sys.exit(1)
+
+    # Assign attributes: for each percentage, mark exactly n_pass random docs 'true'
+    rng = np.random.default_rng(args.seed)
+    attributes = np.full((num_docs, len(args.percentages)), b"false", dtype="|S8")
+    passing_ids = {}
+    for col, pct in enumerate(args.percentages):
+        n_pass = int(round(pct / 100.0 * num_docs))
+        chosen = rng.permutation(num_docs)[:n_pass]
+        attributes[chosen, col] = b"true"
+        passing_ids[col] = np.sort(chosen)
+        print(f"  filter{suffixes[col]}: exactly {n_pass} docs marked true")
+
+    # Per-percentage output arrays
+    out = {}
+    for s in suffixes:
+        out[s] = {
+            "neighbors": np.empty((num_queries, args.take_n), dtype=np.int64),
+            "distances": np.empty((num_queries, args.take_n), dtype=np.float32),
+        }
+
+    print(f"\nComputing ground truth for {num_queries} queries "
+          f"x {len(args.percentages)} percentages (take_n={args.take_n})...")
+    t0 = time.time()
+    for batch_start in range(0, num_queries, args.query_batch_size):
+        batch_end = min(batch_start + args.query_batch_size, num_queries)
+        if batch_start % 1000 == 0:
+            print(f"  {batch_start}/{num_queries} ({time.time()-t0:.0f}s)")
+        # One distance computation per batch, reused for all percentages
+        batch_dists = calculate_distances_batch(test[batch_start:batch_end], train, args.space_type)
+
+        for col, s in enumerate(suffixes):
+            ids = passing_ids[col]
+            sub = batch_dists[:, ids]                      # distances to passing docs only
+            for i in range(batch_end - batch_start):
+                d = sub[i]
+                if args.take_n < len(d):
+                    idx = np.argpartition(d, args.take_n - 1)[:args.take_n]
+                    idx = idx[np.argsort(d[idx])]
+                else:
+                    idx = np.argsort(d)
+                out[s]["neighbors"][batch_start + i] = ids[idx]
+                out[s]["distances"][batch_start + i] = d[idx]
+    print(f"Done in {time.time()-t0:.0f}s")
+
+    # Write output
+    shutil.copy2(args.input, args.output)
+    with h5py.File(args.output, "a") as f_out:
+        def write(name, data):
+            if name in f_out:
+                del f_out[name]
+            f_out.create_dataset(name, data=data)
+
+        write("attributes", attributes)
+        for s in suffixes:
+            dist = out[s]["distances"]
+            write(f"neighbors_{s}", out[s]["neighbors"])
+            write(f"distances_{s}", dist)
+            write(f"faiss_max_distance_{s}", dist.copy())
+            lucene_dist = -dist if args.space_type == "innerproduct" else dist.copy()
+            write(f"lucene_max_distance_{s}", lucene_dist)
+            score = raw_distance_to_opensearch_score(dist, args.space_type).astype(np.float32)
+            write(f"faiss_min_score_{s}", score)
+            write(f"lucene_min_score_{s}", score)
+
+        f_out.attrs["space_type"] = args.space_type
+        f_out.attrs["percentages"] = args.percentages
+        f_out.attrs["take_n"] = args.take_n
+        f_out.attrs["seed"] = args.seed
+
+    print(f"\nWritten to {args.output}")
+    print(f"  attributes: {attributes.shape}")
+    for s in suffixes:
+        print(f"  neighbors_{s} / distances_{s} / thresholds_{s}: ({num_queries}, {args.take_n})")
+    print(f"\nBenchmark filter body example: {{\"term\": {{\"filter{suffixes[-1]}\": \"true\"}}}}")
+
+
+if __name__ == "__main__":
+    main()

--- a/vectorsearch/_tools/radial_threshold_utils.py
+++ b/vectorsearch/_tools/radial_threshold_utils.py
@@ -1,0 +1,77 @@
+"""
+Shared distance and radial-threshold conversions for vector search dataset tools.
+
+Radial search thresholds are engine- and space-type-specific. The conversions
+here mirror the k-NN plugin so that stored thresholds match what each engine
+expects at query time:
+
+- Faiss `max_distance` takes the raw space-type distance. For innerproduct the
+  plugin negates the dot product internally (larger dot product = smaller
+  "distance"), so raw distances (and thresholds) are negative for well-matching
+  vectors. See SpaceType.INNER_PRODUCT and FaissService in opensearch-knn.
+- Lucene `max_distance` for innerproduct is the (non-negated) dot product, the
+  opposite sign convention from Faiss. See LuceneEngine / VectorSimilarityFunction
+  .MAXIMUM_INNER_PRODUCT in opensearch-knn and Lucene.
+- `min_score` uses the plugin's distance-to-score translation, identical for
+  both engines. See SpaceType#scoreTranslation in opensearch-knn:
+    l2:           score = 1 / (1 + d)
+    innerproduct: score = 1 / (1 + d)      if d >= 0
+                  score = -d + 1           if d < 0
+    cosine:       score = (2 - d) / 2
+"""
+
+import numpy as np
+
+SUPPORTED_SPACE_TYPES = ("l2", "innerproduct", "cosine")
+
+
+def calculate_distances_batch(queries, corpus, space_type):
+    """Raw space-type distances from each query to every corpus vector.
+
+    Returns a (num_queries, num_corpus) float array where smaller = closer,
+    matching the k-NN plugin's internal distance convention per space type
+    (innerproduct is negated so it sorts ascending like l2/cosine).
+    """
+    if space_type == "l2":
+        q_norms = np.sum(queries ** 2, axis=1, keepdims=True)
+        c_norms = np.sum(corpus ** 2, axis=1, keepdims=True).T
+        dots = queries @ corpus.T
+        return q_norms + c_norms - 2 * dots
+    if space_type == "innerproduct":
+        return -(queries @ corpus.T)
+    if space_type == "cosine":
+        q_norms = np.linalg.norm(queries, axis=1, keepdims=True)
+        c_norms = np.linalg.norm(corpus, axis=1, keepdims=True).T
+        dots = queries @ corpus.T
+        return 1 - dots / (q_norms * c_norms)
+    raise ValueError(f"Unsupported space type: {space_type}. Supported: {SUPPORTED_SPACE_TYPES}")
+
+
+def raw_distance_to_opensearch_score(distances, space_type):
+    """k-NN plugin score for a raw distance (SpaceType#scoreTranslation)."""
+    if space_type == "l2":
+        return 1.0 / (1.0 + distances)
+    if space_type == "innerproduct":
+        return np.where(distances >= 0, 1.0 / (1.0 + distances), -distances + 1.0)
+    if space_type == "cosine":
+        return (2.0 - distances) / 2.0
+    raise ValueError(f"Unsupported space type: {space_type}. Supported: {SUPPORTED_SPACE_TYPES}")
+
+
+def engine_threshold_values(engine, space_type, distances):
+    """Radial threshold columns for one engine: (max_distance, min_score).
+
+    `distances` are raw space-type distances from calculate_distances_batch.
+    Faiss max_distance is the raw distance. Lucene max_distance for
+    innerproduct flips the sign back to a plain dot product (Lucene's
+    MAXIMUM_INNER_PRODUCT convention); other space types match Faiss.
+    min_score is the shared plugin score translation for both engines.
+    """
+    if engine not in ("faiss", "lucene"):
+        raise ValueError(f"Unsupported engine: {engine}. Supported: faiss, lucene")
+    if engine == "lucene" and space_type == "innerproduct":
+        max_distance = -distances
+    else:
+        max_distance = distances.copy()
+    min_score = raw_distance_to_opensearch_score(distances, space_type).astype(np.float32)
+    return max_distance, min_score

--- a/vectorsearch/_tools/radial_threshold_utils.py
+++ b/vectorsearch/_tools/radial_threshold_utils.py
@@ -18,6 +18,9 @@ expects at query time:
     innerproduct: score = 1 / (1 + d)      if d >= 0
                   score = -d + 1           if d < 0
     cosine:       score = (2 - d) / 2
+
+Distance functions and score translations per space type are documented at
+https://docs.opensearch.org/latest/mappings/supported-field-types/knn-spaces/
 """
 
 import numpy as np

--- a/vectorsearch/indices/filters/faiss-index-filter-percentage.json
+++ b/vectorsearch/indices/filters/faiss-index-filter-percentage.json
@@ -60,10 +60,25 @@
         "filter1pct": {
           "type": "keyword"
         },
+        "filter5pct": {
+          "type": "keyword"
+        },
         "filter10pct": {
           "type": "keyword"
         },
-        "filter60pct": {
+        "filter25pct": {
+          "type": "keyword"
+        },
+        "filter50pct": {
+          "type": "keyword"
+        },
+        "filter75pct": {
+          "type": "keyword"
+        },
+        "filter90pct": {
+          "type": "keyword"
+        },
+        "filter99pct": {
           "type": "keyword"
         }
       }

--- a/vectorsearch/indices/filters/faiss-index-filter-percentage.json
+++ b/vectorsearch/indices/filters/faiss-index-filter-percentage.json
@@ -1,0 +1,71 @@
+{
+    "settings": {
+      "index": {
+        "knn": true
+        {%- if target_index_primary_shards is defined and target_index_primary_shards %}
+        ,"number_of_shards": {{ target_index_primary_shards }}
+        {%- endif %}
+        {%- if target_index_replica_shards is defined %}
+        ,"number_of_replicas": {{ target_index_replica_shards }}
+        {%- endif %}
+        {%- if derived_source_enabled is defined and derived_source_enabled %}
+        ,"knn.derived_source.enabled": true
+        {%- endif %}
+        {%- if approximate_graph_build_threshold is defined%}
+        ,"knn.advanced.approximate_threshold": {{ approximate_graph_build_threshold }}
+        {%- endif %}
+      }
+    },
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        {% if id_field_name is defined and id_field_name != "_id" %}
+          "{{id_field_name}}": {
+            "type": "keyword"
+          },
+        {%- endif %}
+        "{{ target_field_name }}": {
+          "type": "knn_vector",
+          "dimension": {{ target_index_dimension }},
+          {%- if train_model_id is defined %}
+          "model_id": "{{ train_model_id }}"
+          {%- else %}
+          "method": {
+            "name": "hnsw",
+            "space_type": "{{ target_index_space_type }}",
+            "engine": "faiss",
+            "parameters": {
+              {%- if hnsw_ef_search is defined and hnsw_ef_search %}
+                "ef_search": {{ hnsw_ef_search }}
+              {%- endif %}
+              {%- if hnsw_ef_construction is defined and hnsw_ef_construction %}
+              {%- if hnsw_ef_search is defined and hnsw_ef_search %}
+                ,
+              {%- endif %}
+                "ef_construction": {{ hnsw_ef_construction }}
+              {%- endif %}
+              {%- if hnsw_m is defined and hnsw_m %}
+              {%- if hnsw_ef_construction is defined and hnsw_ef_construction %}
+                ,
+              {%- endif %}
+                "m": {{ hnsw_m }}
+              {%- endif %}
+            }
+          }
+          {%- endif %}
+        },
+        "filter01pct": {
+          "type": "keyword"
+        },
+        "filter1pct": {
+          "type": "keyword"
+        },
+        "filter10pct": {
+          "type": "keyword"
+        },
+        "filter60pct": {
+          "type": "keyword"
+        }
+      }
+    }
+  }

--- a/vectorsearch/indices/filters/lucene-index-filter-percentage.json
+++ b/vectorsearch/indices/filters/lucene-index-filter-percentage.json
@@ -1,0 +1,61 @@
+{
+    "settings": {
+      "index": {
+        "knn": true
+        {%- if target_index_primary_shards is defined and target_index_primary_shards %}
+        ,"number_of_shards": {{ target_index_primary_shards }}
+        {%- endif %}
+        {%- if target_index_replica_shards is defined %}
+        ,"number_of_replicas": {{ target_index_replica_shards }}
+        {%- endif %}
+        {%- if hnsw_ef_search is defined and hnsw_ef_search %}
+        ,"knn.algo_param.ef_search": {{ hnsw_ef_search }}
+        {%- endif %}
+        {%- if derived_source_enabled is defined and derived_source_enabled %}
+        ,"knn.derived_source.enabled": true
+        {%- endif %}
+      }
+    },
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        {% if id_field_name is defined and id_field_name != "_id" %}
+          "{{id_field_name}}": {
+            "type": "keyword"
+          },
+        {%- endif %}
+        "{{ target_field_name }}": {
+          "type": "knn_vector",
+          "dimension": {{ target_index_dimension }},
+          "method": {
+            "name": "hnsw",
+            "space_type": "{{ target_index_space_type }}",
+            "engine": "lucene",
+            "parameters": {
+            {%- if hnsw_ef_construction is defined and hnsw_ef_construction %}
+            "ef_construction": {{ hnsw_ef_construction }}
+            {%- endif %}
+            {%- if hnsw_m is defined and hnsw_m %}
+            {%- if hnsw_ef_construction is defined and hnsw_ef_construction %}
+            ,
+            {%- endif %}
+            "m": {{ hnsw_m }}
+            {%- endif %}
+            }
+          }
+        },
+        "filter01pct": {
+          "type": "keyword"
+        },
+        "filter1pct": {
+          "type": "keyword"
+        },
+        "filter10pct": {
+          "type": "keyword"
+        },
+        "filter60pct": {
+          "type": "keyword"
+        }
+      }
+    }
+  }

--- a/vectorsearch/indices/filters/lucene-index-filter-percentage.json
+++ b/vectorsearch/indices/filters/lucene-index-filter-percentage.json
@@ -50,10 +50,25 @@
         "filter1pct": {
           "type": "keyword"
         },
+        "filter5pct": {
+          "type": "keyword"
+        },
         "filter10pct": {
           "type": "keyword"
         },
-        "filter60pct": {
+        "filter25pct": {
+          "type": "keyword"
+        },
+        "filter50pct": {
+          "type": "keyword"
+        },
+        "filter75pct": {
+          "type": "keyword"
+        },
+        "filter90pct": {
+          "type": "keyword"
+        },
+        "filter99pct": {
           "type": "keyword"
         }
       }

--- a/vectorsearch/params/radial_search/filters/faiss-hnsw-cohere-768-1m-efficient.json
+++ b/vectorsearch/params/radial_search/filters/faiss-hnsw-cohere-768-1m-efficient.json
@@ -1,0 +1,45 @@
+{
+    "target_index_name": "target_index",
+    "target_field_name": "target_field",
+    "target_index_body": "indices/filters/faiss-index-filter-percentage.json",
+    "target_index_primary_shards": 2,
+    "target_index_dimension": 768,
+    "target_index_space_type": "innerproduct",
+    "target_index_bulk_size": 100,
+    "target_index_bulk_index_data_set_format": "hdf5",
+    "target_index_bulk_index_data_set_corpus": "cohere-1m-radial-filter-percentage",
+    "target_index_bulk_indexing_clients": 10,
+    "target_dataset_filter_attributes": [
+        "filter01pct",
+        "filter1pct",
+        "filter10pct",
+        "filter60pct"
+    ],
+    "target_index_max_num_segments": 1,
+    "target_index_force_merge_timeout": 600.0,
+    "hnsw_ef_search": 256,
+    "hnsw_ef_construction": 256,
+    "target_index_num_vectors": 1000000,
+    "radial_search_type": "max_distance",
+    "query_k": 100,
+    "query_body": {
+        "size": 100,
+        "docvalue_fields": [
+            "_id"
+        ],
+        "stored_fields": "_none_",
+        "_source": false
+    },
+    "filter_type": "efficient",
+    "filter_percentage": "10pct",
+    "filter_body": {
+        "term": {
+            "filter10pct": "true"
+        }
+    },
+    "query_data_set_format": "hdf5",
+    "query_data_set_corpus": "cohere-1m-radial-filter-percentage",
+    "neighbors_data_set_corpus": "cohere-1m-radial-filter-percentage",
+    "neighbors_data_set_format": "hdf5",
+    "query_count": 10000
+}

--- a/vectorsearch/params/radial_search/filters/faiss-hnsw-cohere-768-1m-efficient.json
+++ b/vectorsearch/params/radial_search/filters/faiss-hnsw-cohere-768-1m-efficient.json
@@ -12,8 +12,13 @@
     "target_dataset_filter_attributes": [
         "filter01pct",
         "filter1pct",
+        "filter5pct",
         "filter10pct",
-        "filter60pct"
+        "filter25pct",
+        "filter50pct",
+        "filter75pct",
+        "filter90pct",
+        "filter99pct"
     ],
     "target_index_max_num_segments": 1,
     "target_index_force_merge_timeout": 600.0,

--- a/vectorsearch/params/radial_search/filters/faiss-hnsw-cohere-768-1m-post-filter.json
+++ b/vectorsearch/params/radial_search/filters/faiss-hnsw-cohere-768-1m-post-filter.json
@@ -1,0 +1,45 @@
+{
+    "target_index_name": "target_index",
+    "target_field_name": "target_field",
+    "target_index_body": "indices/filters/faiss-index-filter-percentage.json",
+    "target_index_primary_shards": 2,
+    "target_index_dimension": 768,
+    "target_index_space_type": "innerproduct",
+    "target_index_bulk_size": 100,
+    "target_index_bulk_index_data_set_format": "hdf5",
+    "target_index_bulk_index_data_set_corpus": "cohere-1m-radial-filter-percentage",
+    "target_index_bulk_indexing_clients": 10,
+    "target_dataset_filter_attributes": [
+        "filter01pct",
+        "filter1pct",
+        "filter10pct",
+        "filter60pct"
+    ],
+    "target_index_max_num_segments": 1,
+    "target_index_force_merge_timeout": 600.0,
+    "hnsw_ef_search": 256,
+    "hnsw_ef_construction": 256,
+    "target_index_num_vectors": 1000000,
+    "radial_search_type": "max_distance",
+    "query_k": 100,
+    "query_body": {
+        "size": 100,
+        "docvalue_fields": [
+            "_id"
+        ],
+        "stored_fields": "_none_",
+        "_source": false
+    },
+    "filter_type": "post_filter",
+    "filter_percentage": "10pct",
+    "filter_body": {
+        "term": {
+            "filter10pct": "true"
+        }
+    },
+    "query_data_set_format": "hdf5",
+    "query_data_set_corpus": "cohere-1m-radial-filter-percentage",
+    "neighbors_data_set_corpus": "cohere-1m-radial-filter-percentage",
+    "neighbors_data_set_format": "hdf5",
+    "query_count": 10000
+}

--- a/vectorsearch/params/radial_search/filters/faiss-hnsw-cohere-768-1m-post-filter.json
+++ b/vectorsearch/params/radial_search/filters/faiss-hnsw-cohere-768-1m-post-filter.json
@@ -12,8 +12,13 @@
     "target_dataset_filter_attributes": [
         "filter01pct",
         "filter1pct",
+        "filter5pct",
         "filter10pct",
-        "filter60pct"
+        "filter25pct",
+        "filter50pct",
+        "filter75pct",
+        "filter90pct",
+        "filter99pct"
     ],
     "target_index_max_num_segments": 1,
     "target_index_force_merge_timeout": 600.0,

--- a/vectorsearch/params/radial_search/filters/lucene-hnsw-cohere-768-1m-efficient.json
+++ b/vectorsearch/params/radial_search/filters/lucene-hnsw-cohere-768-1m-efficient.json
@@ -1,0 +1,45 @@
+{
+    "target_index_name": "target_index",
+    "target_field_name": "target_field",
+    "target_index_body": "indices/filters/lucene-index-filter-percentage.json",
+    "target_index_primary_shards": 2,
+    "target_index_dimension": 768,
+    "target_index_space_type": "innerproduct",
+    "target_index_bulk_size": 100,
+    "target_index_bulk_index_data_set_format": "hdf5",
+    "target_index_bulk_index_data_set_corpus": "cohere-1m-radial-filter-percentage",
+    "target_index_bulk_indexing_clients": 10,
+    "target_dataset_filter_attributes": [
+        "filter01pct",
+        "filter1pct",
+        "filter10pct",
+        "filter60pct"
+    ],
+    "target_index_max_num_segments": 1,
+    "target_index_force_merge_timeout": 600.0,
+    "hnsw_ef_search": 256,
+    "hnsw_ef_construction": 256,
+    "target_index_num_vectors": 1000000,
+    "radial_search_type": "max_distance",
+    "query_k": 100,
+    "query_body": {
+        "size": 100,
+        "docvalue_fields": [
+            "_id"
+        ],
+        "stored_fields": "_none_",
+        "_source": false
+    },
+    "filter_type": "efficient",
+    "filter_percentage": "10pct",
+    "filter_body": {
+        "term": {
+            "filter10pct": "true"
+        }
+    },
+    "query_data_set_format": "hdf5",
+    "query_data_set_corpus": "cohere-1m-radial-filter-percentage",
+    "neighbors_data_set_corpus": "cohere-1m-radial-filter-percentage",
+    "neighbors_data_set_format": "hdf5",
+    "query_count": 10000
+}

--- a/vectorsearch/params/radial_search/filters/lucene-hnsw-cohere-768-1m-efficient.json
+++ b/vectorsearch/params/radial_search/filters/lucene-hnsw-cohere-768-1m-efficient.json
@@ -12,8 +12,13 @@
     "target_dataset_filter_attributes": [
         "filter01pct",
         "filter1pct",
+        "filter5pct",
         "filter10pct",
-        "filter60pct"
+        "filter25pct",
+        "filter50pct",
+        "filter75pct",
+        "filter90pct",
+        "filter99pct"
     ],
     "target_index_max_num_segments": 1,
     "target_index_force_merge_timeout": 600.0,

--- a/vectorsearch/params/radial_search/filters/lucene-hnsw-cohere-768-1m-post-filter.json
+++ b/vectorsearch/params/radial_search/filters/lucene-hnsw-cohere-768-1m-post-filter.json
@@ -1,0 +1,45 @@
+{
+    "target_index_name": "target_index",
+    "target_field_name": "target_field",
+    "target_index_body": "indices/filters/lucene-index-filter-percentage.json",
+    "target_index_primary_shards": 2,
+    "target_index_dimension": 768,
+    "target_index_space_type": "innerproduct",
+    "target_index_bulk_size": 100,
+    "target_index_bulk_index_data_set_format": "hdf5",
+    "target_index_bulk_index_data_set_corpus": "cohere-1m-radial-filter-percentage",
+    "target_index_bulk_indexing_clients": 10,
+    "target_dataset_filter_attributes": [
+        "filter01pct",
+        "filter1pct",
+        "filter10pct",
+        "filter60pct"
+    ],
+    "target_index_max_num_segments": 1,
+    "target_index_force_merge_timeout": 600.0,
+    "hnsw_ef_search": 256,
+    "hnsw_ef_construction": 256,
+    "target_index_num_vectors": 1000000,
+    "radial_search_type": "max_distance",
+    "query_k": 100,
+    "query_body": {
+        "size": 100,
+        "docvalue_fields": [
+            "_id"
+        ],
+        "stored_fields": "_none_",
+        "_source": false
+    },
+    "filter_type": "post_filter",
+    "filter_percentage": "10pct",
+    "filter_body": {
+        "term": {
+            "filter10pct": "true"
+        }
+    },
+    "query_data_set_format": "hdf5",
+    "query_data_set_corpus": "cohere-1m-radial-filter-percentage",
+    "neighbors_data_set_corpus": "cohere-1m-radial-filter-percentage",
+    "neighbors_data_set_format": "hdf5",
+    "query_count": 1000
+}

--- a/vectorsearch/params/radial_search/filters/lucene-hnsw-cohere-768-1m-post-filter.json
+++ b/vectorsearch/params/radial_search/filters/lucene-hnsw-cohere-768-1m-post-filter.json
@@ -12,8 +12,13 @@
     "target_dataset_filter_attributes": [
         "filter01pct",
         "filter1pct",
+        "filter5pct",
         "filter10pct",
-        "filter60pct"
+        "filter25pct",
+        "filter50pct",
+        "filter75pct",
+        "filter90pct",
+        "filter99pct"
     ],
     "target_index_max_num_segments": 1,
     "target_index_force_merge_timeout": 600.0,

--- a/vectorsearch/test_procedures/common/filter-percentage-sweep-schedule.json
+++ b/vectorsearch/test_procedures/common/filter-percentage-sweep-schedule.json
@@ -1,0 +1,39 @@
+{
+    "name" : "warmup-indices",
+    "operation" : "warmup-indices",
+    "index": "{{ target_index_name | default('target_index') }}"
+},
+{%- for pct in filter_percentages %}
+{
+    "operation": {
+        "name": "prod-queries-{{ pct }}",
+        "operation-type": "vector-search",
+        "index": "{{ target_index_name | default('target_index') }}",
+        "detailed-results": true,
+        {% if query_k is defined %}
+        "k": {{ query_k }},
+        {% endif %}
+        {% if radial_search_type is defined %}
+        "radial_search_type": "{{ radial_search_type }}",
+        {% endif %}
+        {% if target_index_body is defined %}
+        "target_index_body": "{{ target_index_body }}",
+        {% endif %}
+        "field" : "{{ target_field_name | default('target_field') }}",
+        "data_set_format" : "{{ query_data_set_format | default('hdf5') }}",
+        "data_set_path" : "{{ query_data_set_path }}",
+        "data_set_corpus" : "{{ query_data_set_corpus }}",
+        "neighbors_data_set_path" : "{{ neighbors_data_set_path }}",
+        "neighbors_data_set_corpus" : "{{ neighbors_data_set_corpus }}",
+        "neighbors_data_set_format" : "{{ neighbors_data_set_format | default('hdf5') }}",
+        "num_vectors" : {{ query_count | default(-1) }},
+        "id-field-name": "{{ id_field_name }}",
+        "body": {{ query_body | default ({}) | tojson }},
+        "filter_body": {"term": {"filter{{ pct }}": "true"}},
+        "filter_type": {{ filter_type | default ({}) | tojson }},
+        "filter_percentage": "{{ pct }}",
+        "repetitions": {{ number_of_repetitions | default(1)}}
+    },
+    "clients": {{ search_clients | default(1)}}
+}{{ "," if not loop.last }}
+{%- endfor %}

--- a/vectorsearch/test_procedures/common/search-only-premerge-schedule.json
+++ b/vectorsearch/test_procedures/common/search-only-premerge-schedule.json
@@ -40,6 +40,9 @@
         "body": {{ query_body | default ({}) | tojson }},
         "filter_body": {{ filter_body | default ({}) | tojson }},
         "filter_type": {{filter_type  | default ({}) | tojson }}
+        {% if filter_percentage is defined %}
+        ,"filter_percentage": "{{ filter_percentage }}"
+        {% endif %}
     },
     "clients": {{ search_clients | default(1)}}
 }

--- a/vectorsearch/test_procedures/common/search-only-schedule.json
+++ b/vectorsearch/test_procedures/common/search-only-schedule.json
@@ -41,7 +41,8 @@
         "filter_type": {{filter_type  | default ({}) | tojson }},
         {% if filter_percentage is defined %}
         "filter_percentage": "{{ filter_percentage }}",
-        {% endif %}"repetitions": {{ number_of_repetitions | default(1)}}
+        {% endif %}
+        "repetitions": {{ number_of_repetitions | default(1)}}
     },
     "clients": {{ search_clients | default(1)}}
 }

--- a/vectorsearch/test_procedures/common/search-only-schedule.json
+++ b/vectorsearch/test_procedures/common/search-only-schedule.json
@@ -39,7 +39,9 @@
         "body": {{ query_body | default ({}) | tojson }},
         "filter_body": {{ filter_body | default ({}) | tojson }},
         "filter_type": {{filter_type  | default ({}) | tojson }},
-        "repetitions": {{ number_of_repetitions | default(1)}}
+        {% if filter_percentage is defined %}
+        "filter_percentage": "{{ filter_percentage }}",
+        {% endif %}"repetitions": {{ number_of_repetitions | default(1)}}
     },
     "clients": {{ search_clients | default(1)}}
 }

--- a/vectorsearch/test_procedures/default.json
+++ b/vectorsearch/test_procedures/default.json
@@ -44,6 +44,24 @@
     ]
 },
 {
+    "name": "filter-percentage-sweep",
+    "default": false,
+    "description": "Index once, then run radial filtered search at each percentage in filter_percentages.",
+    "schedule": [
+       {{ benchmark.collect(parts="common/index-only-schedule.json") }},
+       {{ benchmark.collect(parts="common/force-merge-schedule.json") }},
+       {{ benchmark.collect(parts="common/filter-percentage-sweep-schedule.json") }}
+    ]
+},
+{
+    "name": "filter-percentage-sweep-search-only",
+    "default": false,
+    "description": "Radial filtered search at each percentage in filter_percentages on a previously indexed cluster.",
+    "schedule": [
+       {{ benchmark.collect(parts="common/filter-percentage-sweep-schedule.json") }}
+    ]
+},
+{
     "name": "force-merge-index",
     "default": false,
     "description": "Force merge vector search index to improve search performance",

--- a/vectorsearch/workload.json
+++ b/vectorsearch/workload.json
@@ -133,6 +133,18 @@
           "document-count": 1000000
         }
       ]
+    },
+    {
+      "name": "cohere-1m-radial-filter-percentage",
+      "base-url": "https://dbyiw3u3rf9yr.cloudfront.net/corpora/vectorsearch/cohere-wikipedia-22-12-en-embeddings",
+      "target-index": "{{ target_index_name }}",
+      "documents": [
+        {
+          "source-file": "cohere-1m-radial-filter-percentage.hdf5.bz2",
+          "source-format": "hdf5",
+          "document-count": 1000000
+        }
+      ]
     }
   ],
     "operations": [


### PR DESCRIPTION
### Description

Adds benchmark support for radial search with filtering at controlled selectivities.
Each doc gets one boolean keyword field per ratio (`filter01pct` ... `filter99pct`,
covering 0.1/1/5/10/25/50/75/90/99%), each marking exactly that percentage of docs
`'true'` at random; the benchmark filter is a term query on one field.

Ground truth is filter-first: per percentage, top-1000 nearest passing docs per query,
with the k-th passing distance as the radial threshold. All percentages live as suffixed
columns in one HDF5 corpus (`cohere-1m-radial-filter-percentage`); the `filter_percentage`
param selects which columns to read.

Also adds a `filter-percentage-sweep` test procedure: index once, then run the search
task once per entry in the `filter_percentages` list param (one operation per ratio,
e.g. `prod-queries-10pct`) — so nightly covers multiple selectivities with a single
ingest per engine.

### Testing

Full 18-cell curve (2 engines x 9 selectivities) on OpenSearch 3.8.0.
Ground truth validated by independent brute-force computation and forced exact search (recall 1.0).

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
