### PR TITLE
Add combined-engine-test procedure covering faiss fp32 top-k/radial, faiss SQ, and lucene top-k/radial/SQ

### DIFF
--- a/vectorsearch/README.md
+++ b/vectorsearch/README.md
@@ -13,7 +13,7 @@ OpenSearch.
 Before running a benchmark, ensure that the load generation host is able to access your cluster endpoint and that the 
 appropriate dataset is available on the host.
 
-Currently, we support 4 test procedures for the vector search workload. The default procedure is named no-train-test and does not include the steps required to train the model being used.
+Currently, we support the following test procedures for the vector search workload. The default procedure is named no-train-test and does not include the steps required to train the model being used.
 This test procedures will index a data set of vectors into an OpenSearch cluster and then run a set of queries against the generated index. 
 
 Due to the number of parameters this workload offers, it's recommended to create a parameter file that specifies the desired workload 
@@ -66,6 +66,34 @@ force merge occasionally based on user's requirement.
 This procedure is used to benchmark previously indexed vector search index. This will be useful if you want
 to benchmark large vector search index without indexing everytime since load time is substantial for a large dataset.
 This also contains warmup operation to avoid cold start problem during vector search.
+
+### Combined Engine Test
+
+This procedure (`combined-engine-test`) covers several engine/encoding configurations against the same
+cluster in one invocation, with distinct per-phase operation names so each phase's metrics can be
+compared independently. Phases, in order:
+
+1. **faiss fp32 top-k** — create `target_index`, bulk ingest, force-merge, warmup, `prod-queries-faiss-fp32`
+2. **faiss fp32 radial** — `radial-queries-faiss-max-distance`, `radial-queries-faiss-min-score` against the phase-1 index
+3. **faiss SQ top-k** — delete the fp32 index, then create `faiss_sq_index`, ingest, merge, `prod-queries-faiss-sq`
+4. **lucene fp32 top-k** — delete the SQ index, then create `lucene_index`, ingest, merge, `prod-queries-lucene-fp32`
+5. **lucene fp32 radial** — `radial-queries-lucene-max-distance`, `radial-queries-lucene-min-score`
+6. **lucene SQ top-k** — delete the lucene index, then create `lucene_sq_index`, ingest, merge, `prod-queries-lucene-sq`
+
+All tasks are always defined; use `--include-tasks`/`--exclude-tasks` to run a subset.
+
+Radial tasks support two modes:
+
+- **Fixed threshold**: set `radial_max_distance`, `lucene_radial_max_distance` (engines use opposite sign
+  conventions for inner product), and `radial_min_score`. Ground truth is read from the `radial_neighbors`
+  dataset of the corpus given by `radial_neighbors_data_set_corpus`/`radial_neighbors_data_set_path`.
+- **Per-query threshold** (requires OSB with `radial_search_type` support): set `radial_per_query` and
+  optionally `radial_query_k`. Each query's threshold is read from the engine-specific threshold datasets
+  (`faiss_max_distance`, `lucene_max_distance`, `faiss_min_score`, `lucene_min_score`) of the same corpus.
+
+The SQ index bodies (`indices/faiss-sq-index.json`, `indices/lucene-sq-index.json`) define quantization
+through the `compression_level` mapping parameter (default `32x`, i.e. 1-bit); set
+`faiss_sq_compression_level` / `lucene_sq_compression_level` to benchmark other compression levels.
 
 ### No Train Test AOSS
 

--- a/vectorsearch/indices/faiss-sq-index.json
+++ b/vectorsearch/indices/faiss-sq-index.json
@@ -1,0 +1,46 @@
+{
+    "settings": {
+      "index": {
+        "knn": true
+        {%- if target_index_primary_shards is defined and target_index_primary_shards %}
+        ,"number_of_shards": {{ target_index_primary_shards }}
+        {%- endif %}
+        {%- if target_index_replica_shards is defined %}
+        ,"number_of_replicas": {{ target_index_replica_shards }}
+        {%- endif %}
+        {%- if derived_source_enabled is defined and derived_source_enabled %}
+        ,"knn.derived_source.enabled": true
+        {%- endif %}
+      }
+    },
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        {% if id_field_name is defined and id_field_name != "_id" %}
+          "{{id_field_name}}": {
+            "type": "keyword"
+          },
+        {%- endif %}
+        "{{ target_field_name }}": {
+          "type": "knn_vector",
+          "dimension": {{ target_index_dimension }},
+          "compression_level": "{{ faiss_sq_compression_level | default('32x') }}",
+          {%- if faiss_sq_mode is defined %}
+          "mode": "{{ faiss_sq_mode }}",
+          {%- endif %}
+          "method": {
+            "name": "hnsw",
+            "space_type": "{{ target_index_space_type }}",
+            "engine": "faiss",
+            "parameters": {
+              "ef_search": {{ hnsw_ef_search | default(256) }},
+              "ef_construction": {{ hnsw_ef_construction | default(256) }}
+              {%- if hnsw_m is defined and hnsw_m %}
+              ,"m": {{ hnsw_m }}
+              {%- endif %}
+            }
+          }
+        }
+      }
+    }
+  }

--- a/vectorsearch/indices/lucene-sq-index.json
+++ b/vectorsearch/indices/lucene-sq-index.json
@@ -1,0 +1,45 @@
+{
+    "settings": {
+      "index": {
+        "knn": true
+        {%- if target_index_primary_shards is defined and target_index_primary_shards %}
+        ,"number_of_shards": {{ target_index_primary_shards }}
+        {%- endif %}
+        {%- if target_index_replica_shards is defined %}
+        ,"number_of_replicas": {{ target_index_replica_shards }}
+        {%- endif %}
+        {%- if hnsw_ef_search is defined and hnsw_ef_search %}
+        ,"knn.algo_param.ef_search": {{ hnsw_ef_search }}
+        {%- endif %}
+        {%- if derived_source_enabled is defined and derived_source_enabled %}
+        ,"knn.derived_source.enabled": true
+        {%- endif %}
+      }
+    },
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        {% if id_field_name is defined and id_field_name != "_id" %}
+          "{{id_field_name}}": {
+            "type": "keyword"
+          },
+        {%- endif %}
+        "{{ target_field_name }}": {
+          "type": "knn_vector",
+          "dimension": {{ target_index_dimension }},
+          "compression_level": "{{ lucene_sq_compression_level | default('32x') }}",
+          "method": {
+            "name": "hnsw",
+            "space_type": "{{ target_index_space_type }}",
+            "engine": "lucene",
+            "parameters": {
+              "ef_construction": {{ hnsw_ef_construction | default(256) }}
+              {%- if hnsw_m is defined and hnsw_m %}
+              ,"m": {{ hnsw_m }}
+              {%- endif %}
+            }
+          }
+        }
+      }
+    }
+  }

