### PR TITLE
Fix workload rendering when filter_percentages is not defined

### DIFF
--- a/vectorsearch/test_procedures/common/filter-percentage-sweep-schedule.json
+++ b/vectorsearch/test_procedures/common/filter-percentage-sweep-schedule.json
@@ -2,8 +2,8 @@
     "name" : "warmup-indices",
     "operation" : "warmup-indices",
     "index": "{{ target_index_name | default('target_index') }}"
-},
-{%- for pct in filter_percentages %}
+}
+{%- for pct in filter_percentages | default([]) %},
 {
     "operation": {
         "name": "prod-queries-{{ pct }}",
@@ -35,5 +35,5 @@
         "repetitions": {{ number_of_repetitions | default(1)}}
     },
     "clients": {{ search_clients | default(1)}}
-}{{ "," if not loop.last }}
+}
 {%- endfor %}


### PR DESCRIPTION
### Description
Added a default([]) to the filter_percentages loop in the sweep schedule (from #813) to fix vectorsearch failing to load with a JSON error when the param is not set. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
