### PR TITLE
[Backport 3] Filtered vector search benchmarks (#813, #814, #820)

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -27,14 +27,14 @@ jobs:
     steps:
       - name: GitHub App token
         id: github_app_token
-        uses: tibdex/github-app-token@v1.5.0
+        uses: tibdex/github-app-token@1901dc7d52169e70c27a8da37aef0d423e2867a2 # v1.5.0
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
           installation_id: 22958780
 
       - name: Backport
-        uses: VachaShah/backport@v2.1.0
+        uses: VachaShah/backport@c2d4cc919ef00608e9a6c66373d6bd62a2748153 # v2.1.0
         with:
           github_token: ${{ steps.github_app_token.outputs.token }}
           head_template: backport/backport-<%= number %>-to-<%= base %>

--- a/.github/workflows/delete-backport-branch.yml
+++ b/.github/workflows/delete-backport-branch.yml
@@ -11,6 +11,6 @@ jobs:
     if: startsWith(github.event.pull_request.head.ref,'backport/')
     steps:
       - name: Delete merged branch
-        uses: SvanBoxel/delete-merged-branch@main
+        uses: SvanBoxel/delete-merged-branch@2b5b058e3db41a3328fd9a6a58fd4c2545a14353 # main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workload-format-checker.yml
+++ b/.github/workflows/workload-format-checker.yml
@@ -6,10 +6,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: '3.x'
 
@@ -23,7 +23,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           files: |
             **.json

--- a/vectorsearch/README.md
+++ b/vectorsearch/README.md
@@ -104,6 +104,9 @@ This workload allows the following parameters to be specified using `--workload-
 | query_data_set_format                   | Format of vector data set for queries                                                                                                |
 | query_data_set_path                     | Path to vector data set for queries                                                                                                  |
 | query_count                             | Number of queries for search operation                                                                                               |
+| filter_type                             | Type of filter to apply to the query: `efficient` (inside the knn clause), `post_filter`, `boolean`, or `script` (exact script-score search over filtered docs) |
+| filter_body                             | Body of the filter query (e.g. a term query on a filter field)                                                                       |
+| filter_percentage                       | Filter selectivity suffix for per-percentage ground truth datasets (e.g. `10pct` reads `neighbors_10pct`); must match the field used in filter_body |
 | query_body                              | Json properties that will be merged with search body                                                                                 |
 | search_clients                          | Number of clients to use for running queries                                                                                         |
 | repetitions                             | Number of repetitions until the data set is exhausted (default 1)                                                                    |

--- a/vectorsearch/_tools/filter_percentage_utils.py
+++ b/vectorsearch/_tools/filter_percentage_utils.py
@@ -1,0 +1,38 @@
+"""
+Shared helpers for per-percentage filtered vector search dataset tools.
+
+Each benchmarked filter percentage maps to one boolean keyword field named
+filter<suffix> (e.g. 0.1 -> filter01pct, 25 -> filter25pct). For each field,
+exactly that fraction of documents is marked 'true', chosen uniformly at
+random, so a term query passes exactly that percentage of documents scattered
+randomly across the HNSW graph. Used by the flat radial generator
+(generate_radial_filter_percentage_ground_truth.py, docs = vectors) and the
+nested generator (generate_nested_filter_percentage_ground_truth.py,
+docs = parent documents).
+"""
+
+import numpy as np
+
+
+def pct_suffix(pct):
+    """0.1 -> '01pct', 1 -> '1pct', 25 -> '25pct'"""
+    if pct < 1:
+        return f"0{str(pct).replace('0.', '')}pct"
+    return f"{int(pct)}pct"
+
+
+def assign_attributes(num_docs, percentages, suffixes, seed):
+    """For each percentage, mark exactly n_pass random docs 'true'.
+
+    Returns the (num_docs, P) attribute matrix and per-column sorted passing ids.
+    """
+    rng = np.random.default_rng(seed)
+    attributes = np.full((num_docs, len(percentages)), b"false", dtype="|S8")
+    passing_ids = {}
+    for col, pct in enumerate(percentages):
+        n_pass = int(round(pct / 100.0 * num_docs))
+        chosen = rng.permutation(num_docs)[:n_pass]
+        attributes[chosen, col] = b"true"
+        passing_ids[col] = np.sort(chosen)
+        print(f"  filter{suffixes[col]}: exactly {n_pass} docs marked true")
+    return attributes, passing_ids

--- a/vectorsearch/_tools/generate_nested_filter_percentage_ground_truth.py
+++ b/vectorsearch/_tools/generate_nested_filter_percentage_ground_truth.py
@@ -1,0 +1,305 @@
+"""
+Generate a nested + filtered vector search dataset with per-percentage ground truth.
+
+Documents are parent docs holding multiple nested child vectors (as in
+generate_nested_dataset.py). Each PARENT doc gets one boolean filter attribute
+field per requested percentage, named filter<P>pct (e.g. filter1pct,
+filter25pct). For each field, exactly that fraction of parent docs is marked
+'true', chosen uniformly at random (as in
+generate_radial_filter_percentage_ground_truth.py). Filtering with a term
+query (e.g. {"term": {"filter25pct": "true"}}) therefore passes exactly that
+percentage of parent docs.
+
+For each percentage, ground truth is computed filter-first over parent docs:
+restrict to passing parents, rank them by best child match (min distance over
+the parent's nested vectors — matching OpenSearch nested knn scoring), and
+keep the top take_n parent IDs. The same ground truth serves every filter
+placement (efficient filter inside the knn clause, parent-level bool filter,
+post_filter): the correct answer depends only on which parents pass, not on
+where the query puts the filter.
+
+Usage:
+    python generate_nested_filter_percentage_ground_truth.py \
+        --mode cohere --input cohere-10m.hdf5 \
+        --num-docs 1000000 --distribution uniform --max-vectors-per-doc 20 \
+        --num-queries 10000 --space-type innerproduct \
+        --percentages 0.1 1 5 10 25 50 75 90 99 \
+        --take-n 100 \
+        --output cohere-10m-nested-filter-percentage.hdf5
+
+Output HDF5 layout (one set of columns per percentage, suffixed by its field
+name — e.g. for percentage 10 the suffix is 10pct):
+    train:              (total_vectors, dim) float32 — all child vectors, parent-contiguous
+    test:               (Q, dim)     float32 — query vectors
+    parents:            (total_vectors,) int32 — 1-based parent doc ID per vector
+    attributes:         (total_vectors, P) |S8 — 'true'/'false' per percentage field,
+                        vector-aligned (each parent's value repeated across its
+                        child vectors) so OSB can stream it in lockstep with train
+    neighbors_<suffix>: (Q, take_n)  int32   — top take_n passing parent doc IDs
+                                               (1-based), nearest first
+    distances_<suffix>: (Q, take_n)  float32 — raw best-child distances for those parents
+
+Attribute column order matches --percentages order and maps to index fields:
+    percentage P -> field filter<suffix> (0.1 -> filter01pct, 25 -> filter25pct, ...)
+
+Parent IDs are 1-based to match the document _id written by OSB's nested bulk
+ingest (unlike the flat filter dataset, whose neighbors are 0-based row
+indices). No radial threshold columns: nested+filter benchmarks are top-k.
+
+Memory: train is held in RAM — ~32 GB for 10M x 768d float32; use a
+memory-optimized instance at that scale.
+
+Requires take_n <= passing parent docs at the smallest percentage.
+"""
+
+import argparse
+import time
+
+import h5py
+import numpy as np
+
+from nested_dataset_utils import calculate_distances, generate_parents
+from filter_percentage_utils import assign_attributes, pct_suffix
+from radial_threshold_utils import SUPPORTED_SPACE_TYPES, calculate_distances_batch
+
+DEFAULT_PERCENTAGES = [0.1, 1, 5, 10, 25, 50, 75, 90, 99]
+CORPUS_CHUNK_TARGET = 1_000_000  # child vectors per distance chunk (~400MB per 100-query batch)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Generate per-percentage filtered nested ground truth for vector search benchmarks")
+    parser.add_argument("--mode", choices=["cohere", "synthetic"], default="cohere",
+                        help="Vector source: 'cohere' reads train/test from --input HDF5; "
+                             "'synthetic' generates random unit vectors (for testing)")
+    parser.add_argument("--input", help="Input HDF5 with train/test (required for --mode cohere)")
+    parser.add_argument("--dim", type=int, default=768, help="Vector dimension (synthetic mode only)")
+    parser.add_argument("--output", required=True, help="Output HDF5 path")
+    parser.add_argument("--space-type", required=True, choices=list(SUPPORTED_SPACE_TYPES))
+    parser.add_argument("--num-docs", type=int, required=True, help="Number of parent documents")
+    parser.add_argument("--distribution", choices=["fixed", "uniform", "normal"], default="uniform")
+    parser.add_argument("--vectors-per-doc", type=int, default=10,
+                        help="Vectors per doc (fixed distribution)")
+    parser.add_argument("--max-vectors-per-doc", type=int, default=20,
+                        help="Max vectors per doc (uniform/normal distributions)")
+    parser.add_argument("--num-queries", type=int, default=10000)
+    parser.add_argument("--percentages", type=float, nargs="+", default=DEFAULT_PERCENTAGES,
+                        help="Filter percentages (default: 0.1 1 5 10 25 50 75 90 99)")
+    parser.add_argument("--take-n", type=int, default=100,
+                        help="Ground truth parent docs stored per query per percentage (default: 100)")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--query-batch-size", type=int, default=100)
+    parser.add_argument("--num-verify-queries", type=int, default=5,
+                        help="Spot-check queries per percentage in the verification phase")
+    return parser.parse_args()
+
+
+def validate_args(args):
+    if args.mode == "cohere" and not args.input:
+        raise ValueError("--input is required for --mode cohere")
+    suffixes = [pct_suffix(p) for p in args.percentages]
+    if len(set(suffixes)) != len(suffixes):
+        raise ValueError(f"Percentages {args.percentages} map to duplicate "
+                         f"field suffixes {suffixes}")
+    for pct in args.percentages:
+        if not 0 < pct < 100:
+            raise ValueError(f"Percentages must be in (0, 100), got {pct}")
+        n_pass = int(round(pct / 100.0 * args.num_docs))
+        if n_pass < args.take_n:
+            raise ValueError(f"{pct}% passes only {n_pass} parent docs < take_n={args.take_n}. "
+                             f"Reduce --take-n or raise the percentage.")
+    return suffixes
+
+
+def load_vectors(args, total_vectors):
+    """Load child vectors + queries; synthetic mode generates both."""
+    if args.mode == "synthetic":
+        rng = np.random.default_rng(args.seed + 1)
+        train = rng.standard_normal((total_vectors, args.dim), dtype=np.float32)
+        train /= np.linalg.norm(train, axis=1, keepdims=True)
+        test = rng.standard_normal((args.num_queries, args.dim), dtype=np.float32)
+        test /= np.linalg.norm(test, axis=1, keepdims=True)
+        return train, test
+    with h5py.File(args.input, "r") as f:
+        available = f["train"].shape[0]
+        if total_vectors > available:
+            raise ValueError(f"Need {total_vectors:,} vectors but input only has {available:,}")
+        if args.num_queries > f["test"].shape[0]:
+            raise ValueError(f"Need {args.num_queries:,} queries but input only has "
+                             f"{f['test'].shape[0]:,}")
+        print(f"Loading {total_vectors:,} train vectors and {args.num_queries:,} queries "
+              f"from {args.input}...")
+        train = f["train"][:total_vectors].astype(np.float32, copy=False)
+        test = f["test"][:args.num_queries].astype(np.float32, copy=False)
+    return train, test
+
+
+def build_corpus_chunks(doc_offsets, num_docs, total_vectors):
+    """Split the corpus into chunks aligned to parent boundaries.
+
+    Returns a list of (p0, p1, v0, v1): parents [p0, p1) own vectors [v0, v1).
+    Alignment keeps every parent's vectors inside one chunk so the per-parent
+    min-reduction never straddles a chunk edge.
+    """
+    parent_starts = doc_offsets[:, 0]
+    chunks = []
+    p0 = 0
+    while p0 < num_docs:
+        v0 = int(parent_starts[p0])
+        # First parent starting at or beyond the target end of this chunk
+        p1 = int(np.searchsorted(parent_starts, v0 + CORPUS_CHUNK_TARGET, side="left"))
+        p1 = max(p1, p0 + 1)
+        v1 = int(parent_starts[p1]) if p1 < num_docs else total_vectors
+        chunks.append((p0, p1, v0, v1))
+        p0 = p1
+    return chunks
+
+
+def compute_ground_truth(train, test, doc_offsets, passing_ids, suffixes, args):
+    """Filter-first brute force over parent docs.
+
+    Per query batch: child distances once, per-parent min once (best child
+    match), then each percentage is a cheap column slice of the parent-distance
+    matrix followed by a top-take_n selection over passing parents only.
+    """
+    num_queries = test.shape[0]
+    num_docs = doc_offsets.shape[0]
+    parent_starts = doc_offsets[:, 0]
+    chunks = build_corpus_chunks(doc_offsets, num_docs, train.shape[0])
+
+    out = {}
+    for s in suffixes:
+        out[s] = {
+            "neighbors": np.empty((num_queries, args.take_n), dtype=np.int32),
+            "distances": np.empty((num_queries, args.take_n), dtype=np.float32),
+        }
+
+    print(f"\nComputing ground truth for {num_queries} queries x {len(suffixes)} percentages "
+          f"(take_n={args.take_n}, {len(chunks)} corpus chunks)...")
+    t0 = time.time()
+    for batch_start in range(0, num_queries, args.query_batch_size):
+        batch_end = min(batch_start + args.query_batch_size, num_queries)
+        if batch_start % 1000 == 0:
+            print(f"  {batch_start}/{num_queries} ({time.time()-t0:.0f}s)")
+        test_batch = test[batch_start:batch_end]
+
+        # Best child match per parent: min over each parent's child vectors.
+        doc_dists = np.empty((batch_end - batch_start, num_docs), dtype=np.float32)
+        for p0, p1, v0, v1 in chunks:
+            child_dists = calculate_distances_batch(test_batch, train[v0:v1], args.space_type)
+            doc_dists[:, p0:p1] = np.minimum.reduceat(
+                child_dists, parent_starts[p0:p1] - v0, axis=1)
+
+        # Filter-first per percentage: slice passing parents, take the top take_n.
+        for col, s in enumerate(suffixes):
+            ids = passing_ids[col]
+            sub = doc_dists[:, ids]
+            for i in range(batch_end - batch_start):
+                d = sub[i]
+                if args.take_n < len(d):
+                    idx = np.argpartition(d, args.take_n - 1)[:args.take_n]
+                    idx = idx[np.argsort(d[idx])]
+                else:
+                    idx = np.argsort(d)
+                out[s]["neighbors"][batch_start + i] = ids[idx] + 1  # 1-based parent IDs
+                out[s]["distances"][batch_start + i] = d[idx]
+    print(f"Done in {time.time()-t0:.0f}s")
+    return out
+
+
+def verify_ground_truth(train, test, doc_offsets, passing_ids, suffixes, out, args):
+    """Independent spot-check: recompute a few queries per percentage with a
+    naive per-parent loop (different code path than the batched reduction) and
+    require an exact match against the stored ground truth."""
+    rng = np.random.default_rng(args.seed + 2)
+    query_indices = rng.choice(test.shape[0], size=min(args.num_verify_queries, test.shape[0]),
+                               replace=False)
+    print(f"\nVerifying queries {sorted(query_indices.tolist())} at every percentage...")
+    for col, s in enumerate(suffixes):
+        ids = passing_ids[col]
+        for q_idx in query_indices:
+            dists = np.empty(len(ids), dtype=np.float32)
+            for j, doc in enumerate(ids):
+                start, count = doc_offsets[doc]
+                child = calculate_distances(test[q_idx], train[start:start + count],
+                                            args.space_type)
+                dists[j] = child.min()
+            order = np.argsort(dists, kind="stable")[:args.take_n]
+            expected_neighbors = ids[order] + 1
+            expected_distances = dists[order]
+            got_neighbors = out[s]["neighbors"][q_idx]
+            got_distances = out[s]["distances"][q_idx]
+            if not np.allclose(expected_distances, got_distances, rtol=1e-5, atol=1e-5):
+                raise AssertionError(
+                    f"filter{s} query {q_idx}: stored distances diverge from recomputation")
+            # Distance ties can order differently between argsort and argpartition;
+            # neighbors must agree exactly wherever distances are distinct.
+            mismatched = got_neighbors != expected_neighbors
+            if mismatched.any():
+                tied = np.isclose(got_distances[mismatched], expected_distances[mismatched],
+                                  rtol=1e-6, atol=1e-7)
+                if not tied.all():
+                    raise AssertionError(
+                        f"filter{s} query {q_idx}: neighbor mismatch beyond distance ties")
+        print(f"  filter{s}: OK")
+
+
+def write_output(args, train, test, parents, attributes_vec, out, suffixes):
+    print(f"\nWriting {args.output}...")
+    with h5py.File(args.output, "w") as f:
+        f.create_dataset("train", data=train)
+        f.create_dataset("test", data=test)
+        f.create_dataset("parents", data=parents.astype(np.int32))
+        f.create_dataset("attributes", data=attributes_vec)
+        for s in suffixes:
+            f.create_dataset(f"neighbors_{s}", data=out[s]["neighbors"])
+            f.create_dataset(f"distances_{s}", data=out[s]["distances"])
+        f.attrs["space_type"] = args.space_type
+        f.attrs["percentages"] = args.percentages
+        f.attrs["take_n"] = args.take_n
+        f.attrs["seed"] = args.seed
+        f.attrs["num_docs"] = args.num_docs
+        f.attrs["distribution"] = args.distribution
+        if args.distribution == "fixed":
+            f.attrs["vectors_per_doc"] = args.vectors_per_doc
+        else:
+            f.attrs["max_vectors_per_doc"] = args.max_vectors_per_doc
+
+
+def main():
+    args = parse_args()
+    suffixes = validate_args(args)
+
+    print(f"Phase 1/5: parent assignment ({args.num_docs:,} docs, {args.distribution})")
+    total_available = None
+    if args.mode == "cohere":
+        with h5py.File(args.input, "r") as f:
+            total_available = f["train"].shape[0]
+    else:
+        # Synthetic mode generates exactly as many vectors as the distribution asks for.
+        total_available = args.num_docs * max(args.vectors_per_doc, args.max_vectors_per_doc)
+    parents, doc_offsets, total_vectors = generate_parents(
+        args.num_docs, args.distribution, args.vectors_per_doc,
+        args.max_vectors_per_doc, total_available, args.seed)
+    print(f"  {total_vectors:,} child vectors across {args.num_docs:,} parents")
+
+    print(f"\nPhase 2/5: filter attribute assignment ({len(suffixes)} percentages, per PARENT doc)")
+    attributes, passing_ids = assign_attributes(args.num_docs, args.percentages, suffixes, args.seed)
+    counts = doc_offsets[:, 1]
+    attributes_vec = np.repeat(attributes, counts, axis=0)  # vector-aligned for OSB ingest
+
+    print("\nPhase 3/5: loading vectors")
+    train, test = load_vectors(args, total_vectors)
+
+    print("\nPhase 4/5: ground truth")
+    out = compute_ground_truth(train, test, doc_offsets, passing_ids, suffixes, args)
+
+    print("\nPhase 5/5: verification")
+    verify_ground_truth(train, test, doc_offsets, passing_ids, suffixes, out, args)
+
+    write_output(args, train, test, parents, attributes_vec, out, suffixes)
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/vectorsearch/_tools/generate_radial_filter_percentage_ground_truth.py
+++ b/vectorsearch/_tools/generate_radial_filter_percentage_ground_truth.py
@@ -1,0 +1,211 @@
+"""
+Generate a filtered radial search dataset with per-percentage ground truth.
+
+Each document gets one boolean filter attribute field per requested percentage,
+named filter<P>pct (e.g. filter1pct, filter25pct). For each field, exactly that
+fraction of documents is marked 'true', chosen uniformly at random. Filtering
+with a term query (e.g. {"term": {"filter25pct": "true"}}) therefore passes
+exactly that percentage of documents, scattered randomly across the HNSW graph.
+
+For each percentage, ground truth is computed by brute force over the passing
+documents only: the top take_n nearest passing docs per query, plus per-query
+radial search thresholds (distance to the k-th nearest passing neighbor,
+converted per engine). This mirrors the unfiltered radial per-query benchmark:
+at benchmark time query_k selects the ground truth depth (neighbors[:k]) and
+the radial threshold (threshold[k-1]).
+
+Usage:
+    python generate_radial_filter_percentage_ground_truth.py \
+        --input cohere-1m.hdf5 \
+        --output cohere-1m-radial-filter-percentage.hdf5 \
+        --space-type innerproduct \
+        --percentages 0.1 1 5 10 25 50 75 90 99 \
+        --take-n 1000
+
+Output HDF5 layout (one set of columns per percentage, suffixed by its field
+name — e.g. for percentage 10 the suffix is 10pct):
+    train:                      (N, dim)     float32  — corpus vectors (copied from input)
+    test:                       (Q, dim)     float32  — query vectors (copied from input)
+    attributes:                 (N, P)       |S8      — 'true'/'false' per percentage field
+    neighbors_<suffix>:         (Q, take_n)  int64    — top take_n passing docs, nearest first
+    distances_<suffix>:         (Q, take_n)  float32  — raw distances for those neighbors
+    faiss_max_distance_<suffix>, faiss_min_score_<suffix>,
+    lucene_max_distance_<suffix>, lucene_min_score_<suffix>:
+                                (Q, take_n)  float32  — per-engine radial thresholds
+
+Attribute column order matches --percentages order and maps to index fields:
+    percentage P -> field filter<suffix> (0.1 -> filter01pct, 25 -> filter25pct, ...)
+
+Requires take_n <= passing docs at the smallest percentage.
+"""
+
+import argparse
+import shutil
+import time
+
+import h5py
+import numpy as np
+
+from radial_threshold_utils import (
+    SUPPORTED_SPACE_TYPES,
+    calculate_distances_batch,
+    engine_threshold_values,
+)
+
+ENGINES = ("faiss", "lucene")
+
+
+def pct_suffix(pct):
+    """0.1 -> '01pct', 1 -> '1pct', 25 -> '25pct'"""
+    if pct < 1:
+        return f"0{str(pct).replace('0.', '')}pct"
+    return f"{int(pct)}pct"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Generate per-percentage filtered radial ground truth for vector search benchmarks")
+    parser.add_argument("--input", required=True, help="Input HDF5 with train/test")
+    parser.add_argument("--output", required=True, help="Output HDF5 path")
+    parser.add_argument("--space-type", required=True, choices=list(SUPPORTED_SPACE_TYPES))
+    parser.add_argument("--percentages", type=float, nargs="+",
+                        default=[0.1, 1, 5, 10, 25, 50, 75, 90, 99],
+                        help="Filter percentages (default: 0.1 1 5 10 25 50 75 90 99)")
+    parser.add_argument("--take-n", type=int, default=1000,
+                        help="Neighbors stored per query per percentage (default: 1000)")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--query-batch-size", type=int, default=100)
+    return parser.parse_args()
+
+
+def load_input(path):
+    """Load corpus and query vectors, failing clearly if keys are missing."""
+    with h5py.File(path, "r") as f_in:
+        for key in ("train", "test"):
+            if key not in f_in:
+                raise ValueError(f"Input {path} is missing dataset '{key}'. "
+                                 f"Available keys: {sorted(f_in.keys())}")
+        print("Loading dataset...")
+        train = f_in["train"][:]
+        test = f_in["test"][:]
+    print(f"  train: {train.shape}, test: {test.shape}")
+    return train, test
+
+
+def validate_args(args, num_docs):
+    """Validate percentages and take_n before doing any work. Returns suffixes."""
+    if args.take_n <= 0:
+        raise ValueError(f"--take-n must be positive, got {args.take_n}")
+    suffixes = [pct_suffix(p) for p in args.percentages]
+    if len(set(suffixes)) != len(suffixes):
+        raise ValueError(f"Percentages {args.percentages} map to duplicate "
+                         f"field suffixes {suffixes}")
+    for pct in args.percentages:
+        if not 0 < pct < 100:
+            raise ValueError(f"Percentages must be in (0, 100), got {pct}")
+        n_pass = int(round(pct / 100.0 * num_docs))
+        if n_pass < args.take_n:
+            raise ValueError(f"{pct}% passes only {n_pass} docs < take_n={args.take_n}. "
+                             f"Reduce --take-n or raise the percentage.")
+    return suffixes
+
+
+def assign_attributes(num_docs, percentages, suffixes, seed):
+    """For each percentage, mark exactly n_pass random docs 'true'.
+
+    Returns the (num_docs, P) attribute matrix and per-column sorted passing ids.
+    """
+    rng = np.random.default_rng(seed)
+    attributes = np.full((num_docs, len(percentages)), b"false", dtype="|S8")
+    passing_ids = {}
+    for col, pct in enumerate(percentages):
+        n_pass = int(round(pct / 100.0 * num_docs))
+        chosen = rng.permutation(num_docs)[:n_pass]
+        attributes[chosen, col] = b"true"
+        passing_ids[col] = np.sort(chosen)
+        print(f"  filter{suffixes[col]}: exactly {n_pass} docs marked true")
+    return attributes, passing_ids
+
+
+def compute_ground_truth(train, test, passing_ids, suffixes, args):
+    """Filter-first brute force: per percentage, top take_n passing docs per query."""
+    num_queries = test.shape[0]
+    out = {}
+    for s in suffixes:
+        out[s] = {
+            "neighbors": np.empty((num_queries, args.take_n), dtype=np.int64),
+            "distances": np.empty((num_queries, args.take_n), dtype=np.float32),
+        }
+
+    print(f"\nComputing ground truth for {num_queries} queries "
+          f"x {len(suffixes)} percentages (take_n={args.take_n})...")
+    t0 = time.time()
+    for batch_start in range(0, num_queries, args.query_batch_size):
+        batch_end = min(batch_start + args.query_batch_size, num_queries)
+        if batch_start % 1000 == 0:
+            print(f"  {batch_start}/{num_queries} ({time.time()-t0:.0f}s)")
+        # One distance computation per batch, reused for all percentages
+        batch_dists = calculate_distances_batch(test[batch_start:batch_end], train, args.space_type)
+
+        for col, s in enumerate(suffixes):
+            ids = passing_ids[col]
+            sub = batch_dists[:, ids]                      # distances to passing docs only
+            for i in range(batch_end - batch_start):
+                d = sub[i]
+                if args.take_n < len(d):
+                    idx = np.argpartition(d, args.take_n - 1)[:args.take_n]
+                    idx = idx[np.argsort(d[idx])]
+                else:
+                    idx = np.argsort(d)
+                out[s]["neighbors"][batch_start + i] = ids[idx]
+                out[s]["distances"][batch_start + i] = d[idx]
+    print(f"Done in {time.time()-t0:.0f}s")
+    return out
+
+
+def write_output(args, attributes, out, suffixes):
+    """Copy input to output and add/replace attribute + per-percentage datasets."""
+    shutil.copy2(args.input, args.output)
+    with h5py.File(args.output, "a") as f_out:
+        def write(name, data):
+            if name in f_out:
+                del f_out[name]
+            f_out.create_dataset(name, data=data)
+
+        write("attributes", attributes)
+        for s in suffixes:
+            dist = out[s]["distances"]
+            write(f"neighbors_{s}", out[s]["neighbors"])
+            write(f"distances_{s}", dist)
+            for engine in ENGINES:
+                max_distance, min_score = engine_threshold_values(engine, args.space_type, dist)
+                write(f"{engine}_max_distance_{s}", max_distance)
+                write(f"{engine}_min_score_{s}", min_score)
+
+        f_out.attrs["space_type"] = args.space_type
+        f_out.attrs["percentages"] = args.percentages
+        f_out.attrs["take_n"] = args.take_n
+        f_out.attrs["seed"] = args.seed
+
+
+def main():
+    args = parse_args()
+    train, test = load_input(args.input)
+    num_docs, num_queries = train.shape[0], test.shape[0]
+
+    suffixes = validate_args(args, num_docs)
+    print(f"Percentages: {args.percentages} -> fields filter{{{', filter'.join(suffixes)}}}")
+
+    attributes, passing_ids = assign_attributes(num_docs, args.percentages, suffixes, args.seed)
+    out = compute_ground_truth(train, test, passing_ids, suffixes, args)
+    write_output(args, attributes, out, suffixes)
+
+    print(f"\nWritten to {args.output}")
+    print(f"  attributes: {attributes.shape}")
+    for s in suffixes:
+        print(f"  neighbors_{s} / distances_{s} / thresholds_{s}: ({num_queries}, {args.take_n})")
+    print(f"\nBenchmark filter body example: {{\"term\": {{\"filter{suffixes[-1]}\": \"true\"}}}}")
+
+
+if __name__ == "__main__":
+    main()

--- a/vectorsearch/_tools/generate_radial_filter_percentage_ground_truth.py
+++ b/vectorsearch/_tools/generate_radial_filter_percentage_ground_truth.py
@@ -46,6 +46,7 @@ import time
 import h5py
 import numpy as np
 
+from filter_percentage_utils import assign_attributes, pct_suffix
 from radial_threshold_utils import (
     SUPPORTED_SPACE_TYPES,
     calculate_distances_batch,
@@ -53,13 +54,6 @@ from radial_threshold_utils import (
 )
 
 ENGINES = ("faiss", "lucene")
-
-
-def pct_suffix(pct):
-    """0.1 -> '01pct', 1 -> '1pct', 25 -> '25pct'"""
-    if pct < 1:
-        return f"0{str(pct).replace('0.', '')}pct"
-    return f"{int(pct)}pct"
 
 
 def parse_args():
@@ -108,23 +102,6 @@ def validate_args(args, num_docs):
             raise ValueError(f"{pct}% passes only {n_pass} docs < take_n={args.take_n}. "
                              f"Reduce --take-n or raise the percentage.")
     return suffixes
-
-
-def assign_attributes(num_docs, percentages, suffixes, seed):
-    """For each percentage, mark exactly n_pass random docs 'true'.
-
-    Returns the (num_docs, P) attribute matrix and per-column sorted passing ids.
-    """
-    rng = np.random.default_rng(seed)
-    attributes = np.full((num_docs, len(percentages)), b"false", dtype="|S8")
-    passing_ids = {}
-    for col, pct in enumerate(percentages):
-        n_pass = int(round(pct / 100.0 * num_docs))
-        chosen = rng.permutation(num_docs)[:n_pass]
-        attributes[chosen, col] = b"true"
-        passing_ids[col] = np.sort(chosen)
-        print(f"  filter{suffixes[col]}: exactly {n_pass} docs marked true")
-    return attributes, passing_ids
 
 
 def compute_ground_truth(train, test, passing_ids, suffixes, args):

--- a/vectorsearch/_tools/nested_dataset_utils.py
+++ b/vectorsearch/_tools/nested_dataset_utils.py
@@ -1,0 +1,67 @@
+"""
+Shared helpers for nested vector search dataset tools.
+
+Nested datasets store multiple child vectors per parent document; the parents
+array assigns each vector (contiguously) to a 1-based parent doc ID. Used by
+generate_nested_dataset.py and generate_nested_filter_percentage_ground_truth.py.
+"""
+
+import numpy as np
+
+
+def calculate_distances(query, vectors, space_type):
+    """Compute distances from a single query to a batch of vectors."""
+    if space_type == "l2":
+        return np.sum((vectors - query) ** 2, axis=1)
+    elif space_type == "innerproduct":
+        return -np.dot(vectors, query)
+    elif space_type == "cosine":
+        norm_query = np.linalg.norm(query)
+        norms_vectors = np.linalg.norm(vectors, axis=1)
+        return 1 - (np.dot(vectors, query) / (norms_vectors * norm_query + 1e-10))
+    else:
+        raise ValueError(f"Unsupported space type: {space_type}")
+
+
+def generate_parents(num_docs, distribution, vectors_per_doc, max_vectors_per_doc, total_available, seed):
+    """Generate parent ID array based on distribution.
+
+    Returns:
+        parents: array of parent IDs (1-based) for each vector
+        doc_offsets: array of (start_idx, count) per doc for ground truth
+    """
+    np.random.seed(seed)
+
+    if distribution == "fixed":
+        counts = np.full(num_docs, vectors_per_doc, dtype="int32")
+    elif distribution == "uniform":
+        counts = np.random.randint(1, max_vectors_per_doc + 1, size=num_docs).astype("int32")
+    elif distribution == "normal":
+        mean = (1 + max_vectors_per_doc) / 2
+        std = (max_vectors_per_doc - 1) / 4
+        counts = np.random.normal(mean, std, size=num_docs).astype("int32")
+        counts = np.clip(counts, 1, max_vectors_per_doc)
+
+    total_needed = int(counts.sum())
+    if total_needed > total_available:
+        scale = total_available / total_needed
+        counts = np.maximum(1, (counts * scale).astype("int32"))
+        total_needed = int(counts.sum())
+        if total_needed > total_available:
+            excess = total_needed - total_available
+            for i in range(excess):
+                idx = num_docs - 1 - i
+                if counts[idx] > 1:
+                    counts[idx] -= 1
+
+    total_vectors = int(counts.sum())
+
+    # Build parents array (1-based doc IDs)
+    parents = np.repeat(np.arange(1, num_docs + 1), counts)
+
+    # Build doc_offsets for ground truth computation
+    offsets = np.zeros(num_docs, dtype="int64")
+    offsets[1:] = np.cumsum(counts[:-1])
+    doc_offsets = np.column_stack([offsets, counts])
+
+    return parents, doc_offsets, total_vectors

--- a/vectorsearch/_tools/radial_threshold_utils.py
+++ b/vectorsearch/_tools/radial_threshold_utils.py
@@ -1,0 +1,80 @@
+"""
+Shared distance and radial-threshold conversions for vector search dataset tools.
+
+Radial search thresholds are engine- and space-type-specific. The conversions
+here mirror the k-NN plugin so that stored thresholds match what each engine
+expects at query time:
+
+- Faiss `max_distance` takes the raw space-type distance. For innerproduct the
+  plugin negates the dot product internally (larger dot product = smaller
+  "distance"), so raw distances (and thresholds) are negative for well-matching
+  vectors. See SpaceType.INNER_PRODUCT and FaissService in opensearch-knn.
+- Lucene `max_distance` for innerproduct is the (non-negated) dot product, the
+  opposite sign convention from Faiss. See LuceneEngine / VectorSimilarityFunction
+  .MAXIMUM_INNER_PRODUCT in opensearch-knn and Lucene.
+- `min_score` uses the plugin's distance-to-score translation, identical for
+  both engines. See SpaceType#scoreTranslation in opensearch-knn:
+    l2:           score = 1 / (1 + d)
+    innerproduct: score = 1 / (1 + d)      if d >= 0
+                  score = -d + 1           if d < 0
+    cosine:       score = (2 - d) / 2
+
+Distance functions and score translations per space type are documented at
+https://docs.opensearch.org/latest/mappings/supported-field-types/knn-spaces/
+"""
+
+import numpy as np
+
+SUPPORTED_SPACE_TYPES = ("l2", "innerproduct", "cosine")
+
+
+def calculate_distances_batch(queries, corpus, space_type):
+    """Raw space-type distances from each query to every corpus vector.
+
+    Returns a (num_queries, num_corpus) float array where smaller = closer,
+    matching the k-NN plugin's internal distance convention per space type
+    (innerproduct is negated so it sorts ascending like l2/cosine).
+    """
+    if space_type == "l2":
+        q_norms = np.sum(queries ** 2, axis=1, keepdims=True)
+        c_norms = np.sum(corpus ** 2, axis=1, keepdims=True).T
+        dots = queries @ corpus.T
+        return q_norms + c_norms - 2 * dots
+    if space_type == "innerproduct":
+        return -(queries @ corpus.T)
+    if space_type == "cosine":
+        q_norms = np.linalg.norm(queries, axis=1, keepdims=True)
+        c_norms = np.linalg.norm(corpus, axis=1, keepdims=True).T
+        dots = queries @ corpus.T
+        return 1 - dots / (q_norms * c_norms)
+    raise ValueError(f"Unsupported space type: {space_type}. Supported: {SUPPORTED_SPACE_TYPES}")
+
+
+def raw_distance_to_opensearch_score(distances, space_type):
+    """k-NN plugin score for a raw distance (SpaceType#scoreTranslation)."""
+    if space_type == "l2":
+        return 1.0 / (1.0 + distances)
+    if space_type == "innerproduct":
+        return np.where(distances >= 0, 1.0 / (1.0 + distances), -distances + 1.0)
+    if space_type == "cosine":
+        return (2.0 - distances) / 2.0
+    raise ValueError(f"Unsupported space type: {space_type}. Supported: {SUPPORTED_SPACE_TYPES}")
+
+
+def engine_threshold_values(engine, space_type, distances):
+    """Radial threshold columns for one engine: (max_distance, min_score).
+
+    `distances` are raw space-type distances from calculate_distances_batch.
+    Faiss max_distance is the raw distance. Lucene max_distance for
+    innerproduct flips the sign back to a plain dot product (Lucene's
+    MAXIMUM_INNER_PRODUCT convention); other space types match Faiss.
+    min_score is the shared plugin score translation for both engines.
+    """
+    if engine not in ("faiss", "lucene"):
+        raise ValueError(f"Unsupported engine: {engine}. Supported: faiss, lucene")
+    if engine == "lucene" and space_type == "innerproduct":
+        max_distance = -distances
+    else:
+        max_distance = distances.copy()
+    min_score = raw_distance_to_opensearch_score(distances, space_type).astype(np.float32)
+    return max_distance, min_score

--- a/vectorsearch/indices/filters/faiss-index-filter-percentage.json
+++ b/vectorsearch/indices/filters/faiss-index-filter-percentage.json
@@ -1,0 +1,86 @@
+{
+    "settings": {
+      "index": {
+        "knn": true
+        {%- if target_index_primary_shards is defined and target_index_primary_shards %}
+        ,"number_of_shards": {{ target_index_primary_shards }}
+        {%- endif %}
+        {%- if target_index_replica_shards is defined %}
+        ,"number_of_replicas": {{ target_index_replica_shards }}
+        {%- endif %}
+        {%- if derived_source_enabled is defined and derived_source_enabled %}
+        ,"knn.derived_source.enabled": true
+        {%- endif %}
+        {%- if approximate_graph_build_threshold is defined%}
+        ,"knn.advanced.approximate_threshold": {{ approximate_graph_build_threshold }}
+        {%- endif %}
+      }
+    },
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        {% if id_field_name is defined and id_field_name != "_id" %}
+          "{{id_field_name}}": {
+            "type": "keyword"
+          },
+        {%- endif %}
+        "{{ target_field_name }}": {
+          "type": "knn_vector",
+          "dimension": {{ target_index_dimension }},
+          {%- if train_model_id is defined %}
+          "model_id": "{{ train_model_id }}"
+          {%- else %}
+          "method": {
+            "name": "hnsw",
+            "space_type": "{{ target_index_space_type }}",
+            "engine": "faiss",
+            "parameters": {
+              {%- if hnsw_ef_search is defined and hnsw_ef_search %}
+                "ef_search": {{ hnsw_ef_search }}
+              {%- endif %}
+              {%- if hnsw_ef_construction is defined and hnsw_ef_construction %}
+              {%- if hnsw_ef_search is defined and hnsw_ef_search %}
+                ,
+              {%- endif %}
+                "ef_construction": {{ hnsw_ef_construction }}
+              {%- endif %}
+              {%- if hnsw_m is defined and hnsw_m %}
+              {%- if hnsw_ef_construction is defined and hnsw_ef_construction %}
+                ,
+              {%- endif %}
+                "m": {{ hnsw_m }}
+              {%- endif %}
+            }
+          }
+          {%- endif %}
+        },
+        "filter01pct": {
+          "type": "keyword"
+        },
+        "filter1pct": {
+          "type": "keyword"
+        },
+        "filter5pct": {
+          "type": "keyword"
+        },
+        "filter10pct": {
+          "type": "keyword"
+        },
+        "filter25pct": {
+          "type": "keyword"
+        },
+        "filter50pct": {
+          "type": "keyword"
+        },
+        "filter75pct": {
+          "type": "keyword"
+        },
+        "filter90pct": {
+          "type": "keyword"
+        },
+        "filter99pct": {
+          "type": "keyword"
+        }
+      }
+    }
+  }

--- a/vectorsearch/indices/filters/lucene-index-filter-percentage.json
+++ b/vectorsearch/indices/filters/lucene-index-filter-percentage.json
@@ -1,0 +1,76 @@
+{
+    "settings": {
+      "index": {
+        "knn": true
+        {%- if target_index_primary_shards is defined and target_index_primary_shards %}
+        ,"number_of_shards": {{ target_index_primary_shards }}
+        {%- endif %}
+        {%- if target_index_replica_shards is defined %}
+        ,"number_of_replicas": {{ target_index_replica_shards }}
+        {%- endif %}
+        {%- if hnsw_ef_search is defined and hnsw_ef_search %}
+        ,"knn.algo_param.ef_search": {{ hnsw_ef_search }}
+        {%- endif %}
+        {%- if derived_source_enabled is defined and derived_source_enabled %}
+        ,"knn.derived_source.enabled": true
+        {%- endif %}
+      }
+    },
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        {% if id_field_name is defined and id_field_name != "_id" %}
+          "{{id_field_name}}": {
+            "type": "keyword"
+          },
+        {%- endif %}
+        "{{ target_field_name }}": {
+          "type": "knn_vector",
+          "dimension": {{ target_index_dimension }},
+          "method": {
+            "name": "hnsw",
+            "space_type": "{{ target_index_space_type }}",
+            "engine": "lucene",
+            "parameters": {
+            {%- if hnsw_ef_construction is defined and hnsw_ef_construction %}
+            "ef_construction": {{ hnsw_ef_construction }}
+            {%- endif %}
+            {%- if hnsw_m is defined and hnsw_m %}
+            {%- if hnsw_ef_construction is defined and hnsw_ef_construction %}
+            ,
+            {%- endif %}
+            "m": {{ hnsw_m }}
+            {%- endif %}
+            }
+          }
+        },
+        "filter01pct": {
+          "type": "keyword"
+        },
+        "filter1pct": {
+          "type": "keyword"
+        },
+        "filter5pct": {
+          "type": "keyword"
+        },
+        "filter10pct": {
+          "type": "keyword"
+        },
+        "filter25pct": {
+          "type": "keyword"
+        },
+        "filter50pct": {
+          "type": "keyword"
+        },
+        "filter75pct": {
+          "type": "keyword"
+        },
+        "filter90pct": {
+          "type": "keyword"
+        },
+        "filter99pct": {
+          "type": "keyword"
+        }
+      }
+    }
+  }

--- a/vectorsearch/indices/nested/nested-faiss-index-filter-percentage.json
+++ b/vectorsearch/indices/nested/nested-faiss-index-filter-percentage.json
@@ -1,0 +1,89 @@
+{
+    "settings": {
+      "index": {
+        "knn": true
+        {%- if target_index_primary_shards is defined and target_index_primary_shards %}
+        ,"number_of_shards": {{ target_index_primary_shards }}
+        {%- endif %}
+        {%- if target_index_replica_shards is defined %}
+        ,"number_of_replicas": {{ target_index_replica_shards }}
+        {%- endif %}
+        {%- if derived_source_enabled is defined and derived_source_enabled %}
+        ,"knn.derived_source.enabled": true
+        {%- endif %}
+        {%- if approximate_graph_build_threshold is defined%}
+        ,"knn.advanced.approximate_threshold": {{ approximate_graph_build_threshold }}
+        {%- endif %}
+      }
+    },
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        {% if id_field_name is defined and id_field_name != "_id" %}
+          "{{id_field_name}}": {
+            "type": "keyword"
+          },
+        {%- endif %}
+        {% if target_field_name is defined and target_field_name %}
+        "{{ target_field_name.split('.')[0] }}": {
+          "type": "nested",
+          "properties": {
+            "{{ target_field_name.split('.')[1] }}": {
+              "type": "knn_vector",
+              "dimension": {{ target_index_dimension }},
+              "method": {
+                "name": "hnsw",
+                "space_type": "{{ target_index_space_type }}",
+                "engine": "faiss",
+                "parameters": {
+                    {%- if hnsw_ef_search is defined and hnsw_ef_search %}
+                        "ef_search": {{ hnsw_ef_search }}
+                    {%- endif %}
+                    {%- if hnsw_ef_construction is defined and hnsw_ef_construction %}
+                    {%- if hnsw_ef_search is defined and hnsw_ef_search %}
+                        ,
+                    {%- endif %}
+                        "ef_construction": {{ hnsw_ef_construction }}
+                    {%- endif %}
+                    {%- if hnsw_m is defined and hnsw_m %}
+                    {%- if hnsw_ef_construction is defined and hnsw_ef_construction %}
+                        ,
+                    {%- endif %}
+                        "m": {{ hnsw_m }}
+                    {%- endif %}
+                }
+              }
+            }
+          }
+        },
+        {%- endif %}
+        "filter01pct": {
+          "type": "keyword"
+        },
+        "filter1pct": {
+          "type": "keyword"
+        },
+        "filter5pct": {
+          "type": "keyword"
+        },
+        "filter10pct": {
+          "type": "keyword"
+        },
+        "filter25pct": {
+          "type": "keyword"
+        },
+        "filter50pct": {
+          "type": "keyword"
+        },
+        "filter75pct": {
+          "type": "keyword"
+        },
+        "filter90pct": {
+          "type": "keyword"
+        },
+        "filter99pct": {
+          "type": "keyword"
+        }
+      }
+    }
+  }

--- a/vectorsearch/indices/nested/nested-lucene-index-filter-percentage.json
+++ b/vectorsearch/indices/nested/nested-lucene-index-filter-percentage.json
@@ -1,0 +1,83 @@
+{
+    "settings": {
+      "index": {
+        "knn": true
+        {%- if target_index_primary_shards is defined and target_index_primary_shards %}
+        ,"number_of_shards": {{ target_index_primary_shards }}
+        {%- endif %}
+        {%- if target_index_replica_shards is defined %}
+        ,"number_of_replicas": {{ target_index_replica_shards }}
+        {%- endif %}
+        {%- if derived_source_enabled is defined and derived_source_enabled %}
+        ,"knn.derived_source.enabled": true
+        {%- endif %}
+        {%- if hnsw_ef_search is defined and hnsw_ef_search %}
+        ,"knn.algo_param.ef_search": {{ hnsw_ef_search }}
+        {%- endif %}
+      }
+    },
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        {% if id_field_name is defined and id_field_name != "_id" %}
+          "{{id_field_name}}": {
+            "type": "keyword"
+          },
+        {%- endif %}
+        {% if target_field_name is defined and target_field_name %}
+        "{{ target_field_name.split('.')[0] }}": {
+          "type": "nested",
+          "properties": {
+            "{{ target_field_name.split('.')[1] }}": {
+              "type": "knn_vector",
+              "dimension": {{ target_index_dimension }},
+              "method": {
+                "name": "hnsw",
+                "space_type": "{{ target_index_space_type }}",
+                "engine": "lucene",
+                "parameters": {
+                    {%- if hnsw_ef_construction is defined and hnsw_ef_construction %}
+                    "ef_construction": {{ hnsw_ef_construction }}
+                    {%- endif %}
+                    {%- if hnsw_m is defined and hnsw_m %}
+                    {%- if hnsw_ef_construction is defined and hnsw_ef_construction %}
+                    ,
+                    {%- endif %}
+                    "m": {{ hnsw_m }}
+                    {%- endif %}
+                }
+              }
+            }
+          }
+        },
+        {%- endif %}
+        "filter01pct": {
+          "type": "keyword"
+        },
+        "filter1pct": {
+          "type": "keyword"
+        },
+        "filter5pct": {
+          "type": "keyword"
+        },
+        "filter10pct": {
+          "type": "keyword"
+        },
+        "filter25pct": {
+          "type": "keyword"
+        },
+        "filter50pct": {
+          "type": "keyword"
+        },
+        "filter75pct": {
+          "type": "keyword"
+        },
+        "filter90pct": {
+          "type": "keyword"
+        },
+        "filter99pct": {
+          "type": "keyword"
+        }
+      }
+    }
+  }

--- a/vectorsearch/params/nested/filters/nested-faiss-cohere-10m-efficient.json
+++ b/vectorsearch/params/nested/filters/nested-faiss-cohere-10m-efficient.json
@@ -1,0 +1,48 @@
+{
+    "target_index_name": "target_index",
+    "target_field_name": "nested_field.target_field",
+    "target_index_body": "indices/nested/nested-faiss-index-filter-percentage.json",
+    "target_index_primary_shards": 6,
+    "target_index_dimension": 768,
+    "target_index_space_type": "innerproduct",
+    "target_index_bulk_size": 100,
+    "target_index_bulk_index_data_set_format": "hdf5",
+    "target_index_bulk_index_data_set_corpus": "cohere-10m-nested-filter-percentage",
+    "target_index_bulk_indexing_clients": 10,
+    "target_dataset_filter_attributes": [
+        "filter01pct",
+        "filter1pct",
+        "filter5pct",
+        "filter10pct",
+        "filter25pct",
+        "filter50pct",
+        "filter75pct",
+        "filter90pct",
+        "filter99pct"
+    ],
+    "target_index_max_num_segments": 1,
+    "target_index_force_merge_timeout": 3600.0,
+    "hnsw_ef_search": 256,
+    "hnsw_ef_construction": 256,
+    "query_k": 100,
+    "query_body": {
+        "size": 100,
+        "docvalue_fields": [
+            "_id"
+        ],
+        "stored_fields": "_none_",
+        "_source": false
+    },
+    "filter_type": "efficient",
+    "filter_percentage": "10pct",
+    "filter_body": {
+        "term": {
+            "filter10pct": "true"
+        }
+    },
+    "query_data_set_format": "hdf5",
+    "query_data_set_corpus": "cohere-10m-nested-filter-percentage",
+    "neighbors_data_set_corpus": "cohere-10m-nested-filter-percentage",
+    "neighbors_data_set_format": "hdf5",
+    "query_count": 10000
+}

--- a/vectorsearch/params/nested/filters/nested-faiss-cohere-10m-parent-filter.json
+++ b/vectorsearch/params/nested/filters/nested-faiss-cohere-10m-parent-filter.json
@@ -1,0 +1,48 @@
+{
+    "target_index_name": "target_index",
+    "target_field_name": "nested_field.target_field",
+    "target_index_body": "indices/nested/nested-faiss-index-filter-percentage.json",
+    "target_index_primary_shards": 6,
+    "target_index_dimension": 768,
+    "target_index_space_type": "innerproduct",
+    "target_index_bulk_size": 100,
+    "target_index_bulk_index_data_set_format": "hdf5",
+    "target_index_bulk_index_data_set_corpus": "cohere-10m-nested-filter-percentage",
+    "target_index_bulk_indexing_clients": 10,
+    "target_dataset_filter_attributes": [
+        "filter01pct",
+        "filter1pct",
+        "filter5pct",
+        "filter10pct",
+        "filter25pct",
+        "filter50pct",
+        "filter75pct",
+        "filter90pct",
+        "filter99pct"
+    ],
+    "target_index_max_num_segments": 1,
+    "target_index_force_merge_timeout": 3600.0,
+    "hnsw_ef_search": 256,
+    "hnsw_ef_construction": 256,
+    "query_k": 100,
+    "query_body": {
+        "size": 100,
+        "docvalue_fields": [
+            "_id"
+        ],
+        "stored_fields": "_none_",
+        "_source": false
+    },
+    "filter_type": "boolean",
+    "filter_percentage": "10pct",
+    "filter_body": {
+        "term": {
+            "filter10pct": "true"
+        }
+    },
+    "query_data_set_format": "hdf5",
+    "query_data_set_corpus": "cohere-10m-nested-filter-percentage",
+    "neighbors_data_set_corpus": "cohere-10m-nested-filter-percentage",
+    "neighbors_data_set_format": "hdf5",
+    "query_count": 10000
+}

--- a/vectorsearch/params/nested/filters/nested-lucene-cohere-10m-efficient.json
+++ b/vectorsearch/params/nested/filters/nested-lucene-cohere-10m-efficient.json
@@ -1,0 +1,48 @@
+{
+    "target_index_name": "target_index",
+    "target_field_name": "nested_field.target_field",
+    "target_index_body": "indices/nested/nested-lucene-index-filter-percentage.json",
+    "target_index_primary_shards": 6,
+    "target_index_dimension": 768,
+    "target_index_space_type": "innerproduct",
+    "target_index_bulk_size": 100,
+    "target_index_bulk_index_data_set_format": "hdf5",
+    "target_index_bulk_index_data_set_corpus": "cohere-10m-nested-filter-percentage",
+    "target_index_bulk_indexing_clients": 10,
+    "target_dataset_filter_attributes": [
+        "filter01pct",
+        "filter1pct",
+        "filter5pct",
+        "filter10pct",
+        "filter25pct",
+        "filter50pct",
+        "filter75pct",
+        "filter90pct",
+        "filter99pct"
+    ],
+    "target_index_max_num_segments": 1,
+    "target_index_force_merge_timeout": 3600.0,
+    "hnsw_ef_search": 256,
+    "hnsw_ef_construction": 256,
+    "query_k": 100,
+    "query_body": {
+        "size": 100,
+        "docvalue_fields": [
+            "_id"
+        ],
+        "stored_fields": "_none_",
+        "_source": false
+    },
+    "filter_type": "efficient",
+    "filter_percentage": "10pct",
+    "filter_body": {
+        "term": {
+            "filter10pct": "true"
+        }
+    },
+    "query_data_set_format": "hdf5",
+    "query_data_set_corpus": "cohere-10m-nested-filter-percentage",
+    "neighbors_data_set_corpus": "cohere-10m-nested-filter-percentage",
+    "neighbors_data_set_format": "hdf5",
+    "query_count": 10000
+}

--- a/vectorsearch/params/nested/filters/nested-lucene-cohere-10m-parent-filter.json
+++ b/vectorsearch/params/nested/filters/nested-lucene-cohere-10m-parent-filter.json
@@ -1,0 +1,48 @@
+{
+    "target_index_name": "target_index",
+    "target_field_name": "nested_field.target_field",
+    "target_index_body": "indices/nested/nested-lucene-index-filter-percentage.json",
+    "target_index_primary_shards": 6,
+    "target_index_dimension": 768,
+    "target_index_space_type": "innerproduct",
+    "target_index_bulk_size": 100,
+    "target_index_bulk_index_data_set_format": "hdf5",
+    "target_index_bulk_index_data_set_corpus": "cohere-10m-nested-filter-percentage",
+    "target_index_bulk_indexing_clients": 10,
+    "target_dataset_filter_attributes": [
+        "filter01pct",
+        "filter1pct",
+        "filter5pct",
+        "filter10pct",
+        "filter25pct",
+        "filter50pct",
+        "filter75pct",
+        "filter90pct",
+        "filter99pct"
+    ],
+    "target_index_max_num_segments": 1,
+    "target_index_force_merge_timeout": 3600.0,
+    "hnsw_ef_search": 256,
+    "hnsw_ef_construction": 256,
+    "query_k": 100,
+    "query_body": {
+        "size": 100,
+        "docvalue_fields": [
+            "_id"
+        ],
+        "stored_fields": "_none_",
+        "_source": false
+    },
+    "filter_type": "boolean",
+    "filter_percentage": "10pct",
+    "filter_body": {
+        "term": {
+            "filter10pct": "true"
+        }
+    },
+    "query_data_set_format": "hdf5",
+    "query_data_set_corpus": "cohere-10m-nested-filter-percentage",
+    "neighbors_data_set_corpus": "cohere-10m-nested-filter-percentage",
+    "neighbors_data_set_format": "hdf5",
+    "query_count": 10000
+}

--- a/vectorsearch/params/radial_search/filters/faiss-hnsw-cohere-768-1m-efficient.json
+++ b/vectorsearch/params/radial_search/filters/faiss-hnsw-cohere-768-1m-efficient.json
@@ -1,0 +1,50 @@
+{
+    "target_index_name": "target_index",
+    "target_field_name": "target_field",
+    "target_index_body": "indices/filters/faiss-index-filter-percentage.json",
+    "target_index_primary_shards": 2,
+    "target_index_dimension": 768,
+    "target_index_space_type": "innerproduct",
+    "target_index_bulk_size": 100,
+    "target_index_bulk_index_data_set_format": "hdf5",
+    "target_index_bulk_index_data_set_corpus": "cohere-1m-radial-filter-percentage",
+    "target_index_bulk_indexing_clients": 10,
+    "target_dataset_filter_attributes": [
+        "filter01pct",
+        "filter1pct",
+        "filter5pct",
+        "filter10pct",
+        "filter25pct",
+        "filter50pct",
+        "filter75pct",
+        "filter90pct",
+        "filter99pct"
+    ],
+    "target_index_max_num_segments": 1,
+    "target_index_force_merge_timeout": 600.0,
+    "hnsw_ef_search": 256,
+    "hnsw_ef_construction": 256,
+    "target_index_num_vectors": 1000000,
+    "radial_search_type": "max_distance",
+    "query_k": 100,
+    "query_body": {
+        "size": 100,
+        "docvalue_fields": [
+            "_id"
+        ],
+        "stored_fields": "_none_",
+        "_source": false
+    },
+    "filter_type": "efficient",
+    "filter_percentage": "10pct",
+    "filter_body": {
+        "term": {
+            "filter10pct": "true"
+        }
+    },
+    "query_data_set_format": "hdf5",
+    "query_data_set_corpus": "cohere-1m-radial-filter-percentage",
+    "neighbors_data_set_corpus": "cohere-1m-radial-filter-percentage",
+    "neighbors_data_set_format": "hdf5",
+    "query_count": 10000
+}

--- a/vectorsearch/params/radial_search/filters/faiss-hnsw-cohere-768-1m-post-filter.json
+++ b/vectorsearch/params/radial_search/filters/faiss-hnsw-cohere-768-1m-post-filter.json
@@ -1,0 +1,50 @@
+{
+    "target_index_name": "target_index",
+    "target_field_name": "target_field",
+    "target_index_body": "indices/filters/faiss-index-filter-percentage.json",
+    "target_index_primary_shards": 2,
+    "target_index_dimension": 768,
+    "target_index_space_type": "innerproduct",
+    "target_index_bulk_size": 100,
+    "target_index_bulk_index_data_set_format": "hdf5",
+    "target_index_bulk_index_data_set_corpus": "cohere-1m-radial-filter-percentage",
+    "target_index_bulk_indexing_clients": 10,
+    "target_dataset_filter_attributes": [
+        "filter01pct",
+        "filter1pct",
+        "filter5pct",
+        "filter10pct",
+        "filter25pct",
+        "filter50pct",
+        "filter75pct",
+        "filter90pct",
+        "filter99pct"
+    ],
+    "target_index_max_num_segments": 1,
+    "target_index_force_merge_timeout": 600.0,
+    "hnsw_ef_search": 256,
+    "hnsw_ef_construction": 256,
+    "target_index_num_vectors": 1000000,
+    "radial_search_type": "max_distance",
+    "query_k": 100,
+    "query_body": {
+        "size": 100,
+        "docvalue_fields": [
+            "_id"
+        ],
+        "stored_fields": "_none_",
+        "_source": false
+    },
+    "filter_type": "post_filter",
+    "filter_percentage": "10pct",
+    "filter_body": {
+        "term": {
+            "filter10pct": "true"
+        }
+    },
+    "query_data_set_format": "hdf5",
+    "query_data_set_corpus": "cohere-1m-radial-filter-percentage",
+    "neighbors_data_set_corpus": "cohere-1m-radial-filter-percentage",
+    "neighbors_data_set_format": "hdf5",
+    "query_count": 10000
+}

--- a/vectorsearch/params/radial_search/filters/lucene-hnsw-cohere-768-1m-efficient.json
+++ b/vectorsearch/params/radial_search/filters/lucene-hnsw-cohere-768-1m-efficient.json
@@ -1,0 +1,50 @@
+{
+    "target_index_name": "target_index",
+    "target_field_name": "target_field",
+    "target_index_body": "indices/filters/lucene-index-filter-percentage.json",
+    "target_index_primary_shards": 2,
+    "target_index_dimension": 768,
+    "target_index_space_type": "innerproduct",
+    "target_index_bulk_size": 100,
+    "target_index_bulk_index_data_set_format": "hdf5",
+    "target_index_bulk_index_data_set_corpus": "cohere-1m-radial-filter-percentage",
+    "target_index_bulk_indexing_clients": 10,
+    "target_dataset_filter_attributes": [
+        "filter01pct",
+        "filter1pct",
+        "filter5pct",
+        "filter10pct",
+        "filter25pct",
+        "filter50pct",
+        "filter75pct",
+        "filter90pct",
+        "filter99pct"
+    ],
+    "target_index_max_num_segments": 1,
+    "target_index_force_merge_timeout": 600.0,
+    "hnsw_ef_search": 256,
+    "hnsw_ef_construction": 256,
+    "target_index_num_vectors": 1000000,
+    "radial_search_type": "max_distance",
+    "query_k": 100,
+    "query_body": {
+        "size": 100,
+        "docvalue_fields": [
+            "_id"
+        ],
+        "stored_fields": "_none_",
+        "_source": false
+    },
+    "filter_type": "efficient",
+    "filter_percentage": "10pct",
+    "filter_body": {
+        "term": {
+            "filter10pct": "true"
+        }
+    },
+    "query_data_set_format": "hdf5",
+    "query_data_set_corpus": "cohere-1m-radial-filter-percentage",
+    "neighbors_data_set_corpus": "cohere-1m-radial-filter-percentage",
+    "neighbors_data_set_format": "hdf5",
+    "query_count": 10000
+}

--- a/vectorsearch/params/radial_search/filters/lucene-hnsw-cohere-768-1m-post-filter.json
+++ b/vectorsearch/params/radial_search/filters/lucene-hnsw-cohere-768-1m-post-filter.json
@@ -1,0 +1,50 @@
+{
+    "target_index_name": "target_index",
+    "target_field_name": "target_field",
+    "target_index_body": "indices/filters/lucene-index-filter-percentage.json",
+    "target_index_primary_shards": 2,
+    "target_index_dimension": 768,
+    "target_index_space_type": "innerproduct",
+    "target_index_bulk_size": 100,
+    "target_index_bulk_index_data_set_format": "hdf5",
+    "target_index_bulk_index_data_set_corpus": "cohere-1m-radial-filter-percentage",
+    "target_index_bulk_indexing_clients": 10,
+    "target_dataset_filter_attributes": [
+        "filter01pct",
+        "filter1pct",
+        "filter5pct",
+        "filter10pct",
+        "filter25pct",
+        "filter50pct",
+        "filter75pct",
+        "filter90pct",
+        "filter99pct"
+    ],
+    "target_index_max_num_segments": 1,
+    "target_index_force_merge_timeout": 600.0,
+    "hnsw_ef_search": 256,
+    "hnsw_ef_construction": 256,
+    "target_index_num_vectors": 1000000,
+    "radial_search_type": "max_distance",
+    "query_k": 100,
+    "query_body": {
+        "size": 100,
+        "docvalue_fields": [
+            "_id"
+        ],
+        "stored_fields": "_none_",
+        "_source": false
+    },
+    "filter_type": "post_filter",
+    "filter_percentage": "10pct",
+    "filter_body": {
+        "term": {
+            "filter10pct": "true"
+        }
+    },
+    "query_data_set_format": "hdf5",
+    "query_data_set_corpus": "cohere-1m-radial-filter-percentage",
+    "neighbors_data_set_corpus": "cohere-1m-radial-filter-percentage",
+    "neighbors_data_set_format": "hdf5",
+    "query_count": 1000
+}

--- a/vectorsearch/test_procedures/common/filter-percentage-sweep-schedule.json
+++ b/vectorsearch/test_procedures/common/filter-percentage-sweep-schedule.json
@@ -1,26 +1,23 @@
 {
-    "name" : "refresh-target-index-before-premerge-search",
-    "operation" : "refresh-target-index"
-},
-{
-    "name" : "warmup-indices-premerge",
+    "name" : "warmup-indices",
     "operation" : "warmup-indices",
     "index": "{{ target_index_name | default('target_index') }}"
 },
+{%- for pct in filter_percentages %}
 {
     "operation": {
-        "name": "prod-queries-multisegment",
+        "name": "prod-queries-{{ pct }}",
         "operation-type": "vector-search",
         "index": "{{ target_index_name | default('target_index') }}",
         "detailed-results": true,
         {% if query_k is defined %}
         "k": {{ query_k }},
         {% endif %}
-        {% if query_max_distance is defined %}
-        "max_distance": {{ query_max_distance }},
+        {% if radial_search_type is defined %}
+        "radial_search_type": "{{ radial_search_type }}",
         {% endif %}
-        {% if query_min_score is defined %}
-        "min_score": {{ query_min_score }},
+        {% if target_index_body is defined %}
+        "target_index_body": "{{ target_index_body }}",
         {% endif %}
         "field" : "{{ target_field_name | default('target_field') }}",
         "data_set_format" : "{{ query_data_set_format | default('hdf5') }}",
@@ -32,11 +29,11 @@
         "num_vectors" : {{ query_count | default(-1) }},
         "id-field-name": "{{ id_field_name }}",
         "body": {{ query_body | default ({}) | tojson }},
-        "filter_body": {{ filter_body | default ({}) | tojson }},
-        "filter_type": {{filter_type  | default ({}) | tojson }}
-        {% if filter_percentage is defined %}
-        ,"filter_percentage": "{{ filter_percentage }}"
-        {% endif %}
+        "filter_body": {"term": {"filter{{ pct }}": "true"}},
+        "filter_type": {{ filter_type | default ({}) | tojson }},
+        "filter_percentage": "{{ pct }}",
+        "repetitions": {{ number_of_repetitions | default(1)}}
     },
     "clients": {{ search_clients | default(1)}}
-}
+}{{ "," if not loop.last }}
+{%- endfor %}

--- a/vectorsearch/test_procedures/common/filter-percentage-sweep-schedule.json
+++ b/vectorsearch/test_procedures/common/filter-percentage-sweep-schedule.json
@@ -2,8 +2,8 @@
     "name" : "warmup-indices",
     "operation" : "warmup-indices",
     "index": "{{ target_index_name | default('target_index') }}"
-},
-{%- for pct in filter_percentages %}
+}
+{%- for pct in filter_percentages | default([]) %},
 {
     "operation": {
         "name": "prod-queries-{{ pct }}",
@@ -35,5 +35,5 @@
         "repetitions": {{ number_of_repetitions | default(1)}}
     },
     "clients": {{ search_clients | default(1)}}
-}{{ "," if not loop.last }}
+}
 {%- endfor %}

--- a/vectorsearch/test_procedures/common/search-only-schedule.json
+++ b/vectorsearch/test_procedures/common/search-only-schedule.json
@@ -30,6 +30,9 @@
         "body": {{ query_body | default ({}) | tojson }},
         "filter_body": {{ filter_body | default ({}) | tojson }},
         "filter_type": {{filter_type  | default ({}) | tojson }},
+        {% if filter_percentage is defined %}
+        "filter_percentage": "{{ filter_percentage }}",
+        {% endif %}
         "repetitions": {{ number_of_repetitions | default(1)}}
     },
     "clients": {{ search_clients | default(1)}}

--- a/vectorsearch/test_procedures/default.json
+++ b/vectorsearch/test_procedures/default.json
@@ -44,6 +44,24 @@
     ]
 },
 {
+    "name": "filter-percentage-sweep",
+    "default": false,
+    "description": "Index once, then run radial filtered search at each percentage in filter_percentages.",
+    "schedule": [
+       {{ benchmark.collect(parts="common/index-only-schedule.json") }},
+       {{ benchmark.collect(parts="common/force-merge-schedule.json") }},
+       {{ benchmark.collect(parts="common/filter-percentage-sweep-schedule.json") }}
+    ]
+},
+{
+    "name": "filter-percentage-sweep-search-only",
+    "default": false,
+    "description": "Radial filtered search at each percentage in filter_percentages on a previously indexed cluster.",
+    "schedule": [
+       {{ benchmark.collect(parts="common/filter-percentage-sweep-schedule.json") }}
+    ]
+},
+{
     "name": "force-merge-index",
     "default": false,
     "description": "Force merge vector search index to improve search performance",

--- a/vectorsearch/workload.json
+++ b/vectorsearch/workload.json
@@ -121,6 +121,18 @@
           "document-count": 1000000
         }
       ]
+    },
+    {
+      "name": "cohere-10m-nested-filter-percentage",
+      "base-url": "https://dbyiw3u3rf9yr.cloudfront.net/corpora/vectorsearch/cohere-wikipedia-22-12-en-embeddings",
+      "target-index": "{{ target_index_name }}",
+      "documents": [
+        {
+          "source-file": "cohere-10m-nested-filter-percentage.hdf5.bz2",
+          "source-format": "hdf5",
+          "document-count": 10550170
+        }
+      ]
     }
   ],
     "operations": [

--- a/vectorsearch/workload.json
+++ b/vectorsearch/workload.json
@@ -109,6 +109,18 @@
           "document-count": 1000000
         }
       ]
+    },
+    {
+      "name": "cohere-1m-radial-filter-percentage",
+      "base-url": "https://dbyiw3u3rf9yr.cloudfront.net/corpora/vectorsearch/cohere-wikipedia-22-12-en-embeddings",
+      "target-index": "{{ target_index_name }}",
+      "documents": [
+        {
+          "source-file": "cohere-1m-radial-filter-percentage.hdf5.bz2",
+          "source-format": "hdf5",
+          "document-count": 1000000
+        }
+      ]
     }
   ],
     "operations": [


### PR DESCRIPTION
### Description
Manual backport of #813, #814, and #820 to branch 3 (cherry-picked in dependency order, -x annotated). The auto-backports failed because these PRs modified two files that don't exist on branch 3: enrich_radial_distances.py (from #810) and generate_nested_dataset.py (from #804) — neither was ever backported. Resolved by keeping those files absent; the backported content is self-contained (the shared utils modules ship in these commits).

Validated on the branch: all _tools scripts import, all param files parse, the sweep schedule renders valid JSON with and without filter_percentages (the #814 fix), index templates render, the nested generator runs end-to-end, both corpus entries present in workload.json.

Also includes #792 (Pin GitHub Actions to commit SHAs) — branch 3's workflows predate the org's SHA-pinning requirement, which blocked CI from running on any branch-3 PR.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