--- a/vectorsearch/operations/combined-engine.json
+++ b/vectorsearch/operations/combined-engine.json
@@ -1,0 +1,345 @@
+{
+    "name": "delete-index-faiss-fp32",
+    "operation-type": "delete-index",
+    "only-if-exists": true,
+    "index": "{{ target_index_name | default('target_index') }}"
+},
+{
+    "name": "create-index-faiss-fp32",
+    "operation-type": "create-index",
+    "index": "{{ target_index_name | default('target_index') }}"
+},
+{
+    "name": "custom-vector-bulk-faiss-fp32",
+    "operation-type": "bulk-vector-data-set",
+    "index": "{{ target_index_name | default('target_index') }}",
+    "field": "{{ target_field_name | default('target_field') }}",
+    "bulk_size": {{ target_index_bulk_size | default(500) }},
+    "data_set_format": "{{ target_index_bulk_index_data_set_format | default('hdf5') }}",
+    "data_set_path": "{{ target_index_bulk_index_data_set_path }}",
+    "data_set_corpus": "{{ target_index_bulk_index_data_set_corpus }}",
+    "num_vectors": {{ target_index_num_vectors | default(-1) }},
+    "id-field-name": "{{ id_field_name }}"
+},
+{
+    "name": "refresh-index-faiss-fp32",
+    "operation-type": "refresh",
+    "retries": 100,
+    "index": "{{ target_index_name | default('target_index') }}"
+},
+{
+    "name": "force-merge-faiss-fp32",
+    "operation-type": "force-merge",
+    "request-timeout": {{ target_index_force_merge_timeout | default(7200) }},
+    "index": "{{ target_index_name | default('target_index') }}",
+    "mode": "polling",
+    "max-num-segments": {{ target_index_max_num_segments | default(1) }},
+    "include-in-results_publishing": true
+},
+{
+    "name": "warmup-indices-faiss-fp32",
+    "operation-type": "warmup-knn-indices",
+    "index": "{{ target_index_name | default('target_index') }}",
+    "include-in-results_publishing": true
+},
+{
+    "name": "prod-queries-faiss-fp32",
+    "operation-type": "vector-search",
+    "index": "{{ target_index_name | default('target_index') }}",
+    "detailed-results": true,
+    "k": {{ query_k | default(100) }},
+    "field": "{{ target_field_name | default('target_field') }}",
+    "data_set_format": "{{ query_data_set_format | default('hdf5') }}",
+    "data_set_path": "{{ query_data_set_path }}",
+    "data_set_corpus": "{{ query_data_set_corpus }}",
+    "neighbors_data_set_path": "{{ neighbors_data_set_path }}",
+    "neighbors_data_set_corpus": "{{ neighbors_data_set_corpus }}",
+    "neighbors_data_set_format": "{{ neighbors_data_set_format | default('hdf5') }}",
+    "num_vectors": {{ query_count | default(-1) }},
+    "id-field-name": "{{ id_field_name }}",
+    "body": {{ query_body | default({}) | tojson }},
+    "repetitions": {{ number_of_repetitions | default(1) }}
+},
+{
+    "name": "radial-queries-faiss-max-distance",
+    "operation-type": "vector-search",
+    "index": "{{ target_index_name | default('target_index') }}",
+    "detailed-results": true,
+    {% if radial_per_query is defined %}
+    "radial_search_type": "max_distance",
+    "k": {{ radial_query_k | default(query_k | default(100)) }},
+    "target_index_body": "{{ target_index_body }}",
+    {% elif radial_max_distance is defined %}
+    "max_distance": {{ radial_max_distance }},
+    {% endif %}
+    "field": "{{ target_field_name | default('target_field') }}",
+    "data_set_format": "{{ query_data_set_format | default('hdf5') }}",
+    "data_set_path": "{{ query_data_set_path }}",
+    "data_set_corpus": "{{ query_data_set_corpus }}",
+    "neighbors_data_set_path": "{{ radial_neighbors_data_set_path }}",
+    "neighbors_data_set_corpus": "{{ radial_neighbors_data_set_corpus }}",
+    "neighbors_data_set_format": "{{ neighbors_data_set_format | default('hdf5') }}",
+    "num_vectors": {{ radial_query_count | default(query_count | default(-1)) }},
+    "id-field-name": "{{ id_field_name }}",
+    "body": {{ radial_query_body | default({} if radial_per_query is defined else {"size": radial_query_size | default(1000)}) | tojson }},
+    "repetitions": {{ number_of_repetitions | default(1) }}
+},
+{
+    "name": "radial-queries-faiss-min-score",
+    "operation-type": "vector-search",
+    "index": "{{ target_index_name | default('target_index') }}",
+    "detailed-results": true,
+    {% if radial_per_query is defined %}
+    "radial_search_type": "min_score",
+    "k": {{ radial_query_k | default(query_k | default(100)) }},
+    "target_index_body": "{{ target_index_body }}",
+    {% elif radial_min_score is defined %}
+    "min_score": {{ radial_min_score }},
+    {% endif %}
+    "field": "{{ target_field_name | default('target_field') }}",
+    "data_set_format": "{{ query_data_set_format | default('hdf5') }}",
+    "data_set_path": "{{ query_data_set_path }}",
+    "data_set_corpus": "{{ query_data_set_corpus }}",
+    "neighbors_data_set_path": "{{ radial_neighbors_data_set_path }}",
+    "neighbors_data_set_corpus": "{{ radial_neighbors_data_set_corpus }}",
+    "neighbors_data_set_format": "{{ neighbors_data_set_format | default('hdf5') }}",
+    "num_vectors": {{ radial_query_count | default(query_count | default(-1)) }},
+    "id-field-name": "{{ id_field_name }}",
+    "body": {{ radial_query_body | default({} if radial_per_query is defined else {"size": radial_query_size | default(1000)}) | tojson }},
+    "repetitions": {{ number_of_repetitions | default(1) }}
+},
+{
+    "name": "delete-index-faiss-sq",
+    "operation-type": "delete-index",
+    "only-if-exists": true,
+    "index": "{{ faiss_sq_index_name | default('faiss_sq_index') }}"
+},
+{
+    "name": "create-index-faiss-sq",
+    "operation-type": "create-index",
+    "index": "{{ faiss_sq_index_name | default('faiss_sq_index') }}"
+},
+{
+    "name": "custom-vector-bulk-faiss-sq",
+    "operation-type": "bulk-vector-data-set",
+    "index": "{{ faiss_sq_index_name | default('faiss_sq_index') }}",
+    "field": "{{ target_field_name | default('target_field') }}",
+    "bulk_size": {{ target_index_bulk_size | default(500) }},
+    "data_set_format": "{{ target_index_bulk_index_data_set_format | default('hdf5') }}",
+    "data_set_path": "{{ target_index_bulk_index_data_set_path }}",
+    "data_set_corpus": "{{ target_index_bulk_index_data_set_corpus }}",
+    "num_vectors": {{ target_index_num_vectors | default(-1) }},
+    "id-field-name": "{{ id_field_name }}"
+},
+{
+    "name": "refresh-index-faiss-sq",
+    "operation-type": "refresh",
+    "retries": 100,
+    "index": "{{ faiss_sq_index_name | default('faiss_sq_index') }}"
+},
+{
+    "name": "force-merge-faiss-sq",
+    "operation-type": "force-merge",
+    "request-timeout": {{ target_index_force_merge_timeout | default(7200) }},
+    "index": "{{ faiss_sq_index_name | default('faiss_sq_index') }}",
+    "mode": "polling",
+    "max-num-segments": {{ target_index_max_num_segments | default(1) }},
+    "include-in-results_publishing": true
+},
+{
+    "name": "warmup-indices-faiss-sq",
+    "operation-type": "warmup-knn-indices",
+    "index": "{{ faiss_sq_index_name | default('faiss_sq_index') }}",
+    "include-in-results_publishing": true
+},
+{
+    "name": "prod-queries-faiss-sq",
+    "operation-type": "vector-search",
+    "index": "{{ faiss_sq_index_name | default('faiss_sq_index') }}",
+    "detailed-results": true,
+    "k": {{ query_k | default(100) }},
+    "field": "{{ target_field_name | default('target_field') }}",
+    "data_set_format": "{{ query_data_set_format | default('hdf5') }}",
+    "data_set_path": "{{ query_data_set_path }}",
+    "data_set_corpus": "{{ query_data_set_corpus }}",
+    "neighbors_data_set_path": "{{ neighbors_data_set_path }}",
+    "neighbors_data_set_corpus": "{{ neighbors_data_set_corpus }}",
+    "neighbors_data_set_format": "{{ neighbors_data_set_format | default('hdf5') }}",
+    "num_vectors": {{ faiss_sq_query_count | default(query_count | default(-1)) }},
+    "id-field-name": "{{ id_field_name }}",
+    "body": {{ query_body | default({}) | tojson }},
+    "repetitions": {{ number_of_repetitions | default(1) }}
+},
+{
+    "name": "delete-index-lucene-fp32",
+    "operation-type": "delete-index",
+    "only-if-exists": true,
+    "index": "{{ lucene_index_name | default('lucene_index') }}"
+},
+{
+    "name": "create-index-lucene-fp32",
+    "operation-type": "create-index",
+    "index": "{{ lucene_index_name | default('lucene_index') }}"
+},
+{
+    "name": "custom-vector-bulk-lucene-fp32",
+    "operation-type": "bulk-vector-data-set",
+    "index": "{{ lucene_index_name | default('lucene_index') }}",
+    "field": "{{ target_field_name | default('target_field') }}",
+    "bulk_size": {{ target_index_bulk_size | default(500) }},
+    "data_set_format": "{{ target_index_bulk_index_data_set_format | default('hdf5') }}",
+    "data_set_path": "{{ target_index_bulk_index_data_set_path }}",
+    "data_set_corpus": "{{ target_index_bulk_index_data_set_corpus }}",
+    "num_vectors": {{ target_index_num_vectors | default(-1) }},
+    "id-field-name": "{{ id_field_name }}"
+},
+{
+    "name": "refresh-index-lucene-fp32",
+    "operation-type": "refresh",
+    "retries": 100,
+    "index": "{{ lucene_index_name | default('lucene_index') }}"
+},
+{
+    "name": "force-merge-lucene-fp32",
+    "operation-type": "force-merge",
+    "request-timeout": {{ target_index_force_merge_timeout | default(7200) }},
+    "index": "{{ lucene_index_name | default('lucene_index') }}",
+    "mode": "polling",
+    "max-num-segments": {{ target_index_max_num_segments | default(1) }},
+    "include-in-results_publishing": true
+},
+{
+    "name": "warmup-indices-lucene-fp32",
+    "operation-type": "warmup-knn-indices",
+    "index": "{{ lucene_index_name | default('lucene_index') }}",
+    "include-in-results_publishing": true
+},
+{
+    "name": "prod-queries-lucene-fp32",
+    "operation-type": "vector-search",
+    "index": "{{ lucene_index_name | default('lucene_index') }}",
+    "detailed-results": true,
+    "k": {{ query_k | default(100) }},
+    "field": "{{ target_field_name | default('target_field') }}",
+    "data_set_format": "{{ query_data_set_format | default('hdf5') }}",
+    "data_set_path": "{{ query_data_set_path }}",
+    "data_set_corpus": "{{ query_data_set_corpus }}",
+    "neighbors_data_set_path": "{{ neighbors_data_set_path }}",
+    "neighbors_data_set_corpus": "{{ neighbors_data_set_corpus }}",
+    "neighbors_data_set_format": "{{ neighbors_data_set_format | default('hdf5') }}",
+    "num_vectors": {{ lucene_query_count | default(query_count | default(-1)) }},
+    "id-field-name": "{{ id_field_name }}",
+    "body": {{ query_body | default({}) | tojson }},
+    "repetitions": {{ number_of_repetitions | default(1) }}
+},
+{
+    "name": "radial-queries-lucene-max-distance",
+    "operation-type": "vector-search",
+    "index": "{{ lucene_index_name | default('lucene_index') }}",
+    "detailed-results": true,
+    {% if radial_per_query is defined %}
+    "radial_search_type": "max_distance",
+    "k": {{ radial_query_k | default(query_k | default(100)) }},
+    "target_index_body": "{{ lucene_index_body | default('indices/lucene-index.json') }}",
+    {% elif lucene_radial_max_distance is defined %}
+    "max_distance": {{ lucene_radial_max_distance }},
+    {% endif %}
+    "field": "{{ target_field_name | default('target_field') }}",
+    "data_set_format": "{{ query_data_set_format | default('hdf5') }}",
+    "data_set_path": "{{ query_data_set_path }}",
+    "data_set_corpus": "{{ query_data_set_corpus }}",
+    "neighbors_data_set_path": "{{ radial_neighbors_data_set_path }}",
+    "neighbors_data_set_corpus": "{{ radial_neighbors_data_set_corpus }}",
+    "neighbors_data_set_format": "{{ neighbors_data_set_format | default('hdf5') }}",
+    "num_vectors": {{ lucene_radial_query_count | default(radial_query_count | default(query_count | default(-1))) }},
+    "id-field-name": "{{ id_field_name }}",
+    "body": {{ radial_query_body | default({} if radial_per_query is defined else {"size": radial_query_size | default(1000)}) | tojson }},
+    "repetitions": {{ number_of_repetitions | default(1) }}
+},
+{
+    "name": "radial-queries-lucene-min-score",
+    "operation-type": "vector-search",
+    "index": "{{ lucene_index_name | default('lucene_index') }}",
+    "detailed-results": true,
+    {% if radial_per_query is defined %}
+    "radial_search_type": "min_score",
+    "k": {{ radial_query_k | default(query_k | default(100)) }},
+    "target_index_body": "{{ lucene_index_body | default('indices/lucene-index.json') }}",
+    {% elif radial_min_score is defined %}
+    "min_score": {{ radial_min_score }},
+    {% endif %}
+    "field": "{{ target_field_name | default('target_field') }}",
+    "data_set_format": "{{ query_data_set_format | default('hdf5') }}",
+    "data_set_path": "{{ query_data_set_path }}",
+    "data_set_corpus": "{{ query_data_set_corpus }}",
+    "neighbors_data_set_path": "{{ radial_neighbors_data_set_path }}",
+    "neighbors_data_set_corpus": "{{ radial_neighbors_data_set_corpus }}",
+    "neighbors_data_set_format": "{{ neighbors_data_set_format | default('hdf5') }}",
+    "num_vectors": {{ lucene_radial_query_count | default(radial_query_count | default(query_count | default(-1))) }},
+    "id-field-name": "{{ id_field_name }}",
+    "body": {{ radial_query_body | default({} if radial_per_query is defined else {"size": radial_query_size | default(1000)}) | tojson }},
+    "repetitions": {{ number_of_repetitions | default(1) }}
+}
+,
+{
+    "name": "delete-index-lucene-sq",
+    "operation-type": "delete-index",
+    "only-if-exists": true,
+    "index": "{{ lucene_sq_index_name | default('lucene_sq_index') }}"
+},
+{
+    "name": "create-index-lucene-sq",
+    "operation-type": "create-index",
+    "index": "{{ lucene_sq_index_name | default('lucene_sq_index') }}"
+},
+{
+    "name": "custom-vector-bulk-lucene-sq",
+    "operation-type": "bulk-vector-data-set",
+    "index": "{{ lucene_sq_index_name | default('lucene_sq_index') }}",
+    "field": "{{ target_field_name | default('target_field') }}",
+    "bulk_size": {{ target_index_bulk_size | default(500) }},
+    "data_set_format": "{{ target_index_bulk_index_data_set_format | default('hdf5') }}",
+    "data_set_path": "{{ target_index_bulk_index_data_set_path }}",
+    "data_set_corpus": "{{ target_index_bulk_index_data_set_corpus }}",
+    "num_vectors": {{ target_index_num_vectors | default(-1) }},
+    "id-field-name": "{{ id_field_name }}"
+},
+{
+    "name": "refresh-index-lucene-sq",
+    "operation-type": "refresh",
+    "retries": 100,
+    "index": "{{ lucene_sq_index_name | default('lucene_sq_index') }}"
+},
+{
+    "name": "force-merge-lucene-sq",
+    "operation-type": "force-merge",
+    "request-timeout": {{ target_index_force_merge_timeout | default(7200) }},
+    "index": "{{ lucene_sq_index_name | default('lucene_sq_index') }}",
+    "mode": "polling",
+    "max-num-segments": {{ target_index_max_num_segments | default(1) }},
+    "include-in-results_publishing": true
+},
+{
+    "name": "warmup-indices-lucene-sq",
+    "operation-type": "warmup-knn-indices",
+    "index": "{{ lucene_sq_index_name | default('lucene_sq_index') }}",
+    "include-in-results_publishing": true
+},
+{
+    "name": "prod-queries-lucene-sq",
+    "operation-type": "vector-search",
+    "index": "{{ lucene_sq_index_name | default('lucene_sq_index') }}",
+    "detailed-results": true,
+    "k": {{ query_k | default(100) }},
+    "field": "{{ target_field_name | default('target_field') }}",
+    "data_set_format": "{{ query_data_set_format | default('hdf5') }}",
+    "data_set_path": "{{ query_data_set_path }}",
+    "data_set_corpus": "{{ query_data_set_corpus }}",
+    "neighbors_data_set_path": "{{ neighbors_data_set_path }}",
+    "neighbors_data_set_corpus": "{{ neighbors_data_set_corpus }}",
+    "neighbors_data_set_format": "{{ neighbors_data_set_format | default('hdf5') }}",
+    "num_vectors": {{ lucene_sq_query_count | default(query_count | default(-1)) }},
+    "id-field-name": "{{ id_field_name }}",
+    "body": {{ query_body | default({}) | tojson }},
+    "repetitions": {{ number_of_repetitions | default(1) }}
+}

--- a/vectorsearch/params/combined/combined-engine-cohere-100k-perquery.json
+++ b/vectorsearch/params/combined/combined-engine-cohere-100k-perquery.json
@@ -1,0 +1,39 @@
+{
+    "target_index_name": "target_index",
+    "target_field_name": "target_field",
+    "target_index_body": "indices/faiss-index.json",
+    "faiss_sq_index_name": "faiss_sq_index",
+    "faiss_sq_index_body": "indices/faiss-sq-index.json",
+    "lucene_index_name": "lucene_index",
+    "lucene_index_body": "indices/lucene-index.json",
+    "lucene_sq_index_name": "lucene_sq_index",
+    "lucene_sq_index_body": "indices/lucene-sq-index.json",
+    "target_index_primary_shards": 1,
+    "target_index_replica_shards": 0,
+    "target_index_dimension": 768,
+    "target_index_space_type": "innerproduct",
+    "id_field_name": "_id",
+    "target_index_bulk_size": 100,
+    "target_index_bulk_index_data_set_format": "hdf5",
+    "target_index_bulk_index_data_set_corpus": "cohere-100k",
+    "target_index_bulk_indexing_clients": 10,
+    "target_index_max_num_segments": 1,
+    "hnsw_ef_search": 256,
+    "hnsw_ef_construction": 256,
+    "query_k": 100,
+    "query_body": {
+        "docvalue_fields": [
+            "_id"
+        ],
+        "stored_fields": "_none_",
+        "_source": false
+    },
+    "query_data_set_format": "hdf5",
+    "query_data_set_corpus": "cohere-100k",
+    "neighbors_data_set_corpus": "cohere-100k",
+    "query_count": 10000,
+    "radial_per_query": true,
+    "radial_query_k": 100,
+    "radial_neighbors_data_set_corpus": "cohere-100k-radial",
+    "radial_query_count": 10000
+}

--- a/vectorsearch/params/combined/combined-engine-cohere-100k.json
+++ b/vectorsearch/params/combined/combined-engine-cohere-100k.json
@@ -1,0 +1,49 @@
+{
+    "target_index_name": "target_index",
+    "target_field_name": "target_field",
+    "target_index_body": "indices/faiss-index.json",
+    "faiss_sq_index_name": "faiss_sq_index",
+    "faiss_sq_index_body": "indices/faiss-sq-index.json",
+    "lucene_index_name": "lucene_index",
+    "lucene_index_body": "indices/lucene-index.json",
+    "lucene_sq_index_name": "lucene_sq_index",
+    "lucene_sq_index_body": "indices/lucene-sq-index.json",
+    "target_index_primary_shards": 1,
+    "target_index_replica_shards": 0,
+    "target_index_dimension": 768,
+    "target_index_space_type": "innerproduct",
+    "id_field_name": "_id",
+    "target_index_bulk_size": 100,
+    "target_index_bulk_index_data_set_format": "hdf5",
+    "target_index_bulk_index_data_set_corpus": "cohere-100k",
+    "target_index_bulk_indexing_clients": 10,
+    "target_index_max_num_segments": 1,
+    "hnsw_ef_search": 256,
+    "hnsw_ef_construction": 256,
+    "query_k": 100,
+    "query_body": {
+        "docvalue_fields": [
+            "_id"
+        ],
+        "stored_fields": "_none_",
+        "_source": false
+    },
+    "query_data_set_format": "hdf5",
+    "query_data_set_corpus": "cohere-100k",
+    "neighbors_data_set_corpus": "cohere-100k",
+    "query_count": 10000,
+    "radial_neighbors_data_set_corpus": "cohere-100k-radial",
+    "radial_max_distance": -148.557144,
+    "lucene_radial_max_distance": 148.557144,
+    "radial_min_score": 149.557144,
+    "radial_query_size": 1000,
+    "radial_query_body": {
+        "size": 1000,
+        "docvalue_fields": [
+            "_id"
+        ],
+        "stored_fields": "_none_",
+        "_source": false
+    },
+    "radial_query_count": 10000
+}

--- a/vectorsearch/test_procedures/combined-engine-test.json
+++ b/vectorsearch/test_procedures/combined-engine-test.json
@@ -1,0 +1,147 @@
+{
+    "name": "combined-engine-test",
+    "description": "Multi-engine and multi-encoding coverage in one run against the same cluster: faiss fp32 (top-k + radial), faiss SQ (top-k), lucene fp32 (top-k + radial), and lucene SQ (top-k). Each phase uses distinct operation names so per-operation metrics can be compared independently; select subsets of tasks with --include-tasks/--exclude-tasks.",
+    "default": false,
+    "schedule": [
+        {
+            "operation": "delete-index-faiss-fp32"
+        },
+        {
+            "operation": "create-index-faiss-fp32"
+        },
+        {
+            "operation": "custom-vector-bulk-faiss-fp32",
+            "clients": {{ target_index_bulk_indexing_clients | default(1) }}
+        },
+        {
+            "name": "refresh-index-faiss-fp32-before-force-merge",
+            "operation": "refresh-index-faiss-fp32"
+        },
+        {
+            "operation": "force-merge-faiss-fp32"
+        },
+        {
+            "name": "refresh-index-faiss-fp32-after-force-merge",
+            "operation": "refresh-index-faiss-fp32"
+        },
+        {
+            "operation": "warmup-indices-faiss-fp32"
+        },
+        {
+            "operation": "prod-queries-faiss-fp32",
+            "clients": {{ search_clients | default(1) }}
+        },
+        {
+            "operation": "radial-queries-faiss-max-distance",
+            "clients": {{ search_clients | default(1) }}
+        },
+        {
+            "operation": "radial-queries-faiss-min-score",
+            "clients": {{ search_clients | default(1) }}
+        },
+        {
+            "name": "delete-index-faiss-fp32-before-faiss-sq",
+            "operation": "delete-index-faiss-fp32"
+        },
+        {
+            "operation": "delete-index-faiss-sq"
+        },
+        {
+            "operation": "create-index-faiss-sq"
+        },
+        {
+            "operation": "custom-vector-bulk-faiss-sq",
+            "clients": {{ target_index_bulk_indexing_clients | default(1) }}
+        },
+        {
+            "name": "refresh-index-faiss-sq-before-force-merge",
+            "operation": "refresh-index-faiss-sq"
+        },
+        {
+            "operation": "force-merge-faiss-sq"
+        },
+        {
+            "name": "refresh-index-faiss-sq-after-force-merge",
+            "operation": "refresh-index-faiss-sq"
+        },
+        {
+            "operation": "warmup-indices-faiss-sq"
+        },
+        {
+            "operation": "prod-queries-faiss-sq",
+            "clients": {{ search_clients | default(1) }}
+        },
+        {
+            "name": "delete-index-faiss-sq-before-lucene-fp32",
+            "operation": "delete-index-faiss-sq"
+        },
+        {
+            "operation": "delete-index-lucene-fp32"
+        },
+        {
+            "operation": "create-index-lucene-fp32"
+        },
+        {
+            "operation": "custom-vector-bulk-lucene-fp32",
+            "clients": {{ target_index_bulk_indexing_clients | default(1) }}
+        },
+        {
+            "name": "refresh-index-lucene-fp32-before-force-merge",
+            "operation": "refresh-index-lucene-fp32"
+        },
+        {
+            "operation": "force-merge-lucene-fp32"
+        },
+        {
+            "name": "refresh-index-lucene-fp32-after-force-merge",
+            "operation": "refresh-index-lucene-fp32"
+        },
+        {
+            "operation": "warmup-indices-lucene-fp32"
+        },
+        {
+            "operation": "prod-queries-lucene-fp32",
+            "clients": {{ search_clients | default(1) }}
+        },
+        {
+            "operation": "radial-queries-lucene-max-distance",
+            "clients": {{ search_clients | default(1) }}
+        },
+        {
+            "operation": "radial-queries-lucene-min-score",
+            "clients": {{ search_clients | default(1) }}
+        },
+        {
+            "name": "delete-index-lucene-fp32-before-lucene-sq",
+            "operation": "delete-index-lucene-fp32"
+        },
+        {
+            "operation": "delete-index-lucene-sq"
+        },
+        {
+            "operation": "create-index-lucene-sq"
+        },
+        {
+            "operation": "custom-vector-bulk-lucene-sq",
+            "clients": {{ target_index_bulk_indexing_clients | default(1) }}
+        },
+        {
+            "name": "refresh-index-lucene-sq-before-force-merge",
+            "operation": "refresh-index-lucene-sq"
+        },
+        {
+            "operation": "force-merge-lucene-sq"
+        },
+        {
+            "name": "refresh-index-lucene-sq-after-force-merge",
+            "operation": "refresh-index-lucene-sq"
+        },
+        {
+            "operation": "warmup-indices-lucene-sq"
+        },
+        {
+            "operation": "prod-queries-lucene-sq",
+            "clients": {{ search_clients | default(1) }}
+        }
+    ]
+}

--- a/vectorsearch/workload.json
+++ b/vectorsearch/workload.json
@@ -10,6 +10,18 @@
         {
             "name": "{{ train_index_name | default('train_index') }}",
             "body": "{{ train_index_body }}"
+        },
+        {
+            "name": "{{ faiss_sq_index_name | default('faiss_sq_index') }}",
+            "body": "{{ faiss_sq_index_body | default('indices/faiss-sq-index.json') }}"
+        },
+        {
+            "name": "{{ lucene_index_name | default('lucene_index') }}",
+            "body": "{{ lucene_index_body | default('indices/lucene-index.json') }}"
+        },
+        {
+            "name": "{{ lucene_sq_index_name | default('lucene_sq_index') }}",
+            "body": "{{ lucene_sq_index_body | default('indices/lucene-sq-index.json') }}"
         }
     ],
     "corpora": [
@@ -33,6 +45,18 @@
       "documents": [
         {
           "source-file": "documents-100k.hdf5.bz2",
+          "source-format": "hdf5",
+          "document-count": 100000
+        }
+      ]
+    },
+    {
+      "name": "cohere-100k-radial",
+      "base-url": "https://dbyiw3u3rf9yr.cloudfront.net/corpora/vectorsearch/cohere-wikipedia-22-12-en-embeddings",
+      "target-index": "{{ target_index_name }}",
+      "documents": [
+        {
+          "source-file": "cohere-100k-radial.hdf5.bz2",
           "source-format": "hdf5",
           "document-count": 100000
         }


### PR DESCRIPTION
### Description
Adds a combined-engine-test test procedure to the vectorsearch workload that covers 6 configurations across 4 index builds in one invocation against the same cluster: faiss fp32 (top-k + radial), faiss SQ (top-k), lucene fp32 (top-k + radial), and lucene SQ (top-k). Each phase uses distinct operation names so per-operation metrics can be compared independently, and subsets of tasks can be selected with --include-tasks/--exclude-tasks.

### Backport to Branches:
- [x] 3   

### Testing

The output is the similar as a single-config benchmark run with each phase reporting under its own task name (4 ingest tasks, 4 warmups, 8 query tasks). Run against an OpenSearch 3.8.0 cluster (cohere-100k, fixed-threshold radial); all tasks completed with 0 errors. Full OSB results output: 

|                         Metric |                               Task |   Value |   Unit |
|-------------------------------:|-----------------------------------:|--------:|-------:|
|        Total Young Gen GC time |                                    |   0.023 |      s |
|       Total Young Gen GC count |                                    |       8 |        |
|          Total Old Gen GC time |                                    |       0 |      s |
|         Total Old Gen GC count |                                    |       0 |        |
|                 Min Throughput |      custom-vector-bulk-faiss-fp32 | 3325.58 | docs/s |
|                Mean Throughput |      custom-vector-bulk-faiss-fp32 | 6042.76 | docs/s |
|              Median Throughput |      custom-vector-bulk-faiss-fp32 |  6834.9 | docs/s |
|                 Max Throughput |      custom-vector-bulk-faiss-fp32 | 7741.67 | docs/s |
|        50th percentile latency |      custom-vector-bulk-faiss-fp32 | 37.3514 |     ms |
|        90th percentile latency |      custom-vector-bulk-faiss-fp32 |  40.753 |     ms |
|        99th percentile latency |      custom-vector-bulk-faiss-fp32 | 71.5391 |     ms |
|      99.9th percentile latency |      custom-vector-bulk-faiss-fp32 | 8062.19 |     ms |
|       100th percentile latency |      custom-vector-bulk-faiss-fp32 | 17913.2 |     ms |
|   50th percentile service time |      custom-vector-bulk-faiss-fp32 | 37.3514 |     ms |
|   90th percentile service time |      custom-vector-bulk-faiss-fp32 |  40.753 |     ms |
|   99th percentile service time |      custom-vector-bulk-faiss-fp32 | 71.5391 |     ms |
| 99.9th percentile service time |      custom-vector-bulk-faiss-fp32 | 8062.19 |     ms |
|  100th percentile service time |      custom-vector-bulk-faiss-fp32 | 17913.2 |     ms |
|                     error rate |      custom-vector-bulk-faiss-fp32 |       0 |      % |
|                 Min Throughput |          warmup-indices-faiss-fp32 |    9.72 |  ops/s |
|                Mean Throughput |          warmup-indices-faiss-fp32 |    9.72 |  ops/s |
|              Median Throughput |          warmup-indices-faiss-fp32 |    9.72 |  ops/s |
|                 Max Throughput |          warmup-indices-faiss-fp32 |    9.72 |  ops/s |
|       100th percentile latency |          warmup-indices-faiss-fp32 |  102.65 |     ms |
|  100th percentile service time |          warmup-indices-faiss-fp32 |  102.65 |     ms |
|                     error rate |          warmup-indices-faiss-fp32 |       0 |      % |
|                 Min Throughput |            prod-queries-faiss-fp32 |  216.96 |  ops/s |
|                Mean Throughput |            prod-queries-faiss-fp32 |  216.96 |  ops/s |
|              Median Throughput |            prod-queries-faiss-fp32 |  216.96 |  ops/s |
|                 Max Throughput |            prod-queries-faiss-fp32 |  216.96 |  ops/s |
|        50th percentile latency |            prod-queries-faiss-fp32 | 2.61524 |     ms |
|        90th percentile latency |            prod-queries-faiss-fp32 | 2.88906 |     ms |
|        99th percentile latency |            prod-queries-faiss-fp32 | 3.21272 |     ms |
|       100th percentile latency |            prod-queries-faiss-fp32 | 64.7804 |     ms |
|   50th percentile service time |            prod-queries-faiss-fp32 | 2.61524 |     ms |
|   90th percentile service time |            prod-queries-faiss-fp32 | 2.88906 |     ms |
|   99th percentile service time |            prod-queries-faiss-fp32 | 3.21272 |     ms |
|  100th percentile service time |            prod-queries-faiss-fp32 | 64.7804 |     ms |
|                     error rate |            prod-queries-faiss-fp32 |       0 |      % |
|                 Min Throughput |  radial-queries-faiss-max-distance |  172.06 |  ops/s |
|                Mean Throughput |  radial-queries-faiss-max-distance |  172.06 |  ops/s |
|              Median Throughput |  radial-queries-faiss-max-distance |  172.06 |  ops/s |
|                 Max Throughput |  radial-queries-faiss-max-distance |  172.06 |  ops/s |
|        50th percentile latency |  radial-queries-faiss-max-distance | 2.99089 |     ms |
|        90th percentile latency |  radial-queries-faiss-max-distance | 4.93407 |     ms |
|        99th percentile latency |  radial-queries-faiss-max-distance | 5.61821 |     ms |
|       100th percentile latency |  radial-queries-faiss-max-distance |  8.3316 |     ms |
|   50th percentile service time |  radial-queries-faiss-max-distance | 2.99089 |     ms |
|   90th percentile service time |  radial-queries-faiss-max-distance | 4.93407 |     ms |
|   99th percentile service time |  radial-queries-faiss-max-distance | 5.61821 |     ms |
|  100th percentile service time |  radial-queries-faiss-max-distance |  8.3316 |     ms |
|                     error rate |  radial-queries-faiss-max-distance |       0 |      % |
|                 Min Throughput |     radial-queries-faiss-min-score |  139.74 |  ops/s |
|                Mean Throughput |     radial-queries-faiss-min-score |  139.74 |  ops/s |
|              Median Throughput |     radial-queries-faiss-min-score |  139.74 |  ops/s |
|                 Max Throughput |     radial-queries-faiss-min-score |  139.74 |  ops/s |
|        50th percentile latency |     radial-queries-faiss-min-score | 4.37893 |     ms |
|        90th percentile latency |     radial-queries-faiss-min-score | 6.38553 |     ms |
|        99th percentile latency |     radial-queries-faiss-min-score | 6.97673 |     ms |
|       100th percentile latency |     radial-queries-faiss-min-score | 12.2677 |     ms |
|   50th percentile service time |     radial-queries-faiss-min-score | 4.37893 |     ms |
|   90th percentile service time |     radial-queries-faiss-min-score | 6.38553 |     ms |
|   99th percentile service time |     radial-queries-faiss-min-score | 6.97673 |     ms |
|  100th percentile service time |     radial-queries-faiss-min-score | 12.2677 |     ms |
|                     error rate |     radial-queries-faiss-min-score |       0 |      % |
|                 Min Throughput |        custom-vector-bulk-faiss-sq | 7660.91 | docs/s |
|                Mean Throughput |        custom-vector-bulk-faiss-sq | 7946.83 | docs/s |
|              Median Throughput |        custom-vector-bulk-faiss-sq | 7968.63 | docs/s |
|                 Max Throughput |        custom-vector-bulk-faiss-sq | 8103.04 | docs/s |
|        50th percentile latency |        custom-vector-bulk-faiss-sq | 38.4593 |     ms |
|        90th percentile latency |        custom-vector-bulk-faiss-sq | 42.8816 |     ms |
|        99th percentile latency |        custom-vector-bulk-faiss-sq | 385.809 |     ms |
|      99.9th percentile latency |        custom-vector-bulk-faiss-sq | 902.921 |     ms |
|       100th percentile latency |        custom-vector-bulk-faiss-sq | 910.981 |     ms |
|   50th percentile service time |        custom-vector-bulk-faiss-sq | 38.4593 |     ms |
|   90th percentile service time |        custom-vector-bulk-faiss-sq | 42.8816 |     ms |
|   99th percentile service time |        custom-vector-bulk-faiss-sq | 385.809 |     ms |
| 99.9th percentile service time |        custom-vector-bulk-faiss-sq | 902.921 |     ms |
|  100th percentile service time |        custom-vector-bulk-faiss-sq | 910.981 |     ms |
|                     error rate |        custom-vector-bulk-faiss-sq |       0 |      % |
|                 Min Throughput |            warmup-indices-faiss-sq |   36.47 |  ops/s |
|                Mean Throughput |            warmup-indices-faiss-sq |   36.47 |  ops/s |
|              Median Throughput |            warmup-indices-faiss-sq |   36.47 |  ops/s |
|                 Max Throughput |            warmup-indices-faiss-sq |   36.47 |  ops/s |
|       100th percentile latency |            warmup-indices-faiss-sq | 27.1181 |     ms |
|  100th percentile service time |            warmup-indices-faiss-sq | 27.1181 |     ms |
|                     error rate |            warmup-indices-faiss-sq |       0 |      % |
|                 Min Throughput |              prod-queries-faiss-sq |  226.15 |  ops/s |
|                Mean Throughput |              prod-queries-faiss-sq |  226.15 |  ops/s |
|              Median Throughput |              prod-queries-faiss-sq |  226.15 |  ops/s |
|                 Max Throughput |              prod-queries-faiss-sq |  226.15 |  ops/s |
|        50th percentile latency |              prod-queries-faiss-sq |  2.3457 |     ms |
|        90th percentile latency |              prod-queries-faiss-sq |  2.5712 |     ms |
|        99th percentile latency |              prod-queries-faiss-sq | 2.72918 |     ms |
|       100th percentile latency |              prod-queries-faiss-sq | 65.7616 |     ms |
|   50th percentile service time |              prod-queries-faiss-sq |  2.3457 |     ms |
|   90th percentile service time |              prod-queries-faiss-sq |  2.5712 |     ms |
|   99th percentile service time |              prod-queries-faiss-sq | 2.72918 |     ms |
|  100th percentile service time |              prod-queries-faiss-sq | 65.7616 |     ms |
|                     error rate |              prod-queries-faiss-sq |       0 |      % |
|                 Min Throughput |     custom-vector-bulk-lucene-fp32 | 6228.63 | docs/s |
|                Mean Throughput |     custom-vector-bulk-lucene-fp32 | 6586.08 | docs/s |
|              Median Throughput |     custom-vector-bulk-lucene-fp32 | 6611.02 | docs/s |
|                 Max Throughput |     custom-vector-bulk-lucene-fp32 | 6684.65 | docs/s |
|        50th percentile latency |     custom-vector-bulk-lucene-fp32 |  59.997 |     ms |
|        90th percentile latency |     custom-vector-bulk-lucene-fp32 | 112.702 |     ms |
|        99th percentile latency |     custom-vector-bulk-lucene-fp32 | 203.898 |     ms |
|      99.9th percentile latency |     custom-vector-bulk-lucene-fp32 | 295.568 |     ms |
|       100th percentile latency |     custom-vector-bulk-lucene-fp32 | 317.588 |     ms |
|   50th percentile service time |     custom-vector-bulk-lucene-fp32 |  59.997 |     ms |
|   90th percentile service time |     custom-vector-bulk-lucene-fp32 | 112.702 |     ms |
|   99th percentile service time |     custom-vector-bulk-lucene-fp32 | 203.898 |     ms |
| 99.9th percentile service time |     custom-vector-bulk-lucene-fp32 | 295.568 |     ms |
|  100th percentile service time |     custom-vector-bulk-lucene-fp32 | 317.588 |     ms |
|                     error rate |     custom-vector-bulk-lucene-fp32 |       0 |      % |
|                 Min Throughput |         warmup-indices-lucene-fp32 |  145.82 |  ops/s |
|                Mean Throughput |         warmup-indices-lucene-fp32 |  145.82 |  ops/s |
|              Median Throughput |         warmup-indices-lucene-fp32 |  145.82 |  ops/s |
|                 Max Throughput |         warmup-indices-lucene-fp32 |  145.82 |  ops/s |
|       100th percentile latency |         warmup-indices-lucene-fp32 | 6.63941 |     ms |
|  100th percentile service time |         warmup-indices-lucene-fp32 | 6.63941 |     ms |
|                     error rate |         warmup-indices-lucene-fp32 |       0 |      % |
|                 Min Throughput |           prod-queries-lucene-fp32 |  170.66 |  ops/s |
|                Mean Throughput |           prod-queries-lucene-fp32 |  170.66 |  ops/s |
|              Median Throughput |           prod-queries-lucene-fp32 |  170.66 |  ops/s |
|                 Max Throughput |           prod-queries-lucene-fp32 |  170.66 |  ops/s |
|        50th percentile latency |           prod-queries-lucene-fp32 | 3.62415 |     ms |
|        90th percentile latency |           prod-queries-lucene-fp32 | 3.95008 |     ms |
|        99th percentile latency |           prod-queries-lucene-fp32 |  4.9813 |     ms |
|       100th percentile latency |           prod-queries-lucene-fp32 | 74.3553 |     ms |
|   50th percentile service time |           prod-queries-lucene-fp32 | 3.62415 |     ms |
|   90th percentile service time |           prod-queries-lucene-fp32 | 3.95008 |     ms |
|   99th percentile service time |           prod-queries-lucene-fp32 |  4.9813 |     ms |
|  100th percentile service time |           prod-queries-lucene-fp32 | 74.3553 |     ms |
|                     error rate |           prod-queries-lucene-fp32 |       0 |      % |
|                 Min Throughput | radial-queries-lucene-max-distance |  104.78 |  ops/s |
|                Mean Throughput | radial-queries-lucene-max-distance |  104.78 |  ops/s |
|              Median Throughput | radial-queries-lucene-max-distance |  104.78 |  ops/s |
|                 Max Throughput | radial-queries-lucene-max-distance |  104.78 |  ops/s |
|        50th percentile latency | radial-queries-lucene-max-distance | 5.07072 |     ms |
|        90th percentile latency | radial-queries-lucene-max-distance | 12.7069 |     ms |
|        99th percentile latency | radial-queries-lucene-max-distance | 17.4902 |     ms |
|       100th percentile latency | radial-queries-lucene-max-distance |  18.739 |     ms |
|   50th percentile service time | radial-queries-lucene-max-distance | 5.07072 |     ms |
|   90th percentile service time | radial-queries-lucene-max-distance | 12.7069 |     ms |
|   99th percentile service time | radial-queries-lucene-max-distance | 17.4902 |     ms |
|  100th percentile service time | radial-queries-lucene-max-distance |  18.739 |     ms |
|                     error rate | radial-queries-lucene-max-distance |       0 |      % |
|                 Min Throughput |    radial-queries-lucene-min-score |  132.98 |  ops/s |
|                Mean Throughput |    radial-queries-lucene-min-score |  132.98 |  ops/s |
|              Median Throughput |    radial-queries-lucene-min-score |  132.98 |  ops/s |
|                 Max Throughput |    radial-queries-lucene-min-score |  132.98 |  ops/s |
|        50th percentile latency |    radial-queries-lucene-min-score | 3.58779 |     ms |
|        90th percentile latency |    radial-queries-lucene-min-score | 11.3337 |     ms |
|        99th percentile latency |    radial-queries-lucene-min-score | 16.4024 |     ms |
|       100th percentile latency |    radial-queries-lucene-min-score | 17.1767 |     ms |
|   50th percentile service time |    radial-queries-lucene-min-score | 3.58779 |     ms |
|   90th percentile service time |    radial-queries-lucene-min-score | 11.3337 |     ms |
|   99th percentile service time |    radial-queries-lucene-min-score | 16.4024 |     ms |
|  100th percentile service time |    radial-queries-lucene-min-score | 17.1767 |     ms |
|                     error rate |    radial-queries-lucene-min-score |       0 |      % |
|                 Min Throughput |       custom-vector-bulk-lucene-sq |  6581.6 | docs/s |
|                Mean Throughput |       custom-vector-bulk-lucene-sq | 6707.73 | docs/s |
|              Median Throughput |       custom-vector-bulk-lucene-sq | 6712.68 | docs/s |
|                 Max Throughput |       custom-vector-bulk-lucene-sq | 6792.26 | docs/s |
|        50th percentile latency |       custom-vector-bulk-lucene-sq | 59.6974 |     ms |
|        90th percentile latency |       custom-vector-bulk-lucene-sq | 114.569 |     ms |
|        99th percentile latency |       custom-vector-bulk-lucene-sq | 194.911 |     ms |
|      99.9th percentile latency |       custom-vector-bulk-lucene-sq |  261.18 |     ms |
|       100th percentile latency |       custom-vector-bulk-lucene-sq | 322.605 |     ms |
|   50th percentile service time |       custom-vector-bulk-lucene-sq | 59.6974 |     ms |
|   90th percentile service time |       custom-vector-bulk-lucene-sq | 114.569 |     ms |
|   99th percentile service time |       custom-vector-bulk-lucene-sq | 194.911 |     ms |
| 99.9th percentile service time |       custom-vector-bulk-lucene-sq |  261.18 |     ms |
|  100th percentile service time |       custom-vector-bulk-lucene-sq | 322.605 |     ms |
|                     error rate |       custom-vector-bulk-lucene-sq |       0 |      % |
|                 Min Throughput |           warmup-indices-lucene-sq |  169.45 |  ops/s |
|                Mean Throughput |           warmup-indices-lucene-sq |  169.45 |  ops/s |
|              Median Throughput |           warmup-indices-lucene-sq |  169.45 |  ops/s |
|                 Max Throughput |           warmup-indices-lucene-sq |  169.45 |  ops/s |
|       100th percentile latency |           warmup-indices-lucene-sq | 5.66993 |     ms |
|  100th percentile service time |           warmup-indices-lucene-sq | 5.66993 |     ms |
|                     error rate |           warmup-indices-lucene-sq |       0 |      % |
|                 Min Throughput |             prod-queries-lucene-sq |   130.3 |  ops/s |
|                Mean Throughput |             prod-queries-lucene-sq |   130.3 |  ops/s |
|              Median Throughput |             prod-queries-lucene-sq |   130.3 |  ops/s |
|                 Max Throughput |             prod-queries-lucene-sq |   130.3 |  ops/s |
|        50th percentile latency |             prod-queries-lucene-sq | 5.19755 |     ms |
|        90th percentile latency |             prod-queries-lucene-sq | 5.52847 |     ms |
|        99th percentile latency |             prod-queries-lucene-sq | 5.87645 |     ms |
|       100th percentile latency |             prod-queries-lucene-sq | 72.0426 |     ms |
|   50th percentile service time |             prod-queries-lucene-sq | 5.19755 |     ms |
|   90th percentile service time |             prod-queries-lucene-sq | 5.52847 |     ms |
|   99th percentile service time |             prod-queries-lucene-sq | 5.87645 |     ms |
|  100th percentile service time |             prod-queries-lucene-sq | 72.0426 |     ms |
|                     error rate |             prod-queries-lucene-sq |       0 |      % |
|                  Mean recall@k |            prod-queries-faiss-fp32 |    0.94 |        |
|                  Mean recall@1 |            prod-queries-faiss-fp32 |    0.99 |        |
|       Mean recall@max_distance |  radial-queries-faiss-max-distance |    0.92 |        |
|     Mean recall@max_distance_1 |  radial-queries-faiss-max-distance |    0.99 |        |
|          Mean recall@min_score |     radial-queries-faiss-min-score |    0.92 |        |
|        Mean recall@min_score_1 |     radial-queries-faiss-min-score |    0.99 |        |
|                  Mean recall@k |              prod-queries-faiss-sq |    0.84 |        |
|                  Mean recall@1 |              prod-queries-faiss-sq |    0.99 |        |
|                  Mean recall@k |           prod-queries-lucene-fp32 |    0.95 |        |
|                  Mean recall@1 |           prod-queries-lucene-fp32 |    0.99 |        |
|       Mean recall@max_distance | radial-queries-lucene-max-distance |    0.96 |        |
|     Mean recall@max_distance_1 | radial-queries-lucene-max-distance |       1 |        |
|          Mean recall@min_score |    radial-queries-lucene-min-score |    0.96 |        |
|        Mean recall@min_score_1 |    radial-queries-lucene-min-score |       1 |        |
|                  Mean recall@k |             prod-queries-lucene-sq |    0.85 |        |
|                  Mean recall@1 |             prod-queries-lucene-sq |       1 |        |

 ✅ SUCCESS (took 687 seconds)



---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
